### PR TITLE
Bug 1404484: Xtrabackup doesn't log master co-ordinates while backup …

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1062,7 +1062,9 @@ write_slave_info(MYSQL *connection)
 	} else if (gtid_slave_pos && *gtid_slave_pos) {
 		/* MariaDB >= 10.0 with GTID enabled */
 		result = backup_file_printf(XTRABACKUP_SLAVE_INFO,
-			"CHANGE MASTER TO master_use_gtid = slave_pos\n");
+			"SET GLOBAL gtid_slave_pos = '%s';\n"
+			"CHANGE MASTER TO master_use_gtid = slave_pos\n",
+			gtid_slave_pos);
 		ut_a(asprintf(&mysql_slave_position,
 			"master host '%s', gtid_slave_pos %s",
 			master, gtid_slave_pos) != -1);


### PR DESCRIPTION
…up MariaDB 10

Write "SET GLOBAL gtid_slave_pos = 'N-N-N';" statement to
xtrabackup_slave_info when backing up MariaDB with GTID
enabled. Previously gtid_slave_pos was only logged to stderr.
