### PR TITLE
Bug 1527081: xtrabackup 2.3 does not respect innodb_log_file_size sto…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1550,6 +1550,7 @@ write_backup_config_file()
 		"innodb_log_block_size=%lu\n"
 		"innodb_undo_directory=%s\n"
 		"innodb_undo_tablespaces=%lu\n"
+		"%s%s\n"
 		"%s%s\n",
 		innodb_checksum_algorithm_names[srv_checksum_algorithm],
 		innodb_checksum_algorithm_names[srv_log_checksum_algorithm],
@@ -1562,7 +1563,11 @@ write_backup_config_file()
 		srv_undo_dir,
 		srv_undo_tablespaces,
 		innobase_doublewrite_file ? "innodb_doublewrite_file=" : "",
-		innobase_doublewrite_file ? innobase_doublewrite_file : "");
+		innobase_doublewrite_file ? innobase_doublewrite_file : "",
+		innobase_buffer_pool_filename ?
+			"innodb_buffer_pool_filename=" : "",
+		innobase_buffer_pool_filename ?
+			innobase_buffer_pool_filename : "");
 }
 
 

--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -929,8 +929,6 @@ make_backup_dir()
 bool
 ibx_handle_options(int *argc, char ***argv)
 {
-	char backup_config_path[FN_REFLEN];
-	const char *groups[] = {"mysqld", NULL};
 	int i;
 
 	if (handle_options(argc, argv, ibx_long_options, ibx_get_one_option)) {
@@ -971,14 +969,6 @@ ibx_handle_options(int *argc, char ***argv)
 	if (ibx_position_arg == NULL) {
 		ibx_msg("Missing argument\n");
 		return(false);
-	}
-
-	if (ibx_mode == IBX_MODE_APPLY_LOG
-	    || ibx_mode == IBX_MODE_COPY_BACK
-	    || ibx_mode == IBX_MODE_MOVE_BACK) {
-		ut_snprintf(backup_config_path, sizeof(backup_config_path),
-			"%s/backup_my.cnf", ibx_position_arg);
-		load_defaults(backup_config_path, groups, argc, argv);
 	}
 
 	/* set argv[0] to be the program name */

--- a/storage/innobase/xtrabackup/test/t/bug1527081.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1527081.sh
@@ -1,0 +1,27 @@
+#
+# Bug 1527081: xtrabackup 2.3 does not respect innodb_log_file_size
+#              stored in backup-my.cnf
+#
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb-log-files-in-group=4
+innodb-log-file-size=2M
+"
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+${XB_BIN} --prepare --target-dir=$topdir/backup
+
+stop_server
+
+rm -rf ${mysql_datadir}
+
+xtrabackup --move-back --target-dir=$topdir/backup
+
+start_server
+
+if grep -q "Resizing redo log" ${MYSQLD_ERRFILE} ; then
+	die "backup-my.cnf is ignored!"
+fi


### PR DESCRIPTION
…red in backup-my.cnf
- Make xtrabackup to load "backup-my.cnf" on prepare.
- Store full path of buffer pool dump in "backup-my.cnf"
