### PR TITLE
Bug 1554235: Innobackupex fails when using --throttle

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -172,6 +172,7 @@ lsn_t checkpoint_no_start;
 lsn_t log_copy_scanned_lsn;
 ibool log_copying = TRUE;
 ibool log_copying_running = FALSE;
+ibool io_watching_thread_running = FALSE;
 
 ibool xtrabackup_logfile_is_renamed = FALSE;
 
@@ -2792,14 +2793,10 @@ io_watching_thread(
 	/* currently, for --backup only */
 	ut_a(xtrabackup_backup);
 
+	io_watching_thread_running = TRUE;
+
 	while (log_copying) {
 		os_thread_sleep(1000000); /*1 sec*/
-
-		//for DEBUG
-		//if (io_ticket == xtrabackup_throttle) {
-		//	msg("There seem to be no IO...?\n");
-		//}
-
 		io_ticket = xtrabackup_throttle;
 		os_event_set(wait_throttle);
 	}
@@ -2807,6 +2804,8 @@ io_watching_thread(
 	/* stop io throttle */
 	xtrabackup_throttle = 0;
 	os_event_set(wait_throttle);
+
+	io_watching_thread_running = FALSE;
 
 	os_thread_exit(NULL);
 
@@ -3957,7 +3956,8 @@ reread_log_header:
 		io_ticket = xtrabackup_throttle;
 		wait_throttle = os_event_create();
 
-		os_thread_create(io_watching_thread, NULL, &io_watching_thread_id);
+		os_thread_create(io_watching_thread, NULL,
+				 &io_watching_thread_id);
 	}
 
 	mutex_enter(&log_sys->mutex);
@@ -4128,8 +4128,14 @@ skip_last_cp:
 
 	xtrabackup_destroy_datasinks();
 
-	if (wait_throttle)
+	if (wait_throttle) {
+		/* wait for io_watching_thread completion */
+		while (io_watching_thread_running) {
+			os_thread_sleep(1000000);
+		}
 		os_event_free(wait_throttle);
+		wait_throttle = NULL;
+	}
 
 	msg("xtrabackup: Transaction log of lsn (" LSN_PF ") to (" LSN_PF
 	    ") was copied.\n", checkpoint_lsn_start, log_copy_scanned_lsn);

--- a/storage/innobase/xtrabackup/test/t/throttle.sh
+++ b/storage/innobase/xtrabackup/test/t/throttle.sh
@@ -1,0 +1,8 @@
+#
+# Simple test case for throttle
+#
+
+start_server
+
+xtrabackup --backup --throttle=20 --target-dir=$topdir/backup
+


### PR DESCRIPTION
Race condition between main thread and io_watching_thread could cause
accessing memory used by wait_throttle after it was already freed up.

Bug analysis by Sunguck Lee.
