### PR TITLE
Bug 1523687: xtrabackup_binlog_info is not being updated correctly wh…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1346,10 +1346,17 @@ ibx_copy_incremental_over_full()
 	const char *ext_list[] = {"frm", "isl", "MYD", "MYI", "MAD", "MAI",
 		"MRG", "TRG", "TRN", "ARM", "ARZ", "CSM", "CSV", "opt", "par",
 		NULL};
+	const char *sup_files[] = {"xtrabackup_binlog_info",
+				   "xtrabackup_galera_info",
+				   "xtrabackup_slave_info",
+				   "xtrabackup_info",
+				   "ib_lru_dump",
+				   NULL};
 	datadir_iter_t *it = NULL;
 	datadir_node_t node;
 	bool ret = true;
 	char path[FN_REFLEN];
+	int i;
 
 	datadir_node_init(&node);
 
@@ -1400,12 +1407,20 @@ ibx_copy_incremental_over_full()
 			}
 		}
 
-		snprintf(path, sizeof(path), "%s/%s",
-			xtrabackup_incremental_dir,
-			"ib_lru_dump");
+		/* copy supplementary files */
 
-		if (file_exists(path)) {
-			copy_file(path, "ib_lru_dump", 0);
+		for (i = 0; sup_files[i]; i++) {
+			snprintf(path, sizeof(path), "%s/%s",
+				xtrabackup_incremental_dir,
+				sup_files[i]);
+
+			if (file_exists(sup_files[i])) {
+				unlink(sup_files[i]);
+			}
+
+			if (file_exists(path)) {
+				copy_file(path, sup_files[i], 0);
+			}
 		}
 
 	}

--- a/storage/innobase/xtrabackup/test/t/bug1523687.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1523687.sh
@@ -1,0 +1,32 @@
+#
+# Bug 1523687: xtrabackup_binlog_info is not being
+#              updated correctly when applying incrementals
+#
+
+start_server
+
+$MYSQL $MYSQL_ARGS -e "CREATE TABLE t (a INT) ENGINE=InnoDB" test
+$MYSQL $MYSQL_ARGS -e "INSERT INTO t VALUES (1), (2), (3)" test
+
+xtrabackup --backup --target-dir=$topdir/full
+
+$MYSQL $MYSQL_ARGS -e "INSERT INTO t VALUES (4), (5), (6)" test
+
+xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full \
+				      --incremental-dir=$topdir/inc
+
+xtrabackup --prepare --target-dir=$topdir/full
+
+# verify that following files overwritten in full backup directory with the
+# corresponding files from incremental directory
+for i in xtrabackup_binlog_info xtrabackup_galera_info \
+	 xtrabackup_slave_info xtrabackup_info ;
+do
+	if [ -f $topdir/inc/$i ] ; then
+		diff -u $topdir/full/$i $topdir/inc/$i
+	fi
+done


### PR DESCRIPTION
…en applying incrementals

Copy xtrabackup_binlog_info, xtrabackup_galera_info,
xtrabackup_slave_info, xtrabackup_info from incremental directory
over the corresponding files in full directory.
