### PR TITLE
Bug 1399471: XtraBackup 2.2.x crash on prepare when backing up MySQL/…

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1399471.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1399471.sh
@@ -1,0 +1,37 @@
+############################################################################
+# Bug 1399471: XtraBackup 2.2.x crash on prepare when backing up
+#              MySQL/Percona Server 5.5.x (temp tables involved)
+############################################################################
+
+. inc/common.sh
+
+start_server --innodb_file_per_table
+
+function create_tmp_table()
+{
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+START TRANSACTION;
+CREATE TEMPORARY TABLE tmp_crash(id INT) ENGINE=InnoDB;
+SELECT SLEEP(10000);
+EOF
+}
+
+create_tmp_table &
+job_id=$!
+
+vlog "Starting backup"
+
+innobackupex --no-timestamp $topdir/backup
+
+kill -SIGKILL $job_id
+
+vlog "Preparing backup"
+innobackupex --apply-log $topdir/backup
+
+stop_server
+
+rm -rf ${mysql_datadir}/*
+
+innobackupex --copy-back $topdir/backup
+
+start_server


### PR DESCRIPTION
…Percona Server 5.5.x

When InnoDB rolling back active transactions on recovery it also
removes temporary tables. When temporary table removed from data
dictionary it also removed from system tables like SYS_TABLES,
SYS_FOREIGN, etc. The culprit here are SYS_DATAFILES and
SYS_TABLESPACES which were introduced in 5.6 and absent in backup
taken from MySQL 5.1/5.5.

The fix is not remove from SYS_DATAFILES and SYS_TABLESPACES if they
are absent. Patch also updates
fil_remove_invalid_table_from_data_dict to match
row_drop_table_for_mysql.

Patch contributed by Fungo Wang.
