### PR TITLE
Fix for bug #1425269

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2006,19 +2006,6 @@ innobase_start_or_create_for_mysql(void)
 		os_thread_create(io_handler_thread, n + i, thread_ids + i);
 	}
 
-	if (srv_n_log_files * srv_log_file_size * UNIV_PAGE_SIZE
-	    >= 512ULL * 1024ULL * 1024ULL * 1024ULL) {
-		/* log_block_convert_lsn_to_no() limits the returned block
-		number to 1G and given that OS_FILE_LOG_BLOCK_SIZE is 512
-		bytes, then we have a limit of 512 GB. If that limit is to
-		be raised, then log_block_convert_lsn_to_no() must be
-		modified. */
-		ib_logf(IB_LOG_LEVEL_ERROR,
-			"Combined size of log files must be < 512 GB");
-
-		return(DB_ERROR);
-	}
-
 	if (srv_n_log_files * srv_log_file_size >= ULINT_MAX) {
 		/* fil_io() takes ulint as an argument and we are passing
 		(next_offset / UNIV_PAGE_SIZE) to it in log_group_write_buf().


### PR DESCRIPTION
Bug 1425269: Long-lasting backup of active databases fails with
"Combined size of log files must be < 512 GB"

Comment in srv0start.cc tells that log_block_convert_lsn_to_no()
limits the returned block number to 1G which is true. This however
doesn't impose any limit on combined size of log files.

The purpose of log_block_convert_lsn_to_no() is to return log block
number by given LSN. This number is then written to log block header
and both xtrabackup and server use this number to verify log
integrity.

These numbers are monotonically increasing up to value of 1G, after
that they started from 0. There is no relation between log block
number and it's offset in the log file. LSN offset calculated as
offset of the last checkpoint LSN (stored in log header) plus the
difference of LSN and LSN of the last checkpoint.

These assumptions were verified by modifying
log_block_convert_lsn_to_no() to wrap around value of 0x4000 and
trying to backup and restore modified server with modified
xtrabackup.

Also code has been inspected to find other limitations which would
prevent from successful restoring backup with large
xtrabackup_logfile. None has been found.
