### PR TITLE
Added support for InnoDB encrypted tablespaces

### DIFF
--- a/plugin/keyring/buffered_file_io.cc
+++ b/plugin/keyring/buffered_file_io.cc
@@ -171,7 +171,10 @@ my_bool Buffered_file_io::init(std::string *keyring_filename)
          mysql_file_close(file, MYF(0)) < 0;
 }
 
-my_bool Buffered_file_io::flush_to_file(PSI_file_key *file_key,
+my_bool Buffered_file_io::flush_to_file(
+#ifdef HAVE_PSI_INTERFACE
+                                      PSI_file_key *file_key,
+#endif
                                       const std::string* filename)
 {
   File file;
@@ -195,7 +198,11 @@ my_bool Buffered_file_io::flush_to_file(PSI_file_key *file_key,
 
 my_bool Buffered_file_io::flush_to_backup()
 {
-  if (flush_to_file(&keyring_backup_file_data_key, get_backup_filename()) == FALSE)
+  if (flush_to_file(
+#ifdef HAVE_PSI_INTERFACE
+    &keyring_backup_file_data_key,
+#endif
+    get_backup_filename()) == FALSE)
   {
     backup_exists= TRUE;
     return FALSE;
@@ -210,7 +217,11 @@ my_bool Buffered_file_io::remove_backup()
 
 my_bool Buffered_file_io::flush_to_keyring()
 {
-  return flush_to_file(&keyring_file_data_key, &keyring_filename);
+  return flush_to_file(
+#ifdef HAVE_PSI_INTERFACE
+    &keyring_file_data_key,
+#endif
+    &keyring_filename);
 }
 
 my_bool Buffered_file_io::close()

--- a/plugin/keyring/buffered_file_io.h
+++ b/plugin/keyring/buffered_file_io.h
@@ -64,7 +64,11 @@ private:
   my_bool remove_backup();
   my_bool open_backup_file(File *backup_file);
   my_bool load_keyring_into_input_buffer(File file);
-  my_bool flush_to_file(PSI_file_key *file_key, const std::string* filename);
+  my_bool flush_to_file(
+#ifdef HAVE_PSI_INTERFACE
+    PSI_file_key *file_key,
+#endif
+    const std::string* filename);
   inline my_bool check_file_structure(File file, size_t file_size);
   my_bool is_file_tag_correct(File file);
   my_bool is_file_version_correct(File file);

--- a/plugin/keyring/keyring.h
+++ b/plugin/keyring/keyring.h
@@ -27,8 +27,10 @@ using namespace keyring;
 namespace keyring
 {
 /* Always defined. */
+#ifdef HAVE_PSI_INTERFACE
   extern PSI_memory_key key_memory_KEYRING;
   extern PSI_rwlock_key key_LOCK_keyring;
+#endif
 }
 
 extern mysql_rwlock_t LOCK_keyring;

--- a/plugin/keyring/keyring_impl.cc
+++ b/plugin/keyring/keyring_impl.cc
@@ -20,7 +20,9 @@ namespace keyring
 {
 /* Always defined. */
   PSI_memory_key key_memory_KEYRING;
+#ifdef HAVE_PSI_INTERFACE
   PSI_rwlock_key key_LOCK_keyring;
+#endif
 }
 
 mysql_rwlock_t LOCK_keyring;

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -82,6 +82,11 @@ bool	innodb_calling_exit;
 #include <mysqld.h>
 #include <mysql/service_mysql_keyring.h>
 
+#define my_key_fetch mysql_key_fetch
+
+my_bool mysql_key_fetch(const char *key_id, char **key_type, const char *user_id,
+                        void **key, size_t *key_len);
+
 /** Insert buffer segment id */
 static const ulint IO_IBUF_SEGMENT = 0;
 
@@ -1643,7 +1648,10 @@ os_file_io_complete(
 
 		return(DB_SUCCESS);
 
-	} else if (type.is_read()) {
+	} else if (type.is_read() && !srv_read_only_mode) {
+		/* Do not decrypt / decompress when taking a backup.
+		   We actually decompress the pages in fil_cur.
+		   We want encrypted pages to remain encrypted. */
 		dberr_t		ret;
 		Encryption	encryption(type.encryption_algorithm());
 

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Percona LLC and/or its affiliates.
+# Copyright (c) 2013-2016 Percona LLC and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,6 +16,8 @@
 INCLUDE(gcrypt)
 INCLUDE(curl)
 INCLUDE(libev)
+
+INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/compile_flags.cmake)
 
 ADD_SUBDIRECTORY(libarchive)
 ADD_SUBDIRECTORY(jsmn)
@@ -58,6 +60,15 @@ ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
 ADD_CUSTOM_TARGET(GenVersionCheck
                   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h)
 
+ADD_COMPILE_FLAGS(
+  keyring.cc
+  ../../../../plugin/keyring/keyring_impl.cc
+  ../../../../plugin/keyring/keyring_key.cc
+  ../../../../plugin/keyring/buffered_file_io.cc
+  ../../../../plugin/keyring/keys_container.cc
+  COMPILE_FLAGS -I${BOOST_PATCHES_DIR} -I${BOOST_INCLUDE_DIR}
+)
+
 
 MYSQL_ADD_EXECUTABLE(xtrabackup
   xtrabackup.cc
@@ -83,6 +94,11 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   xbstream_write.c
   backup_mysql.cc
   backup_copy.cc
+  keyring.cc
+  ../../../../plugin/keyring/keyring_impl.cc
+  ../../../../plugin/keyring/keyring_key.cc
+  ../../../../plugin/keyring/buffered_file_io.cc
+  ../../../../plugin/keyring/keys_container.cc
   )
 
 SET_TARGET_PROPERTIES(xtrabackup PROPERTIES ENABLE_EXPORTS TRUE)

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1582,6 +1582,7 @@ write_backup_config_file()
 		"innodb_log_block_size=%lu\n"
 		"innodb_undo_directory=%s\n"
 		"innodb_undo_tablespaces=%lu\n"
+		"server_id=%lu\n"
 		"%s%s\n"
 		"redo_log_version=%lu\n"
 		"%s%s\n",
@@ -1595,6 +1596,7 @@ write_backup_config_file()
 		srv_log_block_size,
 		srv_undo_dir,
 		srv_undo_tablespaces,
+		(ulint)server_id,
 		innobase_doublewrite_file ? "innodb_doublewrite_file=" : "",
 		innobase_doublewrite_file ? innobase_doublewrite_file : "",
 		redo_log_version,

--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -51,6 +51,8 @@ struct xb_fil_cur_t {
 	byte*		buf;		/*!< aligned pointer for orig_buf */
 	byte*		scratch;	/*!< page to use for temporary
 					decompress */
+	byte*		decrypt;	/*!< page to use for temporary
+					decrypt */
 	ulint		buf_size;	/*!< buffer size in bytes */
 	ulint		buf_read;	/*!< number of read bytes in buffer
 					after the last cursor read */
@@ -63,6 +65,13 @@ struct xb_fil_cur_t {
 	uint		thread_n;	/*!< thread number for diagnostics */
 	ulint		space_id;	/*!< ID of tablespace */
 	ulint		space_size;	/*!< space size in pages */
+
+	unsigned char	encryption_key[32];
+					/*!< encryption key */
+	ulint		encryption_klen;
+					/*!< encryption key length */
+	unsigned char	encryption_iv[32];
+					/*!< encryption iv */
 };
 
 typedef enum {

--- a/storage/innobase/xtrabackup/src/keyring.cc
+++ b/storage/innobase/xtrabackup/src/keyring.cc
@@ -1,0 +1,84 @@
+/******************************************************
+Copyright (c) 2016 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#include <my_base.h>
+#include <my_aes.h>
+#include <../plugin/keyring/keyring.h>
+#include "common.h"
+
+class XtraKLogger : public ILogger
+{
+public:
+	XtraKLogger()
+	{}
+	~XtraKLogger() {}
+	void log(plugin_log_level level, const char *message)
+	{
+		msg("%s\n", message);
+	}
+};
+
+
+bool
+xb_keyring_init(const char *file_path)
+{
+	const char *keyring_file_data_value = file_path;
+
+	if (file_path == NULL) {
+		return(false);
+	}
+
+	try {
+
+		if (init_keyring_locks())
+			return(false);
+
+		logger.reset(new XtraKLogger());
+		if (create_keyring_dir_if_does_not_exist(
+			keyring_file_data_value))
+		{
+			logger->log(MY_ERROR_LEVEL, "Could not create keyring "
+				"directory. The keyring_file will stay "
+				"unusable until correct path to the keyring "
+				"directory gets provided");
+			return(false);
+		}
+		Buffered_file_io keyring_io(logger.get());
+		keys.reset(new Keys_container(logger.get()));
+		if (keys->init(&keyring_io, keyring_file_data_value))
+		{
+			is_keys_container_initialized = FALSE;
+			logger->log(MY_ERROR_LEVEL, "keyring_file "
+				"initialization failure. Please check "
+				"if the keyring_file_data points to readable "
+				"keyring file or keyring file "
+				"can be created in the specified location. "
+				"The keyring_file will stay unusable until "
+				"correct path to the keyring file "
+				"gets provided");
+			return(false);
+		}
+		is_keys_container_initialized = TRUE;
+		return(true);
+	}
+	catch (...)
+	{
+		return(false);
+	}
+}
+

--- a/storage/innobase/xtrabackup/src/keyring.h
+++ b/storage/innobase/xtrabackup/src/keyring.h
@@ -1,0 +1,25 @@
+/******************************************************
+Copyright (c) 2016 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#ifndef XB_KEYRING_H
+#define XB_KEYRING_H
+
+bool
+xb_keyring_init(const char *file_path);
+
+#endif // XB_KEYRING_H

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1,6 +1,6 @@
 /******************************************************
 XtraBackup: hot backup tool for InnoDB
-(c) 2009-2015 Percona LLC and/or its affiliates
+(c) 2009-2016 Percona LLC and/or its affiliates
 Originally Created 3/3/2009 Yasufumi Kinoshita
 Written by Alexey Kopytov, Aleksandr Kuzminsky, Stewart Smith, Vadim Tkachenko,
 Yasufumi Kinoshita, Ignacio Nin and Baron Schwartz.
@@ -68,6 +68,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <row0quiesce.h>
 #include <srv0start.h>
 #include <buf0dblwr.h>
+#include <my_aes.h>
 
 #include <sstream>
 #include <mysql.h>
@@ -92,6 +93,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "backup_mysql.h"
 #include "backup_copy.h"
 #include "backup_mysql.h"
+#include "keyring.h"
 #include "xb0xb.h"
 
 /* TODO: replace with appropriate macros used in InnoDB 5.6 */
@@ -296,6 +298,8 @@ my_bool innobase_create_status_file		= FALSE;
 my_bool innobase_adaptive_hash_index		= TRUE;
 
 static char *internal_innobase_data_file_path	= NULL;
+
+char*	xb_keyring_file_data			= NULL;
 
 /* The following counter is used to convey information to InnoDB
 about server activity: in selects it is not sensible to call
@@ -526,6 +530,7 @@ enum options_xtrabackup
   OPT_XTRA_ENCRYPT_KEY_FILE,
   OPT_XTRA_ENCRYPT_THREADS,
   OPT_XTRA_ENCRYPT_CHUNK_SIZE,
+  OPT_XTRA_SERVER_ID,
   OPT_LOG,
   OPT_INNODB,
   OPT_INNODB_CHECKSUMS,
@@ -613,7 +618,8 @@ enum options_xtrabackup
   OPT_DEBUG_SLEEP_BEFORE_UNLOCK,
   OPT_SAFE_SLAVE_BACKUP_TIMEOUT,
   OPT_BINLOG_INFO,
-  OPT_REDO_LOG_VERSION
+  OPT_REDO_LOG_VERSION,
+  OPT_KEYRING_FILE_DATA
 };
 
 struct my_option xb_long_options[] =
@@ -1206,6 +1212,15 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    "Redo log version of the backup. For --prepare only.",
    &redo_log_version, &redo_log_version, 0, GET_UINT,
    REQUIRED_ARG, 1, 0, 0, 0, 0, 0},
+
+  {"keyring-file-data", OPT_KEYRING_FILE_DATA,
+   "The path to the keyring file.", &xb_keyring_file_data,
+   &xb_keyring_file_data, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0,
+   0},
+
+  {"server-id", OPT_XTRA_SERVER_ID, "The server instance being backed up",
+   &server_id, &server_id, 0, GET_UINT, REQUIRED_ARG, 0, 0, UINT_MAX32,
+   0, 0, 0},
 
   { 0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
@@ -3174,6 +3189,19 @@ xb_load_single_table_tablespace(
 
 		ut_a(space != NULL);
 
+		/* For encryption tablespace, initialize encryption
+		information.*/
+		if (FSP_FLAGS_GET_ENCRYPTION(file->flags())) {
+			byte*	key = file->m_encryption_key;
+			byte*	iv = file->m_encryption_iv;
+			ut_ad(key && iv);
+
+			err = fil_set_encryption(space->id, Encryption::AES,
+						 key, iv);
+			ut_ad(err == DB_SUCCESS);
+		}
+
+
 		if (!fil_node_create(file->filepath(), n_pages, space,
 				     false, false)) {
 			ut_error;
@@ -4079,6 +4107,8 @@ xtrabackup_backup_func(void)
 
 	srv_general_init();
 	ut_crc32_init();
+
+	xb_keyring_init(xb_keyring_file_data);
 
 	xb_filters_init();
 
@@ -6520,6 +6550,195 @@ xb_export_cfg_write(
 
 }
 
+/** Write the transfer key to CFP file.
+@param[in]	table		write the data for this table
+@param[in]	file		file to write to
+@return DB_SUCCESS or error code. */
+static	__attribute__((nonnull, warn_unused_result))
+dberr_t
+xb_export_write_transfer_key(
+	const dict_table_t*	table,
+	FILE*			file)
+{
+	byte		key_size[sizeof(ib_uint32_t)];
+	byte		row[ENCRYPTION_KEY_LEN * 3];
+	byte*		ptr = row;
+	byte*		transfer_key = ptr;
+	lint		elen;
+
+	ut_ad(table->encryption_key != NULL
+	      && table->encryption_iv != NULL);
+
+	/* Write the encryption key size. */
+	mach_write_to_4(key_size, ENCRYPTION_KEY_LEN);
+
+	if (fwrite(&key_size, 1,  sizeof(key_size), file)
+		!= sizeof(key_size)) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while writing key size.");
+
+		return(DB_IO_ERROR);
+	}
+
+	/* Generate and write the transfer key. */
+	Encryption::random_value(transfer_key);
+	if (fwrite(transfer_key, 1, ENCRYPTION_KEY_LEN, file)
+		!= ENCRYPTION_KEY_LEN) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while writing transfer key.");
+
+		return(DB_IO_ERROR);
+	}
+
+	ptr += ENCRYPTION_KEY_LEN;
+
+	/* Encrypt tablespace key. */
+	elen = my_aes_encrypt(
+		reinterpret_cast<unsigned char*>(table->encryption_key),
+		ENCRYPTION_KEY_LEN,
+		ptr,
+		reinterpret_cast<unsigned char*>(transfer_key),
+		ENCRYPTION_KEY_LEN,
+		my_aes_256_ecb,
+		NULL, false);
+
+	if (elen == MY_AES_BAD_DATA) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while encrypt tablespace key.");
+		return(DB_ERROR);
+	}
+
+	/* Write encrypted tablespace key */
+	if (fwrite(ptr, 1, ENCRYPTION_KEY_LEN, file)
+		!= ENCRYPTION_KEY_LEN) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while writing encrypted tablespace key.");
+
+		return(DB_IO_ERROR);
+	}
+	ptr += ENCRYPTION_KEY_LEN;
+
+	/* Encrypt tablespace iv. */
+	elen = my_aes_encrypt(
+		reinterpret_cast<unsigned char*>(table->encryption_iv),
+		ENCRYPTION_KEY_LEN,
+		ptr,
+		reinterpret_cast<unsigned char*>(transfer_key),
+		ENCRYPTION_KEY_LEN,
+		my_aes_256_ecb,
+		NULL, false);
+
+	if (elen == MY_AES_BAD_DATA) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while encrypt tablespace iv.");
+		return(DB_ERROR);
+	}
+
+	/* Write encrypted tablespace iv */
+	if (fwrite(ptr, 1, ENCRYPTION_KEY_LEN, file)
+		!= ENCRYPTION_KEY_LEN) {
+		msg("IO Write error: (%d, %s) %s",
+			errno, strerror(errno),
+			"while writing encrypted tablespace iv.");
+
+		return(DB_IO_ERROR);
+	}
+
+	return(DB_SUCCESS);
+}
+
+/** Write the encryption data after quiesce.
+@param[in]	table		write the data for this table
+@return DB_SUCCESS or error code */
+static	__attribute__((nonnull, warn_unused_result))
+dberr_t
+xb_export_cfp_write(
+	dict_table_t*	table)
+{
+	dberr_t			err;
+	char			name[OS_FILE_MAX_PATH];
+
+	/* If table is not encrypted, return. */
+	if (!dict_table_is_encrypted(table)) {
+		return(DB_SUCCESS);
+	}
+
+	/* Get the encryption key and iv from space */
+	/* For encrypted table, before we discard the tablespace,
+	we need save the encryption information into table, otherwise,
+	this information will be lost in fil_discard_tablespace along
+	with fil_space_free(). */
+	if (table->encryption_key == NULL) {
+		table->encryption_key =
+			static_cast<byte*>(mem_heap_alloc(table->heap,
+							  ENCRYPTION_KEY_LEN));
+
+		table->encryption_iv =
+			static_cast<byte*>(mem_heap_alloc(table->heap,
+							  ENCRYPTION_KEY_LEN));
+
+		fil_space_t*	space = fil_space_get(table->space);
+		ut_ad(space != NULL && FSP_FLAGS_GET_ENCRYPTION(space->flags));
+
+		memcpy(table->encryption_key,
+		       space->encryption_key,
+		       ENCRYPTION_KEY_LEN);
+		memcpy(table->encryption_iv,
+		       space->encryption_iv,
+		       ENCRYPTION_KEY_LEN);
+	}
+
+	srv_get_encryption_data_filename(table, name, sizeof(name));
+
+	ib::info() << "Writing table encryption data to '" << name << "'";
+
+	FILE*	file = fopen(name, "w+b");
+
+	if (file == NULL) {
+		msg("Can't create file '%-.200s' (errno: %d - %s)",
+			 name, errno, strerror(errno));
+
+		err = DB_IO_ERROR;
+	} else {
+		err = xb_export_write_transfer_key(table, file);
+
+		if (fflush(file) != 0) {
+
+			char	buf[BUFSIZ];
+
+			ut_snprintf(buf, sizeof(buf), "%s flush() failed",
+				    name);
+
+			msg("IO Write error: (%d, %s) %s",
+				errno, strerror(errno), buf);
+
+			err = DB_IO_ERROR;
+		}
+
+		if (fclose(file) != 0) {
+			char	buf[BUFSIZ];
+
+			ut_snprintf(buf, sizeof(buf), "%s flose() failed",
+				    name);
+
+			msg("IO Write error: (%d, %s) %s",
+				errno, strerror(errno), buf);
+			err = DB_IO_ERROR;
+		}
+	}
+
+	/* Clean the encryption information */
+	table->encryption_key = NULL;
+	table->encryption_iv = NULL;
+
+	return(err);
+}
+
 #if 0
 /********************************************************************//**
 Searches archived log files in archived log directory. The min and max
@@ -6722,6 +6941,8 @@ skip_check:
 		goto error_cleanup;
 	}
 
+	xb_keyring_init(xb_keyring_file_data);
+
 	/* Expand compacted datafiles */
 
 	if (xtrabackup_compact) {
@@ -6923,6 +7144,11 @@ skip_check:
 
 			/* Write MySQL 5.6 .cfg file */
 			if (!xb_export_cfg_write(node, table)) {
+				goto next_node;
+			}
+
+			/* Write transfer key for tablespace file */
+			if (!xb_export_cfp_write(table)) {
 				goto next_node;
 			}
 

--- a/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
@@ -1,0 +1,82 @@
+#
+# Basic test of InnoDB encryption support
+#
+
+require_server_version_higher_than 5.7.10
+
+keyring_file=$topdir/keyring_file
+
+start_server --keyring-file-data=$keyring_file --server_id=10
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+SELECT @@server_id;
+
+CREATE TABLE t1 (c1 VARCHAR(100)) ENCRYPTION='Y';
+
+INSERT INTO t1 (c1) VALUES ('ONE'), ('TWO'), ('THREE');
+INSERT INTO t1 (c1) VALUES ('10'), ('20'), ('30');
+
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup \
+	   --keyring-file-data=$keyring_file --server_id=10
+
+cat $topdir/backup/backup-my.cnf
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --incremental-basedir=$topdir/backup \
+           --target-dir=$topdir/inc1 \
+           --keyring-file-data=$keyring_file --server_id=10
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+	   --target-dir=$topdir/inc2 \
+	   --keyring-file-data=$keyring_file --server_id=10
+
+${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+	  --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+	  --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server --keyring_file_data=$keyring_file --server_id=10
+
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT @@server_id" test
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT @@keyring_file_data" test
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT SUM(c1) FROM t1" test
+

--- a/storage/innobase/xtrabackup/test/t/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption_export.sh
@@ -1,0 +1,113 @@
+#
+# Basic test of InnoDB encryption support
+# Exporting and importing encrypted tables
+#
+
+require_server_version_higher_than 5.7.10
+
+keyring_file=$topdir/keyring_file
+
+start_server --keyring-file-data=$keyring_file --server-id=10
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+CREATE TABLE t1 (c1 INT) ENCRYPTION='Y';
+
+INSERT INTO t1 (c1) VALUES (1), (2), (3);
+INSERT INTO t1 (c1) VALUES (10), (20), (30);
+
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup \
+	   --keyring-file-data=$keyring_file --server-id=10
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --incremental-basedir=$topdir/backup \
+	   --target-dir=$topdir/inc1 \
+	   --keyring-file-data=$keyring_file --server-id=10
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+INSERT INTO t1 SELECT * FROM t1;
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+EOF
+
+xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+	   --target-dir=$topdir/inc2 \
+	   --keyring-file-data=$keyring_file --server-id=10
+
+${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+	  --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+	  --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+${XB_BIN} --prepare --export --target-dir=$topdir/backup \
+	  --keyring-file-data=$keyring_file
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+DROP TABLE t1;
+
+EOF
+
+stop_server
+
+start_server --keyring-file-data=$keyring_file --server-id=20
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+CREATE TABLE t1 (c1 INT) ENCRYPTION='Y';
+
+EOF
+
+function discard_import() {
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+SELECT SLEEP(5);
+
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+EOF
+
+}
+
+discard_import &
+mysql_pid=$!
+
+while [ -f $mysql_datadir/test/t1.ibd ]
+do
+	sleep 1
+done
+
+cp -av $topdir/backup/test/t1.{cfg,cfp,ibd} $mysql_datadir/test
+
+wait $mysql_pid
+
+run_cmd $MYSQL $MYSQL_ARGS -e "SELECT SUM(c1) FROM t1" test
+


### PR DESCRIPTION
Implementation of https://blueprints.launchpad.net/percona-xtrabackup/+spec/innodb-tablespace-encryption
- Made few changes to MySQL keyring implementation to allow it to
  compile without PSI_INTERFACE.
- Linked xtrabackup with MySQL keyring implementation (but without
  using plugin interface).
- Added keyring initialization code.
- Changed os0file.cc to use keyring implementation directly instead
  of plugin interface.
- Changed copy-back to use my_read instead of os_file_read in order
  to prevent it from attempting to decrypt datafiles when they are
  copied back.
- Added code to generate .cfp files for --export (mostly copy-paste
  of corresponding server code).
- Added options --keyring-data-file, pointing to the keyring file and
  --sevrer-id specifying the server id (used as part of master key
  ID). Option --server-id is also stored in backup-my.cnf.
