### PR TITLE
Bug 1509812: backup fails with history on server enabled and binary l…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1332,7 +1332,8 @@ write_xtrabackup_info(MYSQL *connection)
 		buf_start_time,  /* start_time */
 		buf_end_time,  /* end_time */
 		history_lock_time, /* lock_time */
-		mysql_binlog_position,  /* binlog_pos */
+		mysql_binlog_position ?
+			mysql_binlog_position : "", /* binlog_pos */
 		incremental_lsn, /* innodb_from_lsn */
 		metadata_to_lsn, /* innodb_to_lsn */
 		(xtrabackup_tables /* partial */
@@ -1444,7 +1445,11 @@ write_xtrabackup_info(MYSQL *connection)
 	/* binlog_pos */
 	bind[idx].buffer_type = MYSQL_TYPE_STRING;
 	bind[idx].buffer = mysql_binlog_position;
-	bind[idx].buffer_length = strlen(mysql_binlog_position);
+	if (mysql_binlog_position != NULL) {
+		bind[idx].buffer_length = strlen(mysql_binlog_position);
+	} else {
+		bind[idx].is_null = &null;
+	}
 	++idx;
 
 	/* innodb_from_lsn */

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1432,6 +1432,13 @@ xb_get_one_option(int optid,
   case (int) OPT_CORE_FILE:
     test_flags |= TEST_CORE_ON_SIGNAL;
     break;
+  case OPT_HISTORY:
+    if (argument) {
+      opt_history = argument;
+    } else {
+      opt_history = "";
+    }
+    break;
   case '?':
     usage();
     exit(EXIT_SUCCESS);

--- a/storage/innobase/xtrabackup/test/t/bug1509812.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1509812.sh
@@ -1,0 +1,18 @@
+#
+# Bug 1509812: backup fails with history on server enabled
+#              and binary log disabled
+#
+
+start_server --skip-log-bin
+
+xtrabackup --history --backup --target-dir=$topdir/backup
+
+cat $topdir/backup/xtrabackup_info
+
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT * FROM PERCONA_SCHEMA.xtrabackup_history\G"
+
+innobackupex --history $topdir/backup
+
+cat $topdir/backup/xtrabackup_info
+
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT * FROM PERCONA_SCHEMA.xtrabackup_history\G"


### PR DESCRIPTION
…og disabled

When trying to store history record on server, xtrabackup is trying
to obtain binary log position from mysql_binlog_position variable
which is set only if binary log is enabled, otherwise it is NULL.

When mysql_binlog_position xtrabackup fails when trying to invoke
strlen(mysql_binlog_position).
