### PR TITLE
Bug 1512281: innobackupex crashes during sst (MariaDB-specific)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1168,7 +1168,7 @@ write_current_binlog_file(MYSQL *connection)
 		if (log_bin_dir == NULL) {
 			/* log_bin_basename does not exist in MariaDB,
 			fallback to datadir */
-			log_bin_dir = datadir;
+			log_bin_dir = strdup(datadir);
 		}
 
 		dirname_part(log_bin_dir, log_bin_dir, &log_bin_dir_length);


### PR DESCRIPTION
Double free of 'datadir' variable is fixed by using strdup.
