### PR TITLE
Bug 1570560: xtrabackup-v2 SST is broken on MariaDB 10.1/Galera  w/ b…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -374,7 +374,7 @@ get_mysql_vars(MYSQL *connection)
 		have_galera_enabled = true;
 	}
 
-	if (strcmp(version_var, "5.5") >= 0) {
+	if (fnmatch("5.[123].*", version_var, FNM_PATHNAME) != 0) {
 		have_flush_engine_logs = true;
 	}
 


### PR DESCRIPTION
…inary logs enabled

Condition for have_flush_engine_logs was wrong.
