### PR TITLE
Bug 1495367: xtrabackup 2.3 does not set wait_timeout session variable

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -123,6 +123,9 @@ xb_mysql_connect()
 		return(NULL);
 	}
 
+	xb_mysql_query(connection, "SET SESSION wait_timeout=2147483",
+		       false, true);
+
 	return(connection);
 }
 

--- a/storage/innobase/xtrabackup/test/t/bug1495367.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1495367.sh
@@ -1,0 +1,26 @@
+########################################################################
+# Bug 1495367: xtrabackup 2.3 does not set wait_timeout session variable
+########################################################################
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+wait_timeout=1
+"
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup \
+	   --debug-sync="data_copy_thread_func" &
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+sleep 1
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+wait $job_pid


### PR DESCRIPTION
xtrabackup needs to set wait_timeout in order to prevent server to
kill the connection while xtrabackup is copying data files.
