### PR TITLE
Fixed build-rpm.sh and build-dpkg.sh scripts to use git instead bzr (bug1466888) - 2.3

### DIFF
--- a/storage/innobase/xtrabackup/utils/build-dpkg.sh
+++ b/storage/innobase/xtrabackup/utils/build-dpkg.sh
@@ -48,7 +48,7 @@ SOURCEDIR="$(readlink -f $(dirname "$0")/../../../../)"
 XTRABACKUP_VERSION="${XB_VERSION_MAJOR}.${XB_VERSION_MINOR}.${XB_VERSION_PATCH}${XB_VERSION_EXTRA}"
 
 DEBIAN_VERSION="$(lsb_release -sc)"
-REVISION="$(cd "$SOURCEDIR"; bzr revno 2>/dev/null || cat REVNO)"
+REVISION="$(cd "$SOURCEDIR"; git rev-parse --short HEAD 2>/dev/null || cat REVNO)"
 FULL_VERSION="$XTRABACKUP_VERSION-$REVISION.$DEBIAN_VERSION"
 
 # Working directory
@@ -94,12 +94,12 @@ export DEB_DUMMY="$DUMMY"
         make DUMMY="$DUMMY" dist
     # Create the original tarball
         mv "${TMPDIR}/percona-xtrabackup-$XTRABACKUP_VERSION.tar.gz" \
-        "$WORKDIR/percona-xtrabackup-${XB_VERSION_MAJOR}${XB_VERSION_MINOR}_$XTRABACKUP_VERSION-$REVISION.orig.tar.gz"
+        "$WORKDIR/percona-xtrabackup_$XTRABACKUP_VERSION-$REVISION.orig.tar.gz"
         rm -fr ${TMPDIR}
     #
         cd "$WORKDIR"
         rm -fr percona-xtrabackup-$XTRABACKUP_VERSION
-        tar xzf percona-xtrabackup-${XB_VERSION_MAJOR}${XB_VERSION_MINOR}_$XTRABACKUP_VERSION-$REVISION.orig.tar.gz
+        tar xzf percona-xtrabackup_$XTRABACKUP_VERSION-$REVISION.orig.tar.gz
         cd percona-xtrabackup-$XTRABACKUP_VERSION
         cp -a storage/innobase/xtrabackup/utils/debian .
 

--- a/storage/innobase/xtrabackup/utils/build-rpm.sh
+++ b/storage/innobase/xtrabackup/utils/build-rpm.sh
@@ -104,7 +104,7 @@ REDHAT_RELEASE="$(grep -o 'release [0-9][0-9]*' /etc/redhat-release | \
 cut -d ' ' -f 2)"
 
 if [ -z "${REVISION:-}" ]; then
-  REVISION="$(cd "$SOURCEDIR"; (bzr revno 2>/dev/null || cat REVNO))"
+  REVISION="$(cd "$SOURCEDIR"; (git rev-parse --short HEAD 2>/dev/null || cat REVNO))"
 fi
 
 # Fix problems in rpmbuild for rhel4: _libdir and _arch are not correctly set.


### PR DESCRIPTION
This is a more complete PR from contribution: https://github.com/percona/percona-xtrabackup/pull/75

BUG:
https://bugs.launchpad.net/percona-xtrabackup/+bug/1466888

In the script there's calling to bzr which we don't use any more.
The fix is for rpm and dpkg script and also fixes the package name in dpkg script since it used like "percona-xtrabackup-22" which is now just "percona-xtrabackup". For 2.3 it is "percona-xtrabackup-23" so the issue is not visible there.

I'll close the original PR once this gets merged.

I tried both builds and they work - rpm and dpkg.
