### PR TITLE
Bug 1454692: xtrabackup 2.3 should add timestamps to stderr output

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -766,7 +766,7 @@ datafile_copy_backup(const char *filepath, uint thread_n)
 	of the filters value. */
 
 	if (check_if_skip_table(filepath)) {
-		msg("[%02u] Skipping %s.\n", thread_n, filepath);
+		msg_ts("[%02u] Skipping %s.\n", thread_n, filepath);
 		return(true);
 	}
 
@@ -839,7 +839,7 @@ backup_file_vprintf(const char *filename, const char *fmt, va_list ap)
 	}
 
 	action = xb_get_copy_action("Writing");
-	msg("[%02u] %s %s\n", 0, action, filename);
+	msg_ts("[%02u] %s %s\n", 0, action, filename);
 
 	if (buf_len == -1) {
 		goto error;
@@ -850,7 +850,7 @@ backup_file_vprintf(const char *filename, const char *fmt, va_list ap)
 	}
 
 	/* close */
-	msg("[%02u]        ...done\n", 0);
+	msg_ts("[%02u]        ...done\n", 0);
 	free(buf);
 	ds_close(dstfile);
 	return(true);
@@ -958,8 +958,8 @@ copy_file(const char *src_file_path, const char *dst_file_path, uint thread_n)
 	}
 
 	action = xb_get_copy_action();
-	msg("[%02u] %s %s to %s\n",
-		thread_n, action, src_file_path, dstfile->path);
+	msg_ts("[%02u] %s %s to %s\n",
+	       thread_n, action, src_file_path, dstfile->path);
 
 	/* The main copy loop */
 	while ((res = datafile_read(&cursor)) == XB_FIL_CUR_SUCCESS) {
@@ -974,7 +974,7 @@ copy_file(const char *src_file_path, const char *dst_file_path, uint thread_n)
 	}
 
 	/* close */
-	msg("[%02u]        ...done\n", thread_n);
+	msg_ts("[%02u]        ...done\n", thread_n);
 	datafile_close(&cursor);
 	ds_close(dstfile);
 	return(true);
@@ -1018,16 +1018,15 @@ move_file(const char *src_file_path, const char *dst_file_path, uint thread_n)
 		return(false);
 	}
 
-	msg("[%02u] Moving %s to %s\n",
-		thread_n, src_file_path, dst_file_path_abs);
+	msg_ts("[%02u] Moving %s to %s\n",
+	       thread_n, src_file_path, dst_file_path_abs);
 
 	if (my_rename(src_file_path, dst_file_path_abs, MYF(0)) != 0) {
 		if (my_errno == EXDEV) {
 			bool ret;
 			ret = copy_file(src_file_path,
 					dst_file_path, thread_n);
-			msg("[%02u] Removing %s\n",
-					thread_n, src_file_path);
+			msg_ts("[%02u] Removing %s\n", thread_n, src_file_path);
 			if (unlink(src_file_path) != 0) {
 				msg("Error: unlink %s failed: %s\n",
 					src_file_path,
@@ -1042,7 +1041,7 @@ move_file(const char *src_file_path, const char *dst_file_path, uint thread_n)
 		return(false);
 	}
 
-	msg("[%02u]        ...done\n", thread_n);
+	msg_ts("[%02u]        ...done\n", thread_n);
 
 	return(true);
 }
@@ -1090,8 +1089,8 @@ backup_files(const char *from, bool prep_mode)
 		}
 	}
 
-	msg("Starting %s non-InnoDB tables and files\n",
-		prep_mode ? "prep copy of" : "to backup");
+	msg_ts("Starting %s non-InnoDB tables and files\n",
+	       prep_mode ? "prep copy of" : "to backup");
 
 	datadir_node_init(&node);
 	it = datadir_iter_new(from);
@@ -1146,13 +1145,12 @@ backup_files(const char *from, bool prep_mode)
 		cmd << "rsync -t . --files-from=" << rsync_tmpfile_name
 		    << " " << xtrabackup_target_dir;
 
-		msg("Starting rsync as: %s\n", cmd.str().c_str());
+		msg_ts("Starting rsync as: %s\n", cmd.str().c_str());
 		if ((err = system(cmd.str().c_str()) && !prep_mode) != 0) {
-			msg("Error: rsync failed with error code %d\n",
-				err);
+			msg_ts("Error: rsync failed with error code %d\n", err);
 			goto out;
 		}
