### PR TITLE
Bug #1454815: xtrabackup prints warnings for tables, not included into partial backup

### DIFF
--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -847,6 +847,9 @@ fil_space_for_table_exists_in_mem(
 					information to the .err log if a
 					matching tablespace is not found from
 					memory */
+	bool		remove_from_data_dict_if_does_not_exist,
+					/*!< in: remove from the data dictionary
+					if tablespace does not exist */
 	bool		adjust_space,	/*!< in: whether to adjust space id
 					when find table space mismatch */
 	mem_heap_t*	heap,		/*!< in: heap memory */

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -4296,7 +4296,8 @@ row_drop_table_for_mysql(
 			if (!is_temp
 			    && !fil_space_for_table_exists_in_mem(
 					space_id, tablename, FALSE,
-					print_msg, false, NULL, 0)) {
+					print_msg, print_msg, false,
+					NULL, 0)) {
 				/* This might happen if we are dropping a
 				discarded tablespace */
 				err = DB_SUCCESS;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1793,7 +1793,6 @@ or "./database/name.ibd" (InnoDB 5.5-) should be skipped from backup based on
 the --tables or --tables-file options.
 
 @return TRUE if the table should be skipped. */
-static
 my_bool
 check_if_skip_table(
 /******************/
@@ -5683,6 +5682,8 @@ skip_check:
 	mem_init(srv_mem_pool_size);
 	ut_crc32_init();
 
+	xb_filters_init();
+
 	if(!innobase_log_arch_dir && xtrabackup_init_temp_log())
 		goto error;
 
@@ -6105,6 +6106,8 @@ next_node:
 		}
 	}
 
+	xb_filters_free();
+
 	if(!xtrabackup_create_ib_logfile)
 		return;
 
@@ -6118,6 +6121,8 @@ next_node:
 
 error:
 	xtrabackup_close_temp_log(FALSE);
+
+	xb_filters_free();
 
 	exit(EXIT_FAILURE);
 }

--- a/storage/innobase/xtrabackup/test/t/bug1454815.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1454815.sh
@@ -1,0 +1,30 @@
+. inc/common.sh
+
+start_server --innodb_file_per_table
+
+vlog "Creating test data"
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE DATABASE db1;
+USE db1;
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3);
+CREATE DATABASE db2;
+USE db2;
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3);
+EOF
+
+vlog "Creating backup directory"
+mkdir -p $topdir/backup
+
+vlog "Starting backup"
+xtrabackup --datadir=$mysql_datadir --backup --databases=db1 --target-dir=$topdir/backup
+
+vlog "Preparing backup"
+xtrabackup --datadir=$mysql_datadir --prepare --databases=db1 --export --target-dir=$topdir/backup
+
+if grep -q "InnoDB data dictionary has tablespace" $OUTFILE; then
+  exit 1
+fi
+
+stop_server


### PR DESCRIPTION
Whenever preparing a partial backup, several warning messages are
printed about tables that don’t exist. This is due to tables that are
not physically part of the backup (that is, no ibd files) but still
exist in InnoDB’s data dictionary.

Apart from these warnings being misleading to casual users, it can also
lead to overly large and verbose logs if the partial backup is taken on
a instance which has a large number of tables that are not part of the
backup.

When a filtering option (--databases, --tables, etc) is provided to
prepare, assume that the backup can be partial and do not print warnings
about tables that don't exist.
