### PR TITLE
Bug 1507238: Test backup_locks.sh fails on recent versions of PS and PXC

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -790,6 +790,7 @@ lock_tables(MYSQL *connection)
 	}
 
 	if (have_backup_locks) {
+		msg_ts("Executing LOCK TABLES FOR BACKUP...\n");
 		xb_mysql_query(connection, "LOCK TABLES FOR BACKUP", false);
 		return(true);
 	}
@@ -808,7 +809,7 @@ lock_tables(MYSQL *connection)
 		compatible with this trick.
 		*/
 
-		msg("Executing FLUSH NO_WRITE_TO_BINLOG TABLES...\n");
+		msg_ts("Executing FLUSH NO_WRITE_TO_BINLOG TABLES...\n");
 
 		xb_mysql_query(connection,
 			       "FLUSH NO_WRITE_TO_BINLOG TABLES", false);

--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -16,7 +16,7 @@ has_backup_safe_binlog_info && lock_binlog_used=0 || lock_binlog_used=1
 
 load_sakila
 
-innobackupex --no-timestamp $topdir/full_backup
+xtrabackup --backup --target-dir=$topdir/full_backup
 
 $MYSQL $MYSQL_ARGS -Ns -e \
        "SHOW GLOBAL STATUS LIKE 'Com_%lock%'; \
@@ -35,16 +35,16 @@ Com_unlock_tables	1
 Com_flush	1
 EOF
 
-innobackupex --no-timestamp --incremental \
-             --incremental-basedir=$topdir/full_backup \
-             $topdir/inc_backup
+xtrabackup --backup \
+           --incremental-basedir=$topdir/full_backup \
+           --target-dir=$topdir/inc_backup
 
 $MYSQL $MYSQL_ARGS -Ns -e \
        "SHOW GLOBAL STATUS LIKE 'Com_%lock%'; \
        SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
        > $topdir/status2
 
-((binlog_stmts+=lock_binlog_used))
+((binlog_stmts+=lock_binlog_used)) || true
 
 diff $topdir/status2 - <<EOF
 Com_lock_tables	0
@@ -64,7 +64,7 @@ EOF
 
 rm -rf $topdir/full_backup
 
-innobackupex --no-timestamp --no-backup-locks $topdir/full_backup
+xtrabackup --backup --no-backup-locks --target-dir=$topdir/full_backup
 
 $MYSQL $MYSQL_ARGS -Ns -e \
        "SHOW GLOBAL STATUS LIKE 'Com_%lock%'; \


### PR DESCRIPTION
After implementing blueprint lockless-binlog-info test
backup_locks.sh needed adjustment. Adjustment has been made and test
became to expect lockless backups performed on server having version
with safe binlog info support. However for xtrabackup to use new
feature it must be invoked via 'xtrabackup' instead
'innobackupex'. 'innobackupex' behavior remains compatible.

Fix is to replace 'innobackupex' with 'xtrabackup' in backup_locks.sh
test.