-		msg("rsync finished successfully.\n");
+		msg_ts("rsync finished successfully.\n");
 
 		if (!prep_mode && !opt_no_lock) {
 			char path[FN_REFLEN];
@@ -1183,7 +1181,7 @@ backup_files(const char *from, bool prep_mode)
 					snprintf(dst_path, sizeof(dst_path),
 						"%s/%s", xtrabackup_target_dir,
 						path);
-					msg("Removing %s\n", dst_path);
+					msg_ts("Removing %s\n", dst_path);
 					unlink(dst_path);
 				}
 			}
@@ -1193,8 +1191,8 @@ backup_files(const char *from, bool prep_mode)
 		}
 	}
 
-	msg("Finished %s non-InnoDB tables and files\n",
-		prep_mode ? "a prep copy of" : "backing up");
+	msg_ts("Finished %s non-InnoDB tables and files\n",
+	       prep_mode ? "a prep copy of" : "backing up");
 
 out:
 	datadir_iter_free(it);
@@ -1271,7 +1269,7 @@ backup_start()
 	}
 
 	if (have_flush_engine_logs) {
-		msg("Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n");
+		msg_ts("Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n");
 		xb_mysql_query(mysql_connection,
 			"FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS", false);
 	}
@@ -1310,7 +1308,7 @@ backup_finish()
 		}
 	}
 
-	msg("Backup created in directory '%s'\n", xtrabackup_target_dir);
+	msg_ts("Backup created in directory '%s'\n", xtrabackup_target_dir);
 	if (mysql_binlog_position != NULL) {
 		msg("MySQL binlog position: %s\n", mysql_binlog_position);
 	}
@@ -1612,8 +1610,7 @@ copy_back()
 			snprintf(path, sizeof(path), "%s/%s",
 				mysql_data_home, node.filepath_rel);
 
-			msg("[%02u] Creating directory %s\n", 1,
-				path);
+			msg_ts("[%02u] Creating directory %s\n", 1, path);
 
 			if (mkdirp(path, 0777, MYF(0)) < 0) {
 				char errbuf[MYSYS_STRERROR_SIZE];
@@ -1627,7 +1624,7 @@ copy_back()
 
 			}
 
-			msg("[%02u] ...done.", 1);
+			msg_ts("[%02u] ...done.", 1);
 
 			continue;
 		}
