### PR TITLE
Run FLUSH NO_WRITE_TO_BINLOG TABLES instead of FLUSH TABLES

### DIFF
--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -3506,9 +3506,9 @@ sub mysql_lock_tables {
         # compatible with this trick.
 
         $now = current_time();
-        print STDERR "$now  $prefix Executing FLUSH TABLES...\n";
+        print STDERR "$now  $prefix Executing FLUSH NO_WRITE_TO_BINLOG TABLES...\n";
 
-        mysql_query($con, "FLUSH TABLES");
+        mysql_query($con, "FLUSH NO_WRITE_TO_BINLOG TABLES");
     }
 
     if ($option_lock_wait_timeout) {


### PR DESCRIPTION
The latest release of Xtrabackup issues a FLUSH TABLE before the FTWRL.
While it will help the backups in some situation, it also implies that
FLUSH TABLE will be written to the binary log.

While this situation is okay most of the time, it is not in MariaDB 10.0
with GTID enabled. If the backup is taken on the Slave, then the FLUSH
TABLE statement is still written to the binary log. This alters the GTID
of that slave and XtraBackup does not see the "correct" GTID anymore.

It is then impossible to see the GTID of the backup, because we would
only see the "wrong" GTID that was written to the binary log.

To avoid that, we have to issue the flush command with the
NO_WRITE_TO_BINLOG option.

Side note 1:
Our setup: MariaDB 10.0; GTID Replication, with GTID strict mode, and
log-slave-updates=0.

Side note 2:
There is no problem with the FTWRL because it is never written to the
binlog.
