### PR TITLE
Bug 1555423: Fix for 1322658 not ported to 2.3 and 2.4 of Xtrabackup

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -3,6 +3,7 @@
 #define XTRABACKUP_BACKUP_COPY_H
 
 #include <my_global.h>
+#include "datasink.h"
 
 /* special files */
 #define XTRABACKUP_SLAVE_INFO "xtrabackup_slave_info"
@@ -25,7 +26,10 @@ equal_paths(const char *first, const char *second);
 Copy file for backup/restore.
 @return true in case of success. */
 bool
-copy_file(const char *src_file_path, const char *dst_file_path, uint thread_n);
+copy_file(ds_ctxt_t *datasink,
+	  const char *src_file_path,
+	  const char *dst_file_path,
+	  uint thread_n);
 
 bool
 backup_start();

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1207,7 +1207,7 @@ write_current_binlog_file(MYSQL *connection)
 
 		ut_snprintf(filepath, sizeof(filepath), "%s/%s",
 				log_bin_dir, log_bin_file);
-		result = copy_file(filepath, log_bin_file, 0);
+		result = copy_file(ds_data, filepath, log_bin_file, 0);
 	}
 
 cleanup:

--- a/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
@@ -36,6 +36,11 @@ rm -rf $remote_dir
 innobackupex --apply-log $topdir/backup
 innobackupex --copy-back $topdir/backup
 
+if [ ! -f $remote_dir/test/t.ibd ] ; then
+	vlog "Tablepace $remote_dir/t.ibd is missing!"
+	exit -1
+fi
+
 start_server
 
 checksum_b=`checksum_table test t`


### PR DESCRIPTION
The piece of --copy-back logic copying remote tablespaces back to the
place specified in .isl files was missing, but remote_tablespaces.sh
did not fail because InnoDB was still able to find such tablespaces
inside datadir.

The fix includes:
- attempt to find .isl file and copy .ibd into correct destination
  directory
- check presence of t.ibd inside of remote directory in
  remote_tablespaces.sh