@@ -1759,7 +1756,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 
  	if (needs_action) {
 
-	 	msg("[%02u] %s\n", thread_n, message.str().c_str());
+		msg_ts("[%02u] %s\n", thread_n, message.str().c_str());
 
 	 	if (system(cmd.str().c_str()) != 0) {
 	 		return(false);

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -106,10 +106,10 @@ xb_mysql_connect()
 		return(NULL);
 	}
 
-	msg("Connecting to MySQL server host: %s, user: %s, password: %s, "
-		"port: %d, socket: %s\n", opt_host, opt_user,
-		opt_password ? "set" : "not set",
-		opt_port, opt_socket);
+	msg_ts("Connecting to MySQL server host: %s, user: %s, password: %s, "
+	       "port: %d, socket: %s\n", opt_host ? opt_host : "localhost",
+	       opt_user, opt_password ? "set" : "not set",
+	       opt_port, opt_socket);
 
 	if (!mysql_real_connect(connection,
 				opt_host ? opt_host : "localhost",
@@ -616,8 +616,8 @@ have_queries_to_wait_for(MYSQL *connection, uint threshold)
 		    && duration >= (int)threshold
 		    && ((all_queries && is_query(info))
 		    	|| is_update_query(info))) {
-			msg("Waiting for query %s (duration %d sec): %s",
-				id, duration, info);
+			msg_ts("Waiting for query %s (duration %d sec): %s",
+			       id, duration, info);
 			return(true);
 		}
 	}
@@ -646,8 +646,8 @@ kill_long_queries(MYSQL *connection, uint timeout)
 		    duration >= (int)timeout &&
 		    ((all_queries && is_query(info)) ||
 		    	is_select_query(info))) {
-			msg("Killing query %s (duration %d sec): %s\n",
-				id, duration, info);
+			msg_ts("Killing query %s (duration %d sec): %s\n",
+			       id, duration, info);
 			ut_snprintf(kill_stmt, sizeof(kill_stmt),
 				    "KILL %s", id);
 			xb_mysql_query(connection, kill_stmt, false, false);
@@ -663,8 +663,8 @@ wait_for_no_updates(MYSQL *connection, uint timeout, uint threshold)
 
 	start_time = time(NULL);
 
-	msg("Waiting %u seconds for queries running longer than %u seconds "
-		"to finish\n", timeout, threshold);
+	msg_ts("Waiting %u seconds for queries running longer than %u seconds "
+	       "to finish\n", timeout, threshold);
 
 	while (time(NULL) <= (time_t)(start_time + timeout)) {
 		if (!have_queries_to_wait_for(connection, threshold)) {
@@ -673,7 +673,7 @@ wait_for_no_updates(MYSQL *connection, uint timeout, uint threshold)
 		os_thread_sleep(1000000);
 	}
 
-	msg("Unable to obtain lock. Please try again later.");
+	msg_ts("Unable to obtain lock. Please try again later.");
 
 	return(false);
 }
@@ -691,8 +691,8 @@ kill_query_thread(
 
 	os_event_set(kill_query_thread_started);
 
-	msg("Kill query timeout %d seconds.\n",
-		opt_kill_long_queries_timeout);
+	msg_ts("Kill query timeout %d seconds.\n",
+	       opt_kill_long_queries_timeout);
 
 	while (time(NULL) - start_time <
 				(time_t)opt_kill_long_queries_timeout) {
@@ -718,7 +718,7 @@ kill_query_thread(
 	mysql_close(mysql);
 
 stop_thread:
-	msg("Kill query thread stopped\n");
+	msg_ts("Kill query thread stopped\n");
 
 	os_event_set(kill_query_thread_stopped);
 
@@ -796,7 +796,7 @@ lock_tables(MYSQL *connection)
 		}
 	}
 
-	msg("Executing FLUSH TABLES WITH READ LOCK...\n");
+	msg_ts("Executing FLUSH TABLES WITH READ LOCK...\n");
 
 	if (opt_kill_long_queries_timeout) {
 		start_query_killer();
@@ -825,7 +825,7 @@ bool
 lock_binlog_maybe(MYSQL *connection)
 {
 	if (have_backup_locks && !opt_no_lock && !binlog_locked) {
-		msg("Executing LOCK BINLOG FOR BACKUP...\n");
+		msg_ts("Executing LOCK BINLOG FOR BACKUP...\n");
 		xb_mysql_query(connection, "LOCK BINLOG FOR BACKUP", false);
 		binlog_locked = true;
 
@@ -844,20 +844,20 @@ void
 unlock_all(MYSQL *connection)
 {
 	if (opt_debug_sleep_before_unlock) {
-		msg("Debug sleep for %u seconds\n",
-			opt_debug_sleep_before_unlock);
+		msg_ts("Debug sleep for %u seconds\n",
+		       opt_debug_sleep_before_unlock);
 		os_thread_sleep(opt_debug_sleep_before_unlock * 1000);
 	}
 
 	if (binlog_locked) {
-		msg("Executing UNLOCK BINLOG\n");
+		msg_ts("Executing UNLOCK BINLOG\n");
 		xb_mysql_query(connection, "UNLOCK BINLOG", false);
 	}
 
-	msg("Executing UNLOCK TABLES\n");
+	msg_ts("Executing UNLOCK TABLES\n");
 	xb_mysql_query(connection, "UNLOCK TABLES", false);
 
-	msg("All tables unlocked\n");
+	msg_ts("All tables unlocked\n");
 }
 
 
@@ -922,36 +922,36 @@ wait_for_safe_slave(MYSQL *connection)
 	}
 
 	open_temp_tables = get_open_temp_tables(connection);
-	msg("Slave open temp tables: %d\n", open_temp_tables);
+	msg_ts("Slave open temp tables: %d\n", open_temp_tables);
 
 	while (open_temp_tables && n_attempts--) {
-		msg("Starting slave SQL thread, waiting %d seconds, then "
-			"checking Slave_open_temp_tables again (%d attempts "
-			"remaining)...\n", sleep_time, n_attempts);
+		msg_ts("Starting slave SQL thread, waiting %d seconds, then "
+		       "checking Slave_open_temp_tables again (%d attempts "
+		       "remaining)...\n", sleep_time, n_attempts);
 
 		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
 		os_thread_sleep(sleep_time * 1000);
 		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
 
 		open_temp_tables = get_open_temp_tables(connection);
-		msg("Slave open temp tables: %d\n", open_temp_tables);
+		msg_ts("Slave open temp tables: %d\n", open_temp_tables);
 	}
 
 	/* Restart the slave if it was running at start */
 	if (open_temp_tables == 0) {
-		msg("Slave is safe to backup\n");
+		msg_ts("Slave is safe to backup\n");
 		goto cleanup;
 	}
 
 	result = false;
 
 	if (sql_thread_started) {
-		msg("Restarting slave SQL thread.\n");
+		msg_ts("Restarting slave SQL thread.\n");
 		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
 	}
 
-	msg("Slave_open_temp_tables did not become zero after "
-	    "%d seconds\n", opt_safe_slave_backup_timeout);
+	msg_ts("Slave_open_temp_tables did not become zero after "
+	       "%d seconds\n", opt_safe_slave_backup_timeout);
 
 cleanup:
 	free_mysql_variables(status);

--- a/storage/innobase/xtrabackup/src/common.h
+++ b/storage/innobase/xtrabackup/src/common.h
@@ -47,11 +47,35 @@ static inline int msg(const char *fmt, ...) ATTRIBUTE_FORMAT(printf, 1, 2);
 static inline int msg(const char *fmt, ...)
 {
 	int	result;
-	va_list args;
+	va_list	args;
 
 	va_start(args, fmt);
 	result = vfprintf(stderr, fmt, args);
 	va_end(args);
+
+	return result;
+}
+
+static inline int msg_ts(const char *fmt, ...) ATTRIBUTE_FORMAT(printf, 1, 2);
+static inline int msg_ts(const char *fmt, ...)
+{
+	int	result;
+	time_t 	t = time(NULL);
+	char	date[100];
+	char	*line;
+	va_list	args;
+
+	strftime(date, sizeof(date), "%y%m%d %H:%M:%S", localtime(&t));
+
+	va_start(args, fmt);
+	result = vasprintf(&line, fmt, args);
+	va_end(args);
+
+	if (result != -1) {
+		result = fprintf(stderr, "%s %s", date, line);
+		free(line);
+	}
+
 	return result;
 }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2351,10 +2351,10 @@ xtrabackup_copy_datafile(fil_node_t* node, uint thread_n)
 	action = xb_get_copy_action();
 
 	if (xtrabackup_stream) {
-		msg("[%02u] %s %s\n", thread_n, action, node_path);
+		msg_ts("[%02u] %s %s\n", thread_n, action, node_path);
 	} else {
-		msg("[%02u] %s %s to %s\n", thread_n, action,
-		    node_path, dstfile->path);
+		msg_ts("[%02u] %s %s to %s\n", thread_n, action,
+		       node_path, dstfile->path);
 	}
 
 	/* The main copy loop */
@@ -2374,7 +2374,7 @@ xtrabackup_copy_datafile(fil_node_t* node, uint thread_n)
 	}
 
 	/* close */
-	msg("[%02u]        ...done\n", thread_n);
+	msg_ts("[%02u]        ...done\n", thread_n);
 	xb_fil_cur_close(&cursor);
 	ds_close(dstfile);
 	if (write_filter && write_filter->deinit) {
@@ -2611,8 +2611,8 @@ retry_read:
 
 		group->scanned_lsn = group_scanned_lsn;
 
-		msg(">> log scanned up to (" LSN_PF ")\n",
-		    group->scanned_lsn);
+		msg_ts(">> log scanned up to (" LSN_PF ")\n",
+		       group->scanned_lsn);
 
 		group = UT_LIST_GET_NEXT(log_groups, group);
 
@@ -6866,7 +6866,7 @@ int main(int argc, char **argv)
 
 	xb_regex_end();
 
-	msg("completed OK!\n");
+	msg_ts("completed OK!\n");
 
 	free_defaults(argv_defaults);
 


### PR DESCRIPTION
Introduce two functions for logging messages msg() which doesn't add
timestamps and msg_ts() which does. Tools like xbstream, xbcrypt,
etc. use msg() and their output don't contain timestamps. xtrabackup
adds timestamps when needed (when file started or ended copying, when
FTWRL issued, etc.).
