### PR TITLE
Add support for encrypted and page compressed tables supported

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -1304,6 +1304,37 @@ fsp_page_create(
 }
 
 /**********************************************************************//**
+Compute offset after xdes where crypt data can be stored
+@return	offset */
+ulint
+fsp_header_get_crypt_offset(
+/*========================*/
+	ulint   zip_size, /*!< in: zip_size */
+	ulint*  max_size) /*!< out: free space available for crypt data */
+{
+	ulint pageno = 0;
+	/* compute first page_no that will have xdes stored on page != 0*/
+	for (ulint i = 0;
+	     (pageno = xdes_calc_descriptor_page(zip_size, i)) == 0; )
+		i++;
+
+	/* use pageno prior to this...i.e last page on page 0 */
+	ut_ad(pageno > 0);
+	pageno--;
+
+	ulint iv_offset = XDES_ARR_OFFSET +
+		XDES_SIZE * (1 + xdes_calc_descriptor_index(zip_size, pageno));
+
+	if (max_size != NULL) {
+		/* return how much free space there is available on page */
+		*max_size = (zip_size ? zip_size : UNIV_PAGE_SIZE) -
+			(FSP_HEADER_OFFSET + iv_offset + FIL_PAGE_DATA_END);
+	}
+
+	return FSP_HEADER_OFFSET + iv_offset;
+}
+
+/**********************************************************************//**
 Allocates a single free page from a space. The page is marked as used.
 @retval NULL if no page could be allocated
 @retval block, rw_lock_x_lock_count(&block->lock) == 1 if allocation succeeded

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -127,6 +127,14 @@ extern fil_addr_t	fil_addr_null;
 					data file (ibdata*, not *.ibd):
 					the file has been flushed to disk
 					at least up to this lsn */
+#define FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION 26 /*!< for the first page
+					in a system tablespace data file
+					(ibdata*, not *.ibd): the file has
+					been flushed to disk at least up
+					to this lsn
+					for other pages: a 32-bit key version
+					used to encrypt the page + 32-bit checksum
+					or 64 bits of zero if no encryption*/
 #define FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID  34 /*!< starting from 4.1.x this
 					contains the space id of the page */
 #define FIL_PAGE_SPACE_ID  FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID
@@ -145,6 +153,9 @@ extern fil_addr_t	fil_addr_null;
 #ifndef UNIV_INNOCHECKSUM
 
 /** File page types (values of FIL_PAGE_TYPE) @{ */
+#define FIL_PAGE_PAGE_COMPRESSED_ENCRYPTED 37401 /*!< Page is compressed and
+						 then encrypted */
+#define FIL_PAGE_PAGE_COMPRESSED 34354  /*!< page compressed page */
 #define FIL_PAGE_INDEX		17855	/*!< B-tree node */
 #define FIL_PAGE_UNDO_LOG	2	/*!< Undo log page */
 #define FIL_PAGE_INODE		3	/*!< Index node */

