### PR TITLE
Bug 1535312: Failed to prepare incremental backup if general

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -5567,8 +5567,15 @@ xb_delta_open_matching_space(
 			bool		exists;
 			os_file_type_t	type;
 
-			snprintf(tmpname, FN_REFLEN, "%s/xtrabackup_tmp_#%lu",
-				 dbname, fil_space->id);
+			if (dbname != NULL) {
+				snprintf(tmpname, FN_REFLEN,
+					 "%s/xtrabackup_tmp_#%lu",
+					 dbname, fil_space->id);
+			} else {
+				snprintf(tmpname, FN_REFLEN,
+					 "./xtrabackup_tmp_#%lu",
+					 fil_space->id);
+			}
 
 			oldpath = mem_strdup(
 				UT_LIST_GET_FIRST(fil_space->chain)->name);
@@ -5921,7 +5928,6 @@ rm_if_not_found(
 			snprintf(name, FN_REFLEN, "%s/%s/%s", data_home_dir,
 				 db_name, file_name);
 		} else {
-			ut_error;
 			snprintf(name, FN_REFLEN, "%s/%s", data_home_dir,
 				 file_name);
 		}

--- a/storage/innobase/xtrabackup/test/t/bug1535312.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1535312.sh
@@ -1,0 +1,52 @@
+#
+#   Bug 1535312: Failed to prepare incremental backup if general 
+#                tablespace has been recreated between backups
+#
+
+require_server_version_higher_than 5.7.0
+
+start_server
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd';
+
+CREATE TABLE t (a INT) TABLESPACE ts1;
+
+INSERT INTO t VALUES (1), (2), (3);
+
+EOF
+
+xtrabackup --backup --target-dir=$topdir/full
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+DROP TABLE t;
+
+DROP TABLESPACE ts1;
+
+CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd' FILE_BLOCK_SIZE = 8192;
+
+CREATE TABLE p (a INT) TABLESPACE ts1 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+
+INSERT INTO p VALUES (10), (20), (30);
+
+EOF
+
+xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
+
+record_db_state test
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+
+xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/full
+
+start_server
+
+verify_db_state test


### PR DESCRIPTION
```
         tablespace has been recreated between backups
```

While applying deltas for tablespace with given ID,
xtrabackup is trying to find matching tablespace with the same
ID. When tablespace with same name but with different ID was found,
xtrabackup will rename it. The bug was in rename code. It was not
able to handle tablespaces located in data home dir instead of its
subdirectory.
