### PR TITLE
PXB-172: Changed page bitmaps support does not work in innobackupex (2.3)

### DIFF
--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -3050,6 +3050,19 @@ sub mysql_query {
   }
 }
 
+#
+# mysql_get_one_value subroutine gets single value from MySQL query.
+# Parameters:
+#    con       mysql connection
+#    query     query to execute
+#
+sub mysql_get_one_value {
+  my ($con, $query) = @_;
+
+  my $single_val = $con->{dbh}->selectrow_array($query);
+
+  return $single_val;
+}
 
 sub get_mysql_vars {
   mysql_query($_[0], 'SHOW VARIABLES')
@@ -4970,7 +4983,7 @@ sub detect_mysql_capabilities_for_backup {
 
     if ($option_incremental) {
         $have_changed_page_bitmaps =
-            mysql_query($con, "SELECT COUNT(*) FROM " .
+            mysql_get_one_value($con, "SELECT COUNT(*) FROM " .
                         "INFORMATION_SCHEMA.PLUGINS " .
                         "WHERE PLUGIN_NAME LIKE 'INNODB_CHANGED_PAGES'");
     }

--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -47,7 +47,7 @@ Com_lock_binlog_for_backup	2
 Com_show_slave_status_nolock	0
 Com_unlock_binlog	2
 Com_unlock_tables	2
-Com_flush	2
+Com_flush	3
 EOF
 
 ########################################################################
@@ -72,5 +72,5 @@ Com_lock_binlog_for_backup	2
 Com_show_slave_status_nolock	0
 Com_unlock_binlog	2
 Com_unlock_tables	3
-Com_flush	4
+Com_flush	5
 EOF


### PR DESCRIPTION
Code responsible for discovery of CHANGED PAGE BITMAPS support
always returned that support is not found.

Fixed discovery of CHANGED PAGE BITMAPS support and adjusted test
backup_locks to reflect the fact that additional flush command is
needed when CHANGED PAGE BITMAPS is in use.
