### PR TITLE
Bug 1537256: innobackupex in rsync mode fails with 'no space on devic…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1156,6 +1156,7 @@ backup_files(const char *from, bool prep_mode)
 		msg_ts("Starting rsync as: %s\n", cmd.str().c_str());
 		if ((err = system(cmd.str().c_str()) && !prep_mode) != 0) {
 			msg_ts("Error: rsync failed with error code %d\n", err);
+			ret = false;
 			goto out;
 		}
 		msg_ts("rsync finished successfully.\n");

--- a/storage/innobase/xtrabackup/src/ds_local.c
+++ b/storage/innobase/xtrabackup/src/ds_local.c
@@ -52,8 +52,10 @@ local_init(const char *root)
 	if (my_mkdir(root, 0777, MYF(0)) < 0
 	    && my_errno != EEXIST && my_errno != EISDIR)
 	{
+		char errbuf[MYSYS_STRERROR_SIZE];
 		my_error(EE_CANT_MKDIR, MYF(ME_BELL | ME_WAITTANG),
-			 root, my_errno);
+			 root, my_errno, my_strerror(errbuf, sizeof(errbuf),
+			 my_errno));
 		return NULL;
 	}
 
@@ -82,8 +84,10 @@ local_open(ds_ctxt_t *ctxt, const char *path,
 	/* Create the directory if needed */
 	dirname_part(dirpath, fullpath, &dirpath_len);
 	if (my_mkdir(dirpath, 0777, MYF(0)) < 0 && my_errno != EEXIST) {
+		char errbuf[MYSYS_STRERROR_SIZE];
 		my_error(EE_CANT_MKDIR, MYF(ME_BELL | ME_WAITTANG),
-			 dirpath, my_errno);
+			 dirpath, my_errno, my_strerror(errbuf, sizeof(errbuf),
+			 my_errno));
 		return NULL;
 	}
 


### PR DESCRIPTION
…e' but completes with OK message

In rsync mode xtrabackup analyzed error code returned by rsync and
printed error message, but didn't propagate it.

Also fixed error in ds_local which was made xtrabackup to crash when
reporting error message.
