### PR TITLE
Bug 1520569: 2.3 creates empty dir after upgrading

### DIFF
--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -911,7 +911,7 @@ make_backup_dir()
 	time_t t = time(NULL);
 	char buf[100];
 
-	if (!opt_ibx_notimestamp) {
+	if (!opt_ibx_notimestamp && !ibx_xtrabackup_stream_str) {
 		strftime(buf, sizeof(buf), "%Y-%m-%d_%H-%M-%S", localtime(&t));
 		ut_a(asprintf(&ibx_backup_directory, "%s/%s",
 				ibx_position_arg, buf) != -1);

--- a/storage/innobase/xtrabackup/test/t/bug1520569.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1520569.sh
@@ -1,0 +1,13 @@
+#
+# Bug 1520569: 2.3 creates empty dir after upgrading
+#
+
+start_server
+
+# check that directory with timestamp as a name is not created
+# (--stream should imply --no-timestamp)
+innobackupex --stream=tar $topdir/backup > $topdir/xbs
+
+if [ "$(ls -A $topdir/backup)" ] ; then
+	die "Directory is created!"
+fi


### PR DESCRIPTION
innobackupex --stream created empty directory with timestamp as a
name.

Code changed so that --stream implies --no-timestamp.
