### PR TITLE
Bug 1533722: xtrabackup crashed during apply 5.5 backup set with utf8_general50_ci collation

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1610,6 +1610,12 @@ innobase_get_cset_width(
 				sql_print_warning(
 					"Unknown collation #%lu.", cset);
 			}
+		} else if (cset == 253) {
+			/* Charset collation utf8_general50_ci is not support in Oracle MySQL */
+			ut_print_timestamp(stderr);
+			fprintf(stderr,
+				" InnoDB: Warning: Charset collation 'utf8_general50_ci' is"
+				" not supported in Oracle MySQL.\n");
 		} else {
 
 			ut_a(cset == 0);


### PR DESCRIPTION
Charset collation 'utf8_general50_ci'(253) was added in PS 5.1/5.5,
and is not supported by Oracle/MySQL against which xtrabackup is
compiled. This will lead to crash when recovring.

Fix:
Print warning when encounter 'utf8_general50_ci' charset collation,
and leave the decisions(continue or discard recovery) to users.
