### PR TITLE
Small fix in debian package description for supported servers (BLD-350)

### DIFF
--- a/storage/innobase/xtrabackup/utils/debian/control
+++ b/storage/innobase/xtrabackup/utils/debian/control
@@ -33,8 +33,8 @@ Enhances: mysql-server
 Description: Open source backup tool for InnoDB and XtraDB
  Percona XtraBackup is an open-source hot backup utility for MySQL that
  doesn't lock your database during the backup. It can back up data from
- InnoDB, XtraDB and MyISAM tables on MySQL/Percona Server 5.1 and
- 5.5 servers, and has many advanced features.
+ InnoDB, XtraDB and MyISAM tables on MySQL/Percona Server/MariaDB
+ servers, and has many advanced features.
 
 Package: percona-xtrabackup-dbg-23
 Section: debug


### PR DESCRIPTION
Just a small update. Versions were removed since MariaDB has 10/10.1 so we don't make a confusion and the whole list in the package description.
