### PR TITLE
Bug 1475487: xtrabackup handling of space id conflicts

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -4261,7 +4261,8 @@ fil_load_single_table_tablespace(
 			os_file_close(remote.file);
 			mem_free(remote.filepath);
 
-			if (srv_backup_mode) {
+			if (srv_backup_mode && (remote.id == ULINT_UNDEFINED
+				|| remote.id == 0)) {
 
 				/* Ignore files that have uninitialized space
 				IDs on the backup stage. This means that a
@@ -4287,7 +4288,8 @@ fil_load_single_table_tablespace(
 		if (!def.success) {
 			os_file_close(def.file);
 
-			if (srv_backup_mode) {
+			if (srv_backup_mode && (def.id == ULINT_UNDEFINED
+				|| def.id == 0)) {
 
 				/* Ignore files that have uninitialized space
 				IDs on the backup stage. This means that a

--- a/storage/innobase/xtrabackup/test/t/bug1475487.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1475487.sh
@@ -1,0 +1,20 @@
+#
+# Bug 1475487: xtrabackup handling of space id conflicts
+#
+
+start_server --innodb_file_per_table
+
+${MYSQL} ${MYSQL_ARGS} -e "CREATE TABLE t (a INT) engine=InnoDB" test
+
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t VALUES (1), (2), (3)" test
+
+datadir=$mysql_datadir
+
+shutdown_server
+
+cp $datadir/test/t.ibd $datadir/test/a.ibd 
+
+start_server --innodb_file_per_table
+
+run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --backup --datadir=$mysql_datadir \
+					    --target-dir=$topdir/backup


### PR DESCRIPTION
When there are two or more tablespaces with the same ID in the data
directory, xtrabackup picks up the first one by lexical order.

Better choice would be to pick one, actually referenced by data
dictionary and that is what MySQL does after clean shutdown.

However, we cannot rely on data dictionary on "prepare" and
"apply-log" stages. MySQL on crash recovery just refuses to start
with error message.

Xtrabackup silently skips tablespaces with uninitialized space_id,
however because of wrong condition it also skips space_id conflicts.

Fixed by changing condition in fil_load_single_table_tablespace to
not only verify return code form
fil_validate_single_table_tablespace, but also check that space_id is
not defined before silently skip tablespace.
