### PR TITLE
Sometimes xtrabackup is crashed because accessing already freed wait_throttle.

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4441,6 +4441,9 @@ skip_last_cp:
 
 	xtrabackup_destroy_datasinks();
 
+	/* Sleep 5 seconds to make room for io_watching_thread exit the while loop */
+	os_thread_sleep(5000000); /*5 sec*/
+	
 	if (wait_throttle)
 		os_event_destroy(wait_throttle);
 


### PR DESCRIPTION
xtrabackup_backup_func(void) function will free wait_throttle os_event structure when data file copy is done (xtrabackup.cc::4444).
But io_watching_thread will call os_event_set(wait_throttle) after sleeping 1 seconds. So io_watching_thread is sleeping when log_copying variable is set to FALSE, sometimes io_watching_thread will call os_evet_set with freed wait_throttle os event structure. This cause segfault of xtrabackup (signal 11).

So I think we need some sleep(at least over 1 second) in the last part(before call os_event_free(wait_throttle)) of xtrabackup_backup_func().
Or move the os_event_destroy(wait_throttle) line to the end of xtrabackup_backup_func().

Below json text is back trace of xtrabackup segfault.

{   "signal": 11
,   "executable": "/opt/xtrabackup/bin/xtrabackup_innodb56"
,   "stacktrace":
      [ {   "crash_thread": true
        ,   "frames":
              [ {   "address": 5687944
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 1493640
                ,   "function_name": "os_event_set2(os_event_struct_)"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                }
              , {   "address": 4400444
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 206140
                ,   "function_name": "io_watching_thread(void_)"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                }
              , {   "address": 225502591649
                ,   "build_id": "c56dd1b811fc0d9263248ebb308c73fcbcd80fc1"
                ,   "build_id_offset": 31393
                ,   "function_name": "start_thread"
                ,   "file_name": "/lib64/libpthread.so.0"
                }
              , {   "address": 225499318589
                ,   "build_id": "8e6fa4c4b0594c355c1b90c1d49990368c81a040"
                ,   "build_id_offset": 952637
                ,   "function_name": "__clone"
                ,   "file_name": "/lib64/libc.so.6"
                } ]
        }
      , {   "frames":
              [ {   "address": 225499288499
                ,   "build_id": "8e6fa4c4b0594c355c1b90c1d49990368c81a040"
                ,   "build_id_offset": 922547
                ,   "function_name": "__select"
                ,   "file_name": "/lib64/libc.so.6"
                }
              , {   "address": 5694639
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 1500335
                ,   "function_name": "os_thread_sleep(unsigned long)"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                }
              , {   "address": 4401243
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 206939
                ,   "function_name": "xb_data_files_close()"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                }
              , {   "address": 4407926
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 213622
                ,   "function_name": "xtrabackup_backup_func()"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                }
              , {   "address": 4425674
                ,   "build_id": "e9966454ce915ab6103fae4115a0d7669bbf0c82"
                ,   "build_id_offset": 231370
                ,   "function_name": "main"
                ,   "file_name": "/opt/xtrabackup/bin/xtrabackup_innodb56"
                } ]
        } ]
}
