### PR TITLE
Bug 1452307: --decrypt and --decompress do not work with xtrabackup 2.3

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1717,7 +1717,7 @@ cleanup:
 bool
 decrypt_decompress_file(const char *filepath, uint thread_n)
 {
-	std::stringstream cmd;
+	std::stringstream cmd, message;
 	char *dest_filepath = strdup(filepath);
 	bool needs_action = false;
 
@@ -1733,6 +1733,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  			    << xtrabackup_encrypt_key_file;
  		}
  		dest_filepath[strlen(dest_filepath) - 8] = 0;
+ 		message << "decrypting";
  		needs_action = true;
  	}
 
@@ -1742,16 +1743,21 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 		    && opt_decrypt))) {
  		cmd << " | qpress -dio ";
  		dest_filepath[strlen(dest_filepath) - 3] = 0;
+ 		if (needs_action) {
+ 			message << " and ";
+ 		}
+ 		message << "decompressing";
  		needs_action = true;
  	}
 
  	cmd << " > " << dest_filepath;
+ 	message << " " << filepath;
 
  	free(dest_filepath);
 
  	if (needs_action) {
 
-	 	msg("[%02u] %s\n", thread_n, cmd.str().c_str());
+	 	msg("[%02u] %s\n", thread_n, message.str().c_str());
 
 	 	if (system(cmd.str().c_str()) != 0) {
 	 		return(false);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -373,7 +373,7 @@ uint opt_debug_sleep_before_unlock = 0;
 uint opt_safe_slave_backup_timeout = 0;
 
 const char *opt_history = NULL;
-bool opt_decrypt = false;
+my_bool opt_decrypt = FALSE;
 
 /* Simple datasink creation tracking...add datasinks in the reverse order you
 want them destroyed. */
@@ -1405,9 +1405,11 @@ xb_get_one_option(int optid,
           "valid encryption  algorithm.\n");
       return(1);
     }
+    opt_decrypt = TRUE;
     xtrabackup_decrypt_decompress = true;
     break;
   case OPT_DECOMPRESS:
+    opt_decompress = TRUE;
     xtrabackup_decrypt_decompress = true;
     break;
   case (int) OPT_CORE_FILE:

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -166,7 +166,7 @@ extern uint		opt_debug_sleep_before_unlock;
 extern uint		opt_safe_slave_backup_timeout;
 
 extern const char	*opt_history;
-extern bool		opt_decrypt;
+extern my_bool		opt_decrypt;
 
 void xtrabackup_io_throttling(void);
 my_bool xb_write_delta_metadata(const char *filename,

--- a/storage/innobase/xtrabackup/test/t/xb_compress.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_compress.sh
@@ -4,7 +4,7 @@
 
 require_qpress
 
-innobackupex_options="--compress --compress-threads=4 --compress-chunk-size=8K"
-data_decompress_cmd="innobackupex --decompress ./"
+xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K"
+data_decompress_cmd="xtrabackup --decompress --target-dir=./"
 
 . inc/xb_local.sh

--- a/storage/innobase/xtrabackup/test/t/xb_compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_compress_encrypt.sh
@@ -7,9 +7,9 @@ require_qpress
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 
-innobackupex_options="--compress --compress-threads=4 --compress-chunk-size=8K --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
+xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
-data_decrypt_cmd="innobackupex --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} ./"
-data_decompress_cmd="innobackupex --decompress ./"
+data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} --target-dir=./"
+data_decompress_cmd="xtrabackup --decompress --target-dir=./"
 
 . inc/xb_local.sh

--- a/storage/innobase/xtrabackup/test/t/xb_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_encrypt.sh
@@ -5,7 +5,7 @@
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 
-innobackupex_options="--encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
-data_decrypt_cmd="innobackupex --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} ./"
+xtrabackup_options="--encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
+data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} --target-dir=./"
 
 . inc/xb_local.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_compress.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_compress.sh
@@ -6,7 +6,7 @@ require_qpress
 
 stream_format=xbstream
 stream_extract_cmd="xbstream -xv <"
-stream_uncompress_cmd="innobackupex --decompress ./"
+stream_uncompress_cmd="xtrabackup --decompress --target-dir=./"
 xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K"
 
 . inc/xb_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_compress_encrypt.sh
@@ -8,7 +8,7 @@ encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 stream_format=xbstream
 stream_extract_cmd="xbstream -xv <"
-stream_uncompress_cmd="innobackupex --decompress --decrypt=$encrypt_algo --encrypt-key $encrypt_key ./"
+stream_uncompress_cmd="xtrabackup --decompress --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --target-dir=./"
 xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
 . inc/xb_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_encrypt.sh
@@ -5,7 +5,7 @@
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 stream_format=xbstream
-stream_extract_cmd="(xbstream -xv ; innobackupex --decrypt=$encrypt_algo --encrypt-key=$encrypt_key ./) <"
+stream_extract_cmd="(xbstream -xv ; xtrabackup --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --target-dir=./) <"
 xtrabackup_options="--encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
 . inc/xb_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_parallel_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_parallel_encrypt.sh
@@ -6,7 +6,7 @@
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 stream_format=xbstream
-stream_extract_cmd="(xbstream -xv ; innobackupex --decrypt=$encrypt_algo --encrypt-key=$encrypt_key ./) <"
+stream_extract_cmd="(xbstream -xv ; xtrabackup --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --target-dir=./) <"
 xtrabackup_options="--parallel=16 --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
 . inc/xb_stream_common.sh


### PR DESCRIPTION
opt_decrypt and opt_decompress were not properly set by xtranackup.cc.
Relevant test were using innobackupex to decompress/decrypt.

Fix is to set options properly and to adjust test cases.
