### PR TITLE
Bug 1533180: Table with page compression lz4/zlib marked as corrupted

### DIFF
--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -349,13 +349,11 @@ read_retry:
 
 		if (Compression::is_compressed_page(page)) {
 
-
 			if (os_file_decompress_page(false, page,
 			    cursor->scratch, cursor->page_size) != DB_SUCCESS) {
 				goto corruption;
 			}
 
-			memcpy(page, cursor->scratch, cursor->page_size);
 		}
 
 		if (buf_page_is_corrupted(TRUE, page, page_size, false)) {


### PR DESCRIPTION
1. Adjust test case to make sure tablespaces are flushed
2. Remove memcpy because os_file_decompress_page copies dst buffer
   back to src and memcpy copied to wrong location.
