### PR TITLE
Bug #1566228: XB crashes with insufficient param.

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1494,6 +1494,8 @@ copy_back()
 	datadir_node_t node;
 	char *dst_dir;
 
+	memset(&node, 0, sizeof(node));
+
 	if (!opt_force_non_empty_dirs) {
 		if (!directory_exists_and_empty(mysql_data_home,
 							"Original data")) {

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -409,6 +409,11 @@ get_mysql_vars(MYSQL *connection)
 			    "nonexistent directory '%s'\n", mysql_data_home);
 			goto out;
 		}
+		if (!directory_exists(datadir_var, false)) {
+			msg("Error: MySQL variable 'datadir' points to "
+			    "nonexistent directory '%s'\n", datadir_var);
+			goto out;
+		}
 		if (!(ret = equal_paths(mysql_data_home, datadir_var))) {
 			msg("Error: option 'datadir' has different "
 				"values:\n"

--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -449,7 +449,7 @@ static struct my_option ibx_long_options[] =
 	 "before innobackupex will issue the global lock. Default is all.",
 	 (uchar*) &opt_ibx_lock_wait_query_type,
 	 (uchar*) &opt_ibx_lock_wait_query_type, &query_type_typelib,
-	 GET_ENUM, REQUIRED_ARG, QUERY_TYPE_UPDATE, 0, 0, 0, 0, 0},
+	 GET_ENUM, REQUIRED_ARG, QUERY_TYPE_ALL, 0, 0, 0, 0, 0},
 
 	{"kill-long-query-type", OPT_KILL_LONG_QUERY_TYPE,
 	 "This option specifies which types of queries should be killed to "

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7049,9 +7049,13 @@ int main(int argc, char **argv)
 	if (xtrabackup_prepare)
 		xtrabackup_prepare_func();
 
-	if ((xtrabackup_copy_back || xtrabackup_move_back)
-	    && !copy_back()) {
-		exit(EXIT_FAILURE);
+	if (xtrabackup_copy_back || xtrabackup_move_back) {
+		if (!datadir_specified) {
+			msg("Error: datadir must be specified.\n");
+			exit(EXIT_FAILURE);
+		}
+		if (!copy_back())
+			exit(EXIT_FAILURE);
 	}
 
 	if (xtrabackup_decrypt_decompress && !decrypt_decompress()) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1122,7 +1122,7 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    "before innobackupex will issue the global lock. Default is all.",
    (uchar*) &opt_lock_wait_query_type,
    (uchar*) &opt_lock_wait_query_type, &query_type_typelib,
-   GET_ENUM, REQUIRED_ARG, QUERY_TYPE_UPDATE, 0, 0, 0, 0, 0},
+   GET_ENUM, REQUIRED_ARG, QUERY_TYPE_ALL, 0, 0, 0, 0, 0},
 
   {"kill-long-query-type", OPT_KILL_LONG_QUERY_TYPE,
    "This option specifies which types of queries should be killed to "

--- a/storage/innobase/xtrabackup/test/t/bug1566228.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1566228.sh
@@ -1,0 +1,19 @@
+#
+# Bug 1566228: XB crashes with insufficient param
+# 
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+run_cmd_expect_failure ${XB_BIN} --defaults-file= --defaults-group=mysqld.2 \
+	  --no-version-check --move-back --force-non-empty-directories \
+	  --target-dir=$topdir/backup 2>&1 | \
+	  grep "Error: datadir must be specified"
+
+run_cmd_expect_failure ${IB_BIN} --defaults-file= --defaults-group=mysqld.2 \
+	  --no-version-check --move-back --force-non-empty-directories \
+	  $topdir/backup 2>&1 | \
+	  grep "Error: datadir must be specified"


### PR DESCRIPTION
Fix includes:
- fixed memory error when no files were copied on copy-back/move-back
- error is printed when 'datadir' from SHOW VARIABLES doesn't exist
  (aborts backup when remote host is specified)
- error is printed when no 'datadir' is specified for
  copy-back/move-back
