### PR TITLE
PXB-171: GTID support not detected correcly on fresh 5.6.22+ slaves …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3137,3 +3137,15 @@ support-files/plugins.files
 storage/perfschema/pfs_lex_token.h
 storage/perfschema/gen_pfs_lex_token
 sql/share/bulgarian
+storage/innobase/xtrabackup/test/var/*
+storage/innobase/xtrabackup/test/results/*
+storage/innobase/xtrabackup/test/test_results.subunit
+storage/innobase/xtrabackup/src/xbcloud
+storage/innobase/xtrabackup/src/xbcrypt
+storage/innobase/xtrabackup/src/xbstream
+storage/innobase/xtrabackup/innobackupex
+storage/innobase/xtrabackup/src/xtrabackup
+storage/innobase/xtrabackup/src/xtrabackup_version.h
+/CMakeCache.txt
+/storage/innobase/xtrabackup/src/libarchive/DartConfiguration.tcl
+/storage/innobase/xtrabackup/src/libarchive/cmake.tmp/CheckFuncs_stub.c

--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -5016,11 +5016,11 @@ sub detect_mysql_capabilities_for_backup {
         $have_multi_threaded_slave = 1;
     }
 
-    my $gtid_executed = $con->{slave_status}->{Executed_Gtid_Set};
+    my $gtid_mode = $con->{vars}->{gtid_mode};
     my $gtid_slave_pos = $con->{vars}->{gtid_slave_pos};
 
-    if ((defined($gtid_executed) and $gtid_executed ne '') or
-        (defined($gtid_slave_pos) and $gtid_slave_pos ne '')) {
+    if ((defined($gtid_mode) and $gtid_mode->{Value} eq 'ON') or
+        (defined($gtid_slave_pos) and $gtid_slave_pos->{Value} ne '')) {
         $have_gtid_slave = 1;
     }
 

--- a/storage/innobase/xtrabackup/test/t/bug1372679.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1372679.sh
@@ -51,4 +51,6 @@ setup_slave $slave_id $master_id
 
 switch_server $slave_id
 
+sync_slave_with_master $slave_id $master_id
+
 innobackupex --no-timestamp --slave-info $topdir/backup


### PR DESCRIPTION
Executed_Gtid_Set may be empty on a GTID slave when the slave has not
yet processed any events from the master. Use gtid_mode instead to check
GTID is enabled.

http://jenkins.percona.com/view/PXB%202.2/job/percona-xtrabackup-2.2-param/294/
