### PR TITLE
Bug 1414221: Warning "The log was not applied to the intended LSN" should optionally be an error

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6039,11 +6039,13 @@ next_node:
 	       && srv_start_lsn < metadata_last_lsn)) {
 		msg(
 "xtrabackup: ########################################################\n"
-"xtrabackup: # !!WARNING!!                                          #\n"
+"xtrabackup: # !!ERROR!!                                            #\n"
 "xtrabackup: # The transaction log file is corrupted.               #\n"
 "xtrabackup: # The log was not applied to the intended LSN!         #\n"
 "xtrabackup: ########################################################\n"
 		    );
+		msg("xtrabackup: Log applied to lsn " LSN_PF "\n",
+		    srv_start_lsn);
 		if (xtrabackup_incremental) {
 			msg("xtrabackup: The intended lsn is " LSN_PF "\n",
 			    incremental_last_lsn);
@@ -6051,6 +6053,7 @@ next_node:
 			msg("xtrabackup: The intended lsn is " LSN_PF "\n",
 			    metadata_last_lsn);
 		}
+		exit(EXIT_FAILURE);
 	}
 
 	xb_write_galera_info();

--- a/storage/innobase/xtrabackup/test/t/bug1414221.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1414221.sh
@@ -1,0 +1,32 @@
+############################################################################
+# Bug 1414221: Warning "The log was not applied to the intended LSN"
+#              should optionally be an error
+############################################################################
+. inc/common.sh
+
+if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
+then
+    skip_test "Incompatible with AddressSanitizer"
+fi
+
+start_server --innodb_file_per_table
+load_sakila
+
+${MYSQL} ${MYSQL_ARGS} sakila -e "DELETE FROM payment"
+
+# Full backup
+# backup root directory
+vlog "Starting backup"
+
+full_backup_dir=$topdir/full_backup
+innobackupex --no-timestamp $full_backup_dir
+
+ls -al $full_backup_dir/xtrabackup_logfile
+
+sed -i -e 's/last_lsn = [0-9]*$/last_lsn = 999999999/' \
+	$full_backup_dir/xtrabackup_checkpoints
+
+vlog "Preparing backup"
+run_cmd_expect_failure $IB_BIN $IB_ARGS  --apply-log \
+	$full_backup_dir
+vlog "Log applied to full backup"


### PR DESCRIPTION
Bug 1414221: Warning "The log was not applied to the intended LSN" should optionally be an error

Instead of warning print an error message.
Print value of srv_start_lsn right after the error message.

Jenkins build http://jenkins.percona.com/view/PXB%202.2/job/percona-xtrabackup-2.2-param/291/

Test bug723318.sh is an artifact left after bzr -> git conversion. It is not present in bzr version of repo.
