### PR TITLE
Bug 1457016: Out of source tree builds are broken in 2.3 trunk

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -87,8 +87,9 @@ TARGET_LINK_LIBRARIES(xtrabackup
 # innobackupex symlink
 ########################################################################
 ADD_CUSTOM_COMMAND(TARGET xtrabackup
-                   COMMAND ln -sf xtrabackup innobackupex)
-INSTALL_SYMLINK(xtrabackup xtrabackup innobackupex bin runtime)
+                   COMMAND ${CMAKE_COMMAND} ARGS -E create_symlink
+                           xtrabackup innobackupex)
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/innobackupex DESTINATION bin)
 
 ########################################################################
 # xbstream binary


### PR DESCRIPTION
INSTALL_SYMLINK macro messed up with dependencies and caused error
for out of source build. Fix is to replace INSTALL_SYMLINK with
INSTALL.
