### PR TITLE
Bug 1570560: Fix ordering of FLUSH ENGINE LOGS for MariaDB 10.x

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1277,11 +1277,7 @@ backup_start()
 		write_binlog_info(mysql_connection);
 	}
 
-	if (have_flush_engine_logs) {
-		msg_ts("Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n");
-		xb_mysql_query(mysql_connection,
-			"FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS", false);
-	}
+	flush_engine_logs_maybe(mysql_connection);
 
 	return(true);
 }

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -82,6 +82,9 @@ time_t history_start_time;
 time_t history_end_time;
 time_t history_lock_time;
 
+/* Whether FLUSH ENGINE LOGS has been issued during backup */
+bool engine_logs_flushed = false;
+
 char *innobase_data_file_path_alloc = NULL;
 
 MYSQL *mysql_connection;
@@ -859,6 +862,21 @@ lock_tables(MYSQL *connection)
 }
 
 
+bool
+flush_engine_logs_maybe(MYSQL *connection) {
+	if (have_flush_engine_logs) {
+		if (!engine_logs_flushed) {
+			msg_ts("Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n");
+			xb_mysql_query(connection,
+				"FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS", false);
+			engine_logs_flushed = true;
+			return true;
+		}
+	}
+	return false;
+}
+
+
 /*********************************************************************//**
 If backup locks are used, execute LOCK BINLOG FOR BACKUP provided that we are
 not in the --no-lock mode and the lock has not been acquired already.
@@ -1180,7 +1198,9 @@ write_current_binlog_file(MYSQL *connection)
 
 		lock_binlog_maybe(connection);
 
+		msg_ts("Executing FLUSH BINARY LOGS\n");
 		xb_mysql_query(connection, "FLUSH BINARY LOGS", false);
+		flush_engine_logs_maybe(connection);
 
 		read_mysql_variables(connection, "SHOW MASTER STATUS",
 			status_after_flush, false);

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -374,7 +374,7 @@ get_mysql_vars(MYSQL *connection)
 		have_galera_enabled = true;
 	}
 
-	if (strcmp(version_var, "5.5") >= 0) {
+	if (fnmatch("5.[123].*", version_var, FNM_PATHNAME) != 0) {
 		have_flush_engine_logs = true;
 	}
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -68,6 +68,9 @@ bool
 write_backup_config_file();
 
 bool
+flush_engine_logs_maybe(MYSQL *connection);
+
+bool
 lock_binlog_maybe(MYSQL *connection);
 
 bool


### PR DESCRIPTION
This extends PR https://github.com/percona/percona-xtrabackup/pull/196 to ensure that FLUSH NO_WRITE_BINLOG ENGINE LOGS is run before copying the last binlog for GTID state during the handling of --galera-info bits in order to fix a problem with MariaDB/GTID.

Presently, FLUSH ENGINE LOGS is not run at all for MariaDB and even with PR https://github.com/percona/percona-xtrabackup/pull/196,  FLUSH ENGINE LOGS is only run after the binlog is copied.   Under load, this can result in MariaDB failing binlog recovery since the copied binlog may have only a single Binlog_checkpoint event referencing a previous (missing) binlog file.  Executing FLUSH ENGINE LOGS prior to this copy ensures a Binlog_checkpoint event is present for the current binlog under consideration.

This avoids a serious headaches when using MariaDB/Galera + xtrabackup-v2 for SST.

See https://jira.mariadb.org/browse/MDEV-9423 for more details on the MariaDB problem.
