### PR TITLE
Bug 1277403: Use FLUSH TABLES before FTWRL

### DIFF
--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -72,5 +72,5 @@ Com_lock_binlog_for_backup	2
 Com_show_slave_status_nolock	0
 Com_unlock_binlog	2
 Com_unlock_tables	3
-Com_flush	5
+Com_flush	6
 EOF

--- a/storage/innobase/xtrabackup/test/t/bug1277403.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1277403.sh
@@ -1,0 +1,33 @@
+################################################################################
+# Bug 1277403: Use FLUSH TABLES before FTWRL                                   #
+################################################################################
+
+# we don't want to run this test on InnoDB 5.1 since it doesn't support
+# "FLUSH ENGINE LOGS" and Com_flush will show 2 for it
+require_server_version_higher_than 5.5.0
+
+start_server
+
+has_backup_locks && skip_test "Requires server without backup locks support"
+
+$MYSQL $MYSQL_ARGS -Ns -e \
+       "SHOW GLOBAL STATUS LIKE 'Com_unlock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
+       > $topdir/status1
+
+diff -u $topdir/status1 - <<EOF
+Com_unlock_tables	0
+Com_flush	0
+EOF
+
+innobackupex --no-timestamp $topdir/full_backup
+
+$MYSQL $MYSQL_ARGS -Ns -e \
+       "SHOW GLOBAL STATUS LIKE 'Com_unlock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
+       > $topdir/status2
+
+diff -u $topdir/status2 - <<EOF
+Com_unlock_tables	1
+Com_flush	3
+EOF

--- a/storage/innobase/xtrabackup/test/t/bug1410339.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1410339.sh
@@ -36,7 +36,10 @@ conn_id=`$MYSQL $MYSQL_ARGS -e "SHOW PROCESSLIST" | grep "INSERT" | awk '{print 
 start_innobackupex &
 job2=$!
 
-while ! $MYSQL $MYSQL_ARGS -e "SHOW PROCESSLIST" | grep "LOCK"
+# xtrabackup does FLUSH TABLES before FLUSH TABLES WITH READ LOCK
+# or LOCK TABLES FOR BACKUP
+# both are affected by lock_wait_timeout setting
+while ! $MYSQL $MYSQL_ARGS -e "SHOW PROCESSLIST" | grep "TABLES"
 do
     sleep 1
 done


### PR DESCRIPTION
Invoke FLUSH TABLES before FTWRL. Don't invoke FLUSH TABLES when
lock_wait_timeout or kill_long_queries_timeout is specified.

Tests 'bug1410339' and 'backup_locks' adjusted.
