### PR TITLE
Bug 1535673: Failed to prepare full backup (size == space->size_in_header)

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3175,8 +3175,12 @@ xb_load_single_table_tablespace(
 			ut_error;
 		}
 
-		if (srv_backup_mode && !srv_close_files) {
-			fil_space_open(space->name);
+		/* by opening the tablespace we forcing node and space objects
+		in the cache to be populated with fields from space header */
+		fil_space_open(space->name);
+
+		if (!srv_backup_mode || srv_close_files) {
+			fil_space_close(space->name);
 		}
 	} else {
 		if (xtrabackup_backup) {


### PR DESCRIPTION
Prepare failed with assertion: "size == space->size_in_header".

Size stored in space object does not match size stored in tablespace
header.

It is caused by the fact that xb_load_single_table_tablespace has not
always opened tablespace leaving space->size_in_header blank.

Fix is to open tablespace in order to populate some fields of space
object with values stored in tablespace header.
