### PR TITLE
Bug 1461129: Target sql_embedded should depend on GenDigestServerSource

### DIFF
--- a/libmysqld/CMakeLists.txt
+++ b/libmysqld/CMakeLists.txt
@@ -81,7 +81,7 @@ SET(SQL_EMBEDDED_SOURCES
 
 ADD_CONVENIENCE_LIBRARY(sql_embedded ${SQL_EMBEDDED_SOURCES})
 DTRACE_INSTRUMENT(sql_embedded)
-ADD_DEPENDENCIES(sql_embedded GenError GenServerSource)
+ADD_DEPENDENCIES(sql_embedded GenError GenServerSource GenDigestServerSource)
 
 # On Windows, static embedded server library is called mysqlserver.lib
 # On Unix, it is libmysqld.a


### PR DESCRIPTION
Source file 'sql_yacc.yy' needs generated file 'lex_token.h'. This
file is generated by 'GenDigestServerSource', which is dependency for
'sql', but not for 'sql_embedded'.
