### PR TITLE
Bug 1511267: xtrabackup 2.3 can not be built from GitHub sources

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
+++ b/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
@@ -26,13 +26,14 @@ In Debian-based distributions, you need to: ::
 
  $ apt-get install build-essential flex bison automake autoconf \
     libtool cmake libaio-dev mysql-client libncurses-dev zlib1g-dev \
-    libgcrypt11-dev libev-dev libcurl4-gnutls-dev
+    libgcrypt11-dev libev-dev libcurl4-gnutls-dev vim-common
 
 
 In ``RPM``-based distributions, you need to: ::
  
   $ yum install cmake gcc gcc-c++ libaio libaio-devel automake autoconf \
-    bison libtool ncurses-devel libgcrypt-devel libev-devel libcurl-devel
+    bison libtool ncurses-devel libgcrypt-devel libev-devel libcurl-devel \
+    vim-common
 
 Compiling with CMake
 --------------------

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -24,6 +24,13 @@ FIND_GCRYPT()
 FIND_CURL()
 FIND_EV()
 
+# xxd is needed to embed version_check script
+FIND_PROGRAM(XXD_PATH xxd)
+
+IF(NOT XXD_PATH)
+  MESSAGE(FATAL_ERROR "xxd not found. Try to install vim-common.")
+ENDIF(NOT XXD_PATH)
+
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/include
   ${CMAKE_SOURCE_DIR}/storage/innobase/include
@@ -43,9 +50,13 @@ INCLUDE_DIRECTORIES(
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/xtrabackup_version.h.in
                ${CMAKE_CURRENT_BINARY_DIR}/xtrabackup_version.h )
 
-EXECUTE_PROCESS(COMMAND xxd --include version_check.pl
-                ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
+                   COMMAND ${XXD_PATH} --include version_check.pl
+                   ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+ADD_CUSTOM_TARGET(GenVersionCheck
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h)
 
 
 MYSQL_ADD_EXECUTABLE(xtrabackup
@@ -82,6 +93,7 @@ TARGET_LINK_LIBRARIES(xtrabackup
   archive_static
   )
 
+ADD_DEPENDENCIES(xtrabackup GenVersionCheck)
 
 ########################################################################
 # innobackupex symlink


### PR DESCRIPTION
- added vim-common (contains xxd) to build instruction
- added check that xxd binary is present
- moved version_check code generation from configure stage to build
  stage
