### PR TITLE
Bug 1449834: innobackupex does not record binlog file and pos when GT…

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/howtos/recipes_ibkx_gtid.rst
+++ b/storage/innobase/xtrabackup/doc/source/howtos/recipes_ibkx_gtid.rst
@@ -17,11 +17,11 @@ Following command will take a backup to the /data/backups/$TIMESTAMP folder: ::
 In the destination folder there will be a file with the name :file:`xtrabackup_binlog_info`. This file will contain both, binary log coordinates and ``GTID`` information. :: 
 
  $ cat xtrabackup_binlog_info
- c777888a-b6df-11e2-a604-080027635ef5:1-4
+ mysql-bin.000002    1232        c777888a-b6df-11e2-a604-080027635ef5:1-4
 
 That information is also printed by innobackupex after backup is taken: ::
 
- innobackupex: MySQL binlog position: GTID of the last change 'c777888a-b6df-11e2-a604-080027635ef5:1-4'
+ innobackupex: MySQL binlog position: filename 'mysql-bin.000002', position 1232, GTID of the last change 'c777888a-b6df-11e2-a604-080027635ef5:1-4'
 
 STEP 2: Prepare the backup
 --------------------------

--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -3125,10 +3125,10 @@ sub write_binlog_info {
         return;
     }
 
-    if ($mariadb_gtid || !$mysql_gtid) {
-        @binlog_coordinates = ("filename '$filename'", "position $position");
-        @binlog_info_content = ($filename, $position);
-    }
+    # sometimes it is useful to know file based binlog coordinates
+    # even though GTID is enabled (see lp:1449834)
+    @binlog_coordinates = ("filename '$filename'", "position $position");
+    @binlog_info_content = ($filename, $position);
 
     $gtid = $con->{master_status}->{Executed_Gtid_Set};
     if (!defined($gtid)) {

--- a/storage/innobase/xtrabackup/test/t/bug1391041.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1391041.sh
@@ -31,19 +31,19 @@ innobackupex --no-timestamp $topdir/backup
 
 binlog_info=$topdir/backup/xtrabackup_binlog_info
 
-if egrep -q "filename.*position" $OUTFILE ; then
-	die "Found filename/position with GTID_MODE=ON"
+if ! egrep -q "filename.*position" $OUTFILE ; then
+	die "filename/position NOT FOUND with GTID_MODE=ON"
 fi
 
 if ! egrep -q "GTID of the last change" $OUTFILE ; then
 	die "GTID of the last change not found with GTID_MODE=ON"
 fi
 
-if egrep -q "^mysql-bin.[0-9]+[[:space:]]+[0-9]+$" $binlog_info ; then
-	die "Found filename/position with GTID_MODE=ON"
+if ! egrep -q "^mysql-bin.[0-9]+[[:space:]]+[0-9]+" $binlog_info ; then
+	die "filename/position NOT FOUND with GTID_MODE=ON"
 fi
 
-if ! egrep -q "^[a-f0-9:-]+$" $binlog_info ; then
+if ! egrep -q "[a-f0-9:-]+$" $binlog_info ; then
 	die "GTID not found in xtrabackup_binlog_info with GTID_MODE=ON"
 fi
 

--- a/storage/innobase/xtrabackup/test/t/bug977101.sh
+++ b/storage/innobase/xtrabackup/test/t/bug977101.sh
@@ -17,6 +17,7 @@ switch_server $slave_id
 
 # Check that binlog info is correct with --safe-slave-backup
 innobackupex --no-timestamp --safe-slave-backup $topdir/backup
+cat $topdir/backup/xtrabackup_binlog_info
 run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
 
@@ -24,6 +25,7 @@ run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
 # --safe-slave-backup
 rm -rf $topdir/backup
 innobackupex --no-timestamp --slave-info --safe-slave-backup $topdir/backup
+cat $topdir/backup/xtrabackup_binlog_info
 run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
 run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \

--- a/storage/innobase/xtrabackup/test/t/gtid.sh
+++ b/storage/innobase/xtrabackup/test/t/gtid.sh
@@ -30,7 +30,7 @@ EOF
 innobackupex --no-timestamp $topdir/backup
 
 # Check that the value of gtid_executed is in xtrabackup_binlog_info
-if ! egrep -q '^[a-f0-9:-]+$' \
+if ! egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+[[:space:]]+[a-f0-9:-]+$' \
     $topdir/backup/xtrabackup_binlog_info
 then
     die "Cannot find GTID coordinates in xtrabackup_binlog_info"


### PR DESCRIPTION
…ID is enabled

Sometimes it is useful to know file based binlog coordinates even
though GTID is enabled.

Fix is to print file based coordinates and to store them in
xtrabackup_binlog_info regardless of GTID mode.
