### PR TITLE
Bug 1500508: xbcloud fails to create container with "error: curl_easy_perform() failed: Failed sending data to the peer"

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud.cc
@@ -602,9 +602,19 @@ cleanup:
 
 static
 size_t
-write_null_cb(char *buffer, size_t size, size_t nmemb, void *stream) {
-	return nmemb * size;
+write_null_cb(char *buffer, size_t size, size_t nmemb, void *stream)
+{
+	return fwrite(buffer, size, nmemb, stderr);
 }
+
+
+static
+size_t
+read_null_cb(char *ptr, size_t size, size_t nmemb, void *data)
+{
+	return 0;
+}
+
 
 static
 int
@@ -632,6 +642,8 @@ swift_create_container(swift_auth_info *info, const char *name)
 		curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, slist);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_null_cb);
+		curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_null_cb);
+		curl_easy_setopt(curl, CURLOPT_INFILESIZE, 0L);
 		curl_easy_setopt(curl, CURLOPT_PUT, 1L);
 		if (opt_cacert != NULL)
 			curl_easy_setopt(curl, CURLOPT_CAINFO, opt_cacert);
@@ -1118,7 +1130,7 @@ static int conn_upload_start(connection_info *conn)
 	}
 	curl_easy_setopt(conn->easy, CURLOPT_URL, object_url);
 	curl_easy_setopt(conn->easy, CURLOPT_READFUNCTION,
-							swift_upload_read_cb);
+				     swift_upload_read_cb);
 	curl_easy_setopt(conn->easy, CURLOPT_READDATA, conn);
 	curl_easy_setopt(conn->easy, CURLOPT_VERBOSE, opt_verbose);
 	curl_easy_setopt(conn->easy, CURLOPT_ERRORBUFFER, conn->error);
@@ -1129,8 +1141,10 @@ static int conn_upload_start(connection_info *conn)
 	curl_easy_setopt(conn->easy, CURLOPT_PUT, 1L);
 	curl_easy_setopt(conn->easy, CURLOPT_HTTPHEADER, conn->slist);
 	curl_easy_setopt(conn->easy, CURLOPT_HEADERFUNCTION,
-			 upload_header_read_cb);
+				     upload_header_read_cb);
 	curl_easy_setopt(conn->easy, CURLOPT_HEADERDATA, conn);
+	curl_easy_setopt(conn->easy, CURLOPT_INFILESIZE,
+				     (long) conn->chunk_size);
 	if (opt_cacert != NULL)
 		curl_easy_setopt(conn->easy, CURLOPT_CAINFO, opt_cacert);
 	if (opt_insecure)

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -14,7 +14,11 @@
 
 . inc/common.sh
 
-[ $[1 + $[ RANDOM % 5 ]] == 1 ] || skip_test "Skipping"
+# run this test only when backing up PS 5.6
+require_xtradb
+require_server_version_lower_than 5.7.0
+require_server_version_higher_than 5.6.0
+is_galera && skip_test "skipping"
 
 [ "${XBCLOUD_CREDENTIALS:-unset}" == "unset" ] && \
 	skip_test "Requires XBCLOUD_CREDENTIALS"


### PR DESCRIPTION
Fixed by doing following:
1. Always set read data callback for PUT method
2. Set input file size when appropriate

Change test case to run it only on PS 5.6. This will both provide
sufficient coverage and reduce load on swift server.
