### PR TITLE
Bug 1503964: innobackupex stream corrupted "xb_stream_read_chunk():

### DIFF
--- a/storage/innobase/xtrabackup/innobackupex.pl
+++ b/storage/innobase/xtrabackup/innobackupex.pl
@@ -4460,7 +4460,7 @@ sub read_config_file {
               && do { last; };
 
           # unknown
-          print("$prefix: Warning: Ignored unrecognized line ",
+          print STDERR ("$prefix: Warning: Ignored unrecognized line ",
                 $i + 1,
                 " in options : '${lines[$i]}'\n"
                 );


### PR DESCRIPTION
wrong chunk magic at offset 0x0"

innobackupex wrote error message to STDOUT instead of STDIN which
broke xbstream and tar stream.
