### PR TITLE
Bug 1368846: xtrabackup Assertion failure with Apply log process

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2493,7 +2493,7 @@ DECLARE_THREAD(buf_flush_page_cleaner_thread)(
 		success = buf_flush_list(PCT_IO(100), LSN_MAX, &n_flushed);
 		buf_flush_wait_batch_end(NULL, BUF_FLUSH_LIST);
 
-	} while (!success || n_flushed > 0);
+	} while (!success || n_flushed > 0 || buf_get_n_pending_read_ios() > 0);
 
 	/* Some sanity checks */
 	ut_a(srv_get_active_thread_type() == SRV_NONE);


### PR DESCRIPTION
Looking at the stack trace I see pending IO complete (read)
operations which caused ibuf merge. This merge happened after
page_cleaner thread stopped, so there were no thread to flush dirty
pages from buffer pool. We should not allow page_cleaner to stop
when there are pending reads.

http://jenkins.percona.com/view/PXB%202.2/job/percona-xtrabackup-2.2-param/296/
