### PR TITLE
Bug 1533542: innobackupex silently skip extra arguments

### DIFF
--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -931,7 +931,7 @@ ibx_handle_options(int *argc, char ***argv)
 {
 	char backup_config_path[FN_REFLEN];
 	const char *groups[] = {"mysqld", NULL};
-	int i;
+	int i, n_arguments;
 
 	if (handle_options(argc, argv, ibx_long_options, ibx_get_one_option)) {
 		return(false);
@@ -951,6 +951,7 @@ ibx_handle_options(int *argc, char ***argv)
 
 	/* find and save position argument */
 	i = 0;
+	n_arguments = 0;
 	while (i < *argc) {
 		char *opt = (*argv)[i];
 
@@ -962,10 +963,14 @@ ibx_handle_options(int *argc, char ***argv)
 					opt);
 			}
 			ibx_position_arg = opt;
-			--(*argc);
-			continue;
+			++n_arguments;
 		}
 		++i;
+	}
+
+	*argc -= n_arguments;
+	if (n_arguments > 1) {
+		return(false);
 	}
 
 	if (ibx_position_arg == NULL) {

--- a/storage/innobase/xtrabackup/test/t/bug1533542.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1533542.sh
@@ -1,0 +1,16 @@
+########################################################################
+# Bug #1533542: innobackupex silently skip extra arguments
+########################################################################
+
+. inc/common.sh
+
+start_server
+
+# Full backup
+vlog "Starting backup"
+
+# Invoke innobackupex with an extra argument 'tmp-dir'
+run_cmd_expect_failure $IB_BIN $IB_ARGS --no-timestamp $topdir/backup tmp-dir
+
+# Should failed with error
+grep -q "Error: extra argument found tmp-dir" $OUTFILE


### PR DESCRIPTION
Should print error about extra arguments and exit
