### PR TITLE
Bug 1467574: xtrabackup should initialize current_thd

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6170,6 +6170,10 @@ int main(int argc, char **argv)
 	setup_signals();
 
 	MY_INIT(argv[0]);
+
+	pthread_key_create(&THR_THD, NULL);
+	my_pthread_setspecific_ptr(THR_THD, NULL);
+
 	xb_regex_init();
 
 	system_charset_info= &my_charset_utf8_general_ci;
@@ -6375,6 +6379,9 @@ int main(int argc, char **argv)
 		xtrabackup_prepare_func();
 
 	xb_regex_end();
+
+	if (THR_THD)
+		(void) pthread_key_delete(THR_THD);
 
 	exit(EXIT_SUCCESS);
 }

--- a/storage/innobase/xtrabackup/test/t/bug1415191.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1415191.sh
@@ -1,0 +1,26 @@
+#
+# Bug 1415191: apply log crashes - signal 11 (ib_warn_row_too_big)
+#
+
+start_server
+
+( echo -n "CREATE TABLE test.foo ( "
+  for i in {1..197}; do
+    echo -n "text${i} TEXT"
+    [[ ${i} -ne 197 ]] && echo -n ", "
+  done
+  echo ") ENGINE = InnoDB" ) | $MYSQL $MYSQL_ARGS test
+
+( echo -n "INSERT INTO test.foo VALUES ("
+  for i in {1..197}; do
+    echo -n "'abcdef'"
+    [[ ${i} -ne 197 ]] && echo -n ", "
+  done
+  echo ")" ) | $MYSQL $MYSQL_ARGS test
+
+$MYSQL $MYSQL_ARGS -e "DELETE FROM test.foo WHERE text1 = 'abcdef'" test
+
+innobackupex --no-timestamp $topdir/backup
+
+# prepare will crash if bug is present
+innobackupex --apply-log $topdir/backup


### PR DESCRIPTION
Set thread-local variable THR_THD to NULL. This patch also fixes and
adds test case for bug #1415191.
