### PR TITLE
Bug 1511701: rsync parameter return error with 2.3.2 build

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6823,6 +6823,22 @@ int main(int argc, char **argv)
 	my_load_path(xtrabackup_real_target_dir, xtrabackup_target_dir, NULL);
 	xtrabackup_target_dir= xtrabackup_real_target_dir;
 
+	/* get default temporary directory */
+	if (!opt_mysql_tmpdir || !opt_mysql_tmpdir[0]) {
+		opt_mysql_tmpdir = getenv("TMPDIR");
+#if defined(__WIN__)
+		if (!opt_mysql_tmpdir) {
+			opt_mysql_tmpdir = getenv("TEMP");
+		}
+		if (!opt_mysql_tmpdir) {
+			opt_mysql_tmpdir = getenv("TMP");
+		}
+#endif
+		if (!opt_mysql_tmpdir || !opt_mysql_tmpdir[0]) {
+			opt_mysql_tmpdir = const_cast<char*>(DEFAULT_TMPDIR);
+		}
+	}
+
 	/* temporary setting of enough size */
 	srv_page_size_shift = UNIV_PAGE_SIZE_SHIFT_MAX;
 	srv_page_size = UNIV_PAGE_SIZE_MAX;

--- a/storage/innobase/xtrabackup/test/t/bug1511701.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1511701.sh
@@ -1,0 +1,13 @@
+###############################################################################
+# Bug 1511701: rsync parameter return error with 2.3.2 build
+###############################################################################
+
+start_server
+
+# remove tmpdir from my.cnf
+cp ${MYSQLD_VARDIR}/my.cnf ${MYSQLD_VARDIR}/my.cnf.orig
+sed -ie '/tmpdir/d' ${MYSQLD_VARDIR}/my.cnf
+
+innobackupex --rsync --datadir=$mysql_datadir --no-timestamp $topdir/backup1
+
+xtrabackup --rsync --datadir=$mysql_datadir --backup --target-dir=$topdir/backup2


### PR DESCRIPTION
With --rsync specified, xtrabackup is trying to write file list into
temporary directory set by --tmpdir. If --tmpdir is not set,
xtrabackup fails to do so.

Fix is to set --tmpdir either from environment variable or to any
good default if it is not specified explicitly or in my.cnf.
