### PR TITLE
Removed python-sphinx10 build dependency in rpm for centos 5/6 (JEN-378) - 2.2

### DIFF
--- a/storage/innobase/xtrabackup/utils/percona-xtrabackup.spec
+++ b/storage/innobase/xtrabackup/utils/percona-xtrabackup.spec
@@ -19,8 +19,6 @@ Source:         percona-xtrabackup-%{version}%{xb_version_extra}.tar.gz
 BuildRequires:  cmake, libaio-devel, libgcrypt-devel, ncurses-devel, readline-devel, zlib-devel
 %if 0%{?rhel} > 6
 BuildRequires:  python-sphinx >= 1.0.1, python-docutils >= 0.6
-%else
-BuildRequires:  python-sphinx10 >= 1.0.1, python-docutils >= 0.6
 %endif
 Requires:       perl(DBD::mysql), rsync
 BuildRoot:      %{_tmppath}/%{name}-%{version}-root


### PR DESCRIPTION
This is for: https://jira.percona.com/browse/JEN-378

There no longer exists python-sphinx10 package in epel repo for centos 5/6 so we need to remove this dependency on those packages.
If someone wants to build xtrabackup on their own they will need to install sphinx and docutils python modules in some python way.
Centos 7 is not affected because there is native package for python-sphinx and python-docutils.
