### PR TITLE
Bug 1448447: Fix for bug 1403237 is incomplete (2.2)

### DIFF
--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -751,6 +751,8 @@ struct log_group_t{
 	lsn_t		lsn_offset;	/*!< the offset of the above lsn */
 	lsn_t		lsn_offset_alt;	/*!< alternative lsn offset for PS 5.5
 					with large log files */
+	ibool		alt_offset_chosen;/*!< alternative lsn offset for PS 5.5
+					with large log files is chosen */
 	ulint		n_pending_writes;/*!< number of currently pending flush
 					writes for this log group */
 	byte**		file_header_bufs_ptr;/*!< unaligned buffers */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -998,7 +998,9 @@ log_group_init(
 	group->state = LOG_GROUP_OK;
 	group->lsn = LOG_START_LSN;
 	group->lsn_offset = LOG_FILE_HDR_SIZE;
+	group->lsn_offset_alt = LOG_FILE_HDR_SIZE;
 	group->n_pending_writes = 0;
+	group->alt_offset_chosen = FALSE;
 
 	group->file_header_bufs_ptr = static_cast<byte**>(
 		mem_zalloc(sizeof(byte*) * n_files));

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -809,6 +809,10 @@ recv_find_max_checkpoint(
 				group->lsn_offset_alt =
 					((lsn_t) mach_read_from_8(
 					buf + LOG_CHECKPOINT_ARCHIVED_LSN));
+				if (group->alt_offset_chosen) {
+					group->lsn_offset =
+						group->lsn_offset_alt;
+				}
 			}
 			checkpoint_no = mach_read_from_8(
 				buf + LOG_CHECKPOINT_NO);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2063,7 +2063,7 @@ skip:
 }
 
 static my_bool
-xtrabackup_copy_logfile(lsn_t from_lsn, my_bool is_last, my_bool is_first)
+xtrabackup_copy_logfile(lsn_t from_lsn, my_bool is_last)
 {
 	/* definition from recv_recovery_from_checkpoint_start() */
 	log_group_t*	group;
@@ -2128,10 +2128,10 @@ retry_read:
 
 			/* Can be just wrong lsn_offset. Is it PS 5.5 with large
 			log files? */
-			if (is_first &&
+			if (!group->alt_offset_chosen &&
 			    group->lsn_offset != group->lsn_offset_alt) {
 				group->lsn_offset = group->lsn_offset_alt;
-				is_first = FALSE;
+				group->alt_offset_chosen = TRUE;
 				goto retry_read;
 			}
 
@@ -2313,7 +2313,7 @@ log_copying_thread(
 				       0);
 		if (log_copying) {
 			if(xtrabackup_copy_logfile(log_copy_scanned_lsn,
-						   FALSE, FALSE)) {
+						   FALSE)) {
 
 				exit(EXIT_FAILURE);
 			}
@@ -2321,7 +2321,7 @@ log_copying_thread(
 	}
 
 	/* last copying */
-	if(xtrabackup_copy_logfile(log_copy_scanned_lsn, TRUE, FALSE)) {
+	if(xtrabackup_copy_logfile(log_copy_scanned_lsn, TRUE)) {
 
 		exit(EXIT_FAILURE);
 	}
@@ -3565,7 +3565,7 @@ reread_log_header:
 
 
 	/* copy log file by current position */
-	if(xtrabackup_copy_logfile(checkpoint_lsn_start, FALSE, TRUE))
+	if(xtrabackup_copy_logfile(checkpoint_lsn_start, FALSE))
 		exit(EXIT_FAILURE);
 
 


### PR DESCRIPTION
At the end of the log copying process XtraBackup invokes
log_group_read_checkpoint_info to grab latest checkpoint LSN which
resets group->lsn_offset to wrong value. As the result last copied
batch of log records is copied from wrong location.

Fix is following:
1. Remember if we chose to use alternative LSN offset location.
2. Allow to try different offset at any time, not only when
   reading the first log block. It handles the case when copying
   started with offset lower than 4G and finished with offset
   higher than 4G.

http://jenkins.percona.com/view/PXB%202.2/job/percona-xtrabackup-2.2-param/301/
