### PR TITLE
Bug 1452375: innobackupex symlink is not created by make install in 2.3

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -86,6 +86,7 @@ TARGET_LINK_LIBRARIES(xtrabackup
 ########################################################################
 ADD_CUSTOM_COMMAND(TARGET xtrabackup
                    COMMAND ln -sf xtrabackup innobackupex)
+INSTALL_SYMLINK(xtrabackup xtrabackup innobackupex bin runtime)
 
 ########################################################################
 # xbstream binary


### PR DESCRIPTION
Fixed by adding appropriate command to CMakeLists.txt
