### PR TITLE
Bug 1242309: xtrabackup_logfile not compressed in XtraBackup 2.1+

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1242309.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1242309.sh
@@ -1,0 +1,19 @@
+#############################################################################
+# Bug 1242309: xtrabackup_logfile not compressed in XtraBackup 2.1+
+#############################################################################
+
+start_server
+
+innobackupex --no-timestamp --compress $topdir/backup
+
+if [ ! -f $topdir/backup/xtrabackup_logfile.qp ] ; then
+	die "xtrabackup_logfile is not compressed!"
+fi
+
+rm -rf $topdir/backup/*
+
+innobackupex --no-timestamp --compress --stream=xbstream $topdir/backup | xbstream -xv -C $topdir/backup
+
+if [ ! -f $topdir/backup/xtrabackup_logfile.qp ] ; then
+	die "xtrabackup_logfile is not compressed!"
+fi


### PR DESCRIPTION
xtrabackup_logfile goes to "ds_meta" datasink, which is not
compressed allowing to use compressed backup as a base for
incremental.

xtrabackup_logfile cannot go "ds_data" datasink, because it needs to
be saved in temporary directory and then streamed at the end of the
backup process, otherwise it will interfere with the innobackupex
stream.

Fix is to create new "ds_redo" datasink, which goes the same path as
"ds_meta", except for it is compressed if compressed backup created.
