### PR TITLE
Bug 1544671: bug1535312 test failure

### DIFF
--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -279,14 +279,18 @@ Datafile::set_name(const char*	name)
 
 	if (name != NULL) {
 		m_name = mem_strdup(name);
-	} else if (fsp_is_file_per_table(m_space_id, m_flags)) {
-		m_name = fil_path_to_space_name(m_filepath);
-	} else {
+	} else if (!fsp_is_file_per_table(m_space_id, m_flags) ||
+		   strchr(m_filepath, OS_PATH_SEPARATOR) ==
+		   strrchr(m_filepath, OS_PATH_SEPARATOR)) {
+		/* FSP flags could be unitialized. Treat the tablespace as
+		general if it contains only one path separator. */
 		/* Give this general tablespace a temporary name. */
 		m_name = static_cast<char*>(
 			ut_malloc_nokey(strlen(general_space_name) + 20));
 
 		sprintf(m_name, "%s_" ULINTPF, general_space_name, m_space_id);
+	} else {
+		m_name = fil_path_to_space_name(m_filepath);
 	}
 }
 


### PR DESCRIPTION
Once datafile is opened by Datafile::validate_for_recovery, it then
invokes Datafile::set_name. Datafile::set_name behave differently for
different kinds of tablespaces. For file-per-table tablespaces it
will invoke `fil_path_to_space_name` which expect filepath to look
like `./dbname/table_name.ibd`. The issue is that Datafile::set_name
makes decision whether tablespace is file-per-table or general
depending on FSP flags stored on the first page. During the recovery
FSP flags could sometimes be uninitialized. In this case
`fil_path_to_space_name` will crash trying to parse file path which
looks like './datafile.ibd'
