### PR TITLE
Fixes DOC-197 by updating the apt installation instructions

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/conf.py
+++ b/storage/innobase/xtrabackup/doc/source/conf.py
@@ -236,7 +236,12 @@ latex_logo = 'percona-logo.jpg'
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = True
+
+latex_elements = {
+  'classoptions': ',oneside',
+  'babel': '\\usepackage[english]{babel}'
+}
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/storage/innobase/xtrabackup/doc/source/installation/apt_repo.rst
+++ b/storage/innobase/xtrabackup/doc/source/installation/apt_repo.rst
@@ -40,31 +40,19 @@ The ``percona-xtrabackup-2x`` package contains the older version of the |Percona
 Installing |Percona XtraBackup| from Percona ``apt`` repository
 ===============================================================
 
-1. Import the public key for the package management system
-
-   *Debian* and *Ubuntu* packages from *Percona* are signed with the Percona's GPG key. Before using the repository, you should add the key to :program:`apt`. To do that, run the following commands as root or with sudo:
+1. Fetch the repository packages from Percona web:
 
    .. code-block:: bash
 
-     $ sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A
+     $ wget https://repo.percona.com/apt/percona-release_0.1-3.$(lsb_release -sc)_all.deb
 
-   .. note::
-
-     In case you're getting timeouts when using ``keys.gnupg.net`` as an alternative you can fetch the key from ``keyserver.ubuntu.com``.
-
-2. Create the :program:`apt` source list for Percona's repository:
-
-   You can create the source list and add the Percona repository by running:
+2. Install the downloaded package with :program:`dpkg`. To do that, run the following commands as root or with :program:`sudo`:
 
    .. code-block:: bash
 
-     $ echo "deb http://repo.percona.com/apt "$(lsb_release -sc)" main" | sudo tee /etc/apt/sources.list.d/percona.list
+     $ sudo dpkg -i percona-release_0.1-3.$(lsb_release -sc)_all.deb
 
-   Additionally you can enable the source package repository by running:
-
-   .. code-block:: bash
-
-     $ echo "deb-src http://repo.percona.com/apt "$(lsb_release -sc)" main" | sudo tee -a /etc/apt/sources.list.d/percona.list
+   Once you install this package the Percona repositories should be added. You can check the repository setup in the :file:`/etc/apt/sources.list.d/percona-release.list` file.
 
 3. Remember to update the local cache:
 
@@ -84,10 +72,15 @@ Installing |Percona XtraBackup| from Percona ``apt`` repository
 Percona ``apt`` Testing repository
 ----------------------------------
 
-Percona offers pre-release builds from the testing repository. To enable it add the just add the ``testing`` word at the end of the Percona repository definition in your repository file (default :file:`/etc/apt/sources.list.d/percona.list`). It should looks like this (in this example ``VERSION`` is the name of your distribution): ::
+Percona offers pre-release builds from the testing repository. To enable it add the just add the ``testing`` word at the end of the Percona repository definition in your repository file (default :file:`/etc/apt/sources.list.d/percona-release.list`). It should looks like this (in this example ``VERSION`` is the name of your distribution): ::
 
   deb http://repo.percona.com/apt VERSION main testing
   deb-src http://repo.percona.com/apt VERSION main testing
+
+For example, if you are running *Debian* 8 (*jessie*) and want to install the latest testing builds, the definitions should look like this: ::
+
+  deb http://repo.percona.com/apt jessie main testing
+  deb-src http://repo.percona.com/apt jessie main testing
 
 Apt-Pinning the packages
 ------------------------

--- a/storage/innobase/xtrabackup/doc/source/intro.rst
+++ b/storage/innobase/xtrabackup/doc/source/intro.rst
@@ -24,8 +24,9 @@ Percona's enterprise-grade commercial `MySQL Support <http://www.percona.com/mys
 MySQL Backup Tool Feature Comparison
 ====================================
 
+.. tabularcolumns:: |p{5cm}|p{5cm}|p{5cm}|
+
 .. list-table::
-   :widths: 30 15 15
    :header-rows: 1
 
    * - Features
@@ -36,11 +37,11 @@ MySQL Backup Tool Feature Comparison
      - Proprietary
    * - Price
      - Free
-     - Included in subscription at $5000 per Serve
+     - Included in subscription at $5000 per Server
    * - Streaming and encryption formats
      - Open source
      - Proprietary
-   * - Supported MySQL flavors
+   * - Supported |MySQL| flavors
      - |MySQL|, |Percona Server|, |MariaDB|, |Percona XtraDB Cluster|,
        *MariaDB Galera Cluster*
      - |MySQL|


### PR DESCRIPTION
to use the repo package instead of manually creating the repo file
Fixes DOC-125 by adding custom table size for latex/pdf builds
