### PR TITLE
Bug 1513520: xtrabackup doesn't handle --slave-info option well with PXC

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1023,6 +1023,8 @@ write_slave_info(MYSQL *connection)
 		msg("This means that the server is not a "
 			"replication slave. Ignoring the --slave-info "
 			"option\n");
+		/* we still want to continue the backup */
+		result = true;
 		goto cleanup;
 	}
 

--- a/storage/innobase/xtrabackup/test/t/bug1513520.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1513520.sh
@@ -1,0 +1,9 @@
+#
+# Bug 1513520: xtrabackup doesn't handle --slave-info option well with PXC
+#
+
+start_server
+
+innobackupex --slave-info --no-timestamp $topdir/backup1
+
+xtrabackup --slave-info --backup --target-dir=$topdir/backup2


### PR DESCRIPTION
Continue backup after ignoring the --slave-info option.
