### PR TITLE
fixes bug: https://launchpad.net/bugs/1413044

### DIFF
--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -1780,7 +1780,6 @@ sub decrypt_decompress_file {
   }
   print STDERR "$prefix $file_cmd\n";
   system("$file_cmd") && die "$file_cmd failed with $!";
-  system("rm -f $file");
 }
 
 #


### PR DESCRIPTION
Merge branch '2.2-xb-ST-50113' into 2.3-xb-ST-50113
fixes bug: https://launchpad.net/bugs/1413044

Deleted line that does 'rm' on existing .qp and .xbcrypt files when using
inobackupex --decrypt and/or --decompress.

Also needs doc updates that if someone is using innobackupex with
--decompress and/or --decrypt, they will need to manually verify
that the result is correct (check to see if xtrabackup_checkpoints
is a readable file that makes sense) and manually delete or move
their original .qp and .xbcrypt files before performing a prepare
and --copy_back.

Jenkins : http://jenkins.percona.com/view/PXB%202.3/job/percona-xtrabackup-2.3-param/37/
