### PR TITLE
Bug 1493015: Sporadic bug 1410339 failures in Jenkins (2.3)

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1410339.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1410339.sh
@@ -49,8 +49,6 @@ sleep 1
 
 $MYSQL $MYSQL_ARGS -e "KILL $conn_id"
 
-kill -SIGKILL $job1
-
 # Test that FTWRL / LOCK TABLES FOR BACKUP succeeds
 
 wait $job2


### PR DESCRIPTION
For older bash versions killing child bash process caused cleanup to
be invoked which led to backup directory being deleted and xtrabackup
was unable to create 'xtrabackup_log_copied' file and innobackupex
falsely assumed that backup completed with errors.