--- a/storage/innobase/include/fsp0fsp.ic
+++ b/storage/innobase/include/fsp0fsp.ic
@@ -63,6 +63,9 @@ fsp_flags_is_valid(
 	ulint	atomic_blobs = FSP_FLAGS_HAS_ATOMIC_BLOBS(flags);
 	ulint	page_ssize = FSP_FLAGS_GET_PAGE_SSIZE(flags);
 	ulint	unused = FSP_FLAGS_GET_UNUSED(flags);
+	ulint	page_compression = FSP_FLAGS_GET_PAGE_COMPRESSION(flags);
+	ulint	page_compression_level = FSP_FLAGS_GET_PAGE_COMPRESSION_LEVEL(flags);
+	ulint	atomic_writes = FSP_FLAGS_GET_ATOMIC_WRITES(flags);
 
 	DBUG_EXECUTE_IF("fsp_flags_is_valid_failure", return(false););
 
@@ -102,6 +105,18 @@ fsp_flags_is_valid(
 
 	} else if (UNIV_PAGE_SIZE != UNIV_PAGE_SIZE_ORIG && !page_ssize) {
 		return(false);
+	}
+
+	/* Page compression level requires page compression and atomic blobs
+	to be set */
+        if (page_compression_level || page_compression) {
+		if (!page_compression || !atomic_blobs) {
+			return(false);
+		}
+	}
+
+	if (atomic_writes > ATOMIC_WRITES_OFF) {
+		return (false);
 	}
 
 #if UNIV_FORMAT_MAX != UNIV_FORMAT_B

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -33,6 +33,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "common.h"
 #include "read_filt.h"
 #include "xtrabackup.h"
+#include "page0zip.h"
 
 /* Size of read buffer in pages */
 #define XB_FIL_CUR_PAGES 64
@@ -253,6 +254,7 @@ xb_fil_cur_open(
 	cursor->buf_offset = 0;
 	cursor->buf_page_no = 0;
 	cursor->thread_n = thread_n;
+	cursor->encryption = CRYPT_SCHEME_UNENCRYPTED;
 
 	cursor->space_size = cursor->statinfo.st_size / page_size;
 
@@ -261,6 +263,91 @@ xb_fil_cur_open(
 				  node->space->id);
 
 	return(XB_FIL_CUR_SUCCESS);
+}
+
+/******************************************************************
+Read crypt data from a page (0)
+@return crypt information from page 0. */
+static
+void
+fil_space_read_crypt_data(
+/*======================*/
+	ulint		space,	/*!< in: file space id */
+	const byte*	page,	/*!< in: page 0 */
+	ulint		offset,	/*!< in: offset */
+	xb_fil_cur_t*	cursor) /*!< in/out: source file cursor */
+{
+	if (memcmp(page + offset, EMPTY_PATTERN, MAGIC_SZ) == 0) {
+		/* Crypt data is not stored. */
+		return;
+	}
+
+	if (memcmp(page + offset, CRYPT_MAGIC, MAGIC_SZ) != 0) {
+		/* Crypt data is not stored. */
+		return;
+	}
+
+	ulint type = mach_read_from_1(page + offset + MAGIC_SZ + 0);
+
+	if (! (type == CRYPT_SCHEME_UNENCRYPTED ||
+	       type == CRYPT_SCHEME_1)) {
+		/* Assume not present */
+		return;
+	}
+
+	ulint iv_length = mach_read_from_1(page + offset + MAGIC_SZ + 1);
+
+	if (! (iv_length == CRYPT_SCHEME_1_IV_LEN)) {
+		/* Assume not present */
+		return;
+	}
+
+	if (type == CRYPT_SCHEME_1) {
+		msg("[%02u] %s is encrypted\n", cursor->thread_n, cursor->abs_path);
+	}
+
+	cursor->encryption = type;
+}
+
+/******************************************************************
+Calculate post encryption checksum
+@return page checksum or BUF_NO_CHECKSUM_MAGIC
+not needed. */
+UNIV_INTERN
+ulint
+fil_crypt_calculate_checksum(
+/*=========================*/
+	ulint	zip_size,	/*!< in: zip_size or 0 */
+	byte*	dst_frame)	/*!< in: page where to calculate */
+{
+	ib_uint32_t checksum = 0;
+	srv_checksum_algorithm_t algorithm =
+			static_cast<srv_checksum_algorithm_t>(srv_checksum_algorithm);
+
+	if (zip_size == 0) {
+		switch (algorithm) {
+		case SRV_CHECKSUM_ALGORITHM_CRC32:
+		case SRV_CHECKSUM_ALGORITHM_STRICT_CRC32:
+			checksum = buf_calc_page_crc32(dst_frame);
+			break;
+		case SRV_CHECKSUM_ALGORITHM_INNODB:
+		case SRV_CHECKSUM_ALGORITHM_STRICT_INNODB:
+			checksum = (ib_uint32_t) buf_calc_page_new_checksum(
+				dst_frame);
+			break;
+		case SRV_CHECKSUM_ALGORITHM_NONE:
+		case SRV_CHECKSUM_ALGORITHM_STRICT_NONE:
+			checksum = BUF_NO_CHECKSUM_MAGIC;
+			break;
+			/* no default so the compiler will emit a warning
+			* if new enum is added and not handled here */
+		}
+	} else {
+		checksum = page_zip_calc_checksum(dst_frame, zip_size,
+				                          algorithm);
+	}
+
+	return checksum;
 }
 
 /************************************************************************
@@ -340,40 +427,68 @@ read_retry:
 	partially written pages */
 	for (page = cursor->buf, i = 0; i < npages;
 	     page += cursor->page_size, i++) {
+		ulint page_no = cursor->buf_page_no + i;
+
+		if (offset == 0 && page_no == 0) {
+			ulint crypt_offset = fsp_header_get_crypt_offset(
+				cursor->zip_size, NULL);
+			fil_space_read_crypt_data(cursor->space_id, page, crypt_offset, cursor);
+		}
 
 		if (buf_page_is_corrupted(TRUE, page, cursor->zip_size)) {
+			uint key_version = mach_read_from_4(page + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION);
+			ulint page_type = mach_read_from_2(page+FIL_PAGE_TYPE);
+			ulint stored_checksum = BUF_NO_CHECKSUM_MAGIC;
+			ulint calculated_checksum =  BUF_NO_CHECKSUM_MAGIC;
+			bool page_compressed = (page_type == FIL_PAGE_PAGE_COMPRESSED);
+			bool page_compressed_encrypted = (page_type == FIL_PAGE_PAGE_COMPRESSED_ENCRYPTED);
+			bool corrupted = true;
 
-			ulint page_no = cursor->buf_page_no + i;
+			if (key_version != 0 ||
+				(cursor->encryption != CRYPT_SCHEME_UNENCRYPTED) ||
+				page_compressed || page_compressed_encrypted) {
 
-			if (cursor->is_system &&
-			    page_no >= FSP_EXTENT_SIZE &&
-			    page_no < FSP_EXTENT_SIZE * 3) {
-				/* skip doublewrite buffer pages */
-				xb_a(cursor->page_size == UNIV_PAGE_SIZE);
-				msg("[%02u] xtrabackup: "
-				    "Page %lu is a doublewrite buffer page, "
-				    "skipping.\n", cursor->thread_n, page_no);
-			} else {
-				retry_count--;
-				if (retry_count == 0) {
+				/* Page is really corrupted if post encryption stored
+				checksum does not match calculated checksum after page was
+				read. For pages compressed and then encrypted, there is no
+				checksum. */
+				stored_checksum = mach_read_from_4(page + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION + 4);
+				calculated_checksum = fil_crypt_calculate_checksum(cursor->zip_size, page);
+				corrupted = (!page_compressed_encrypted && stored_checksum != calculated_checksum);
+			}
+
+			if (corrupted) {
+				if (cursor->is_system &&
+					page_no >= FSP_EXTENT_SIZE &&
+					page_no < FSP_EXTENT_SIZE * 3) {
+					/* skip doublewrite buffer pages */
+					xb_a(cursor->page_size == UNIV_PAGE_SIZE);
 					msg("[%02u] xtrabackup: "
-					    "Error: failed to read page after "
-					    "10 retries. File %s seems to be "
-					    "corrupted.\n", cursor->thread_n,
-					    cursor->abs_path);
-					ret = XB_FIL_CUR_ERROR;
-					break;
+						"Page %lu is a doublewrite buffer page, "
+						"skipping.\n", cursor->thread_n, page_no);
+				} else {
+					retry_count--;
+					if (retry_count == 0) {
+						msg("[%02u] xtrabackup: "
+							"Error: failed to read page after "
+							"10 retries. File %s seems to be "
+							"corrupted.\n", cursor->thread_n,
+							cursor->abs_path);
+						ret = XB_FIL_CUR_ERROR;
+						break;
+					}
+					msg("[%02u] xtrabackup: "
+						"Database page corruption detected at page "
+						"%lu, retrying...\n", cursor->thread_n,
+						page_no);
+
+					os_thread_sleep(100000);
+
+					goto read_retry;
 				}
-				msg("[%02u] xtrabackup: "
-				    "Database page corruption detected at page "
-				    "%lu, retrying...\n", cursor->thread_n,
-				    page_no);
-
-				os_thread_sleep(100000);
-
-				goto read_retry;
 			}
 		}
+
 		cursor->buf_read += cursor->page_size;
 		cursor->buf_npages++;
 	}

--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -28,6 +28,18 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <my_dir.h>
 #include "read_filt.h"
 
+#define MAGIC_SZ 6
+
+static const unsigned char CRYPT_MAGIC[MAGIC_SZ] = {
+	's', 0xE, 0xC, 'R', 'E', 't' };
+
+static const unsigned char EMPTY_PATTERN[MAGIC_SZ] = {
+	0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+
+#define CRYPT_SCHEME_1 1
+#define CRYPT_SCHEME_1_IV_LEN 16
+#define CRYPT_SCHEME_UNENCRYPTED 0
+
 struct xb_fil_cur_t {
 	os_file_t	file;		/*!< source file handle */
 	fil_node_t*	node;		/*!< source tablespace node */
@@ -61,6 +73,7 @@ struct xb_fil_cur_t {
 	uint		thread_n;	/*!< thread number for diagnostics */
 	ulint		space_id;	/*!< ID of tablespace */
 	ulint		space_size;	/*!< space size in pages */
+	ulint		encryption;	/*!< encryption type if present */
 };
 
 typedef enum {


### PR DESCRIPTION
by MariaDB 10.1

In backup encrypted tables remain encrypted. Similarly, page
compressed tables are still compressed.
