### PR TITLE
Bug 1555626: Backup corrupted for PS 5.7 when DDL statements running

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -4348,7 +4348,7 @@ skip_validate:
 }
 #endif /* !UNIV_HOTBACKUP */
 
-#ifdef UNIV_HOTBACKUP
+#if 1
 /*******************************************************************//**
 Allocates a file name for an old version of a single-table tablespace.
 The string must be freed by caller with ut_free()!
@@ -4723,7 +4723,7 @@ fil_ibd_load(
 		/* Fall through to error handling */
 
 	case DB_TABLESPACE_EXISTS:
-#ifdef UNIV_HOTBACKUP
+#if 1
 		if (file.flags() == ~(ulint)0) {
 			return FIL_LOAD_OK;
 		}
@@ -4737,14 +4737,14 @@ fil_ibd_load(
 
 	ut_ad(space == NULL);
 
-#ifdef UNIV_HOTBACKUP
+#if 1
 	if (file.space_id() == ULINT_UNDEFINED || file.space_id() == 0) {
 		char*	new_path;
 
 		ib::info() << "Renaming tablespace file '" << file.filepath()
 			<< "' with space ID " << file.space_id() << " to "
 			<< file.name() << "_ibbackup_old_vers_<timestamp>"
-			" because its size " << size() << " is too small"
+			" because its size " << 0 << " is too small"
 			" (< 4 pages 16 kB each), or the space id in the"
 			" file header is not sensible. This can happen in"
 			" an mysqlbackup run, and is not dangerous.";

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -296,7 +296,6 @@ void
 ut_sprintf_timestamp(
 /*=================*/
 	char*	buf); /*!< in: buffer where to sprintf */
-#ifdef UNIV_HOTBACKUP
 /**********************************************************//**
 Sprintfs a timestamp to a buffer with no spaces and with ':' characters
 replaced by '_'. */
@@ -312,7 +311,6 @@ ut_get_year_month_day(
 	ulint*	year,	/*!< out: current year */
 	ulint*	month,	/*!< out: month */
 	ulint*	day);	/*!< out: day */
-#else /* UNIV_HOTBACKUP */
 /*************************************************************//**
 Runs an idle loop on CPU. The argument gives the desired delay
 in microseconds on 100 MHz Pentium + Visual C++.
@@ -321,7 +319,6 @@ ulint
 ut_delay(
 /*=====*/
 	ulint	delay);	/*!< in: delay in microseconds on 100 MHz Pentium */
-#endif /* UNIV_HOTBACKUP */
 /*************************************************************//**
 Prints the contents of a memory buffer in hex and ascii. */
 void

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -265,7 +265,8 @@ fil_name_process(
 		if (!p.second && !f.deleted) {
 			f.deleted = true;
 			if (f.space != NULL) {
-				fil_space_free(space_id, false);
+				fil_delete_tablespace(space_id,
+					BUF_REMOVE_FLUSH_NO_WRITE);
 				f.space = NULL;
 			}
 		}
@@ -808,7 +809,9 @@ fil_name_parse(
 			space_id, first_page_no,
 			name,
 			new_name)) {
+#if 0
 			recv_sys->found_corrupt_fs = true;
+#endif
 		}
 	}
 

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -290,7 +290,6 @@ ut_sprintf_timestamp(
 #endif
 }
 
-#ifdef UNIV_HOTBACKUP
 /**********************************************************//**
 Sprintfs a timestamp to a buffer with no spaces and with ':' characters
 replaced by '_'. */
@@ -360,8 +359,6 @@ ut_get_year_month_day(
 #endif
 }
 
-#else /* UNIV_HOTBACKUP */
-
 /*************************************************************//**
 Runs an idle loop on CPU. The argument gives the desired delay
 in microseconds on 100 MHz Pentium + Visual C++.
@@ -386,7 +383,6 @@ ut_delay(
 
 	return(j);
 }
-#endif /* UNIV_HOTBACKUP */
 
 /*************************************************************//**
 Prints the contents of a memory buffer in hex and ascii. */


### PR DESCRIPTION
1. Delete tablespace file when replaying MLOG_FILE_DELETE.
2. Handle few corner cases when opening tablespace file by enabling
   UNIV_HOTBACKUP pieces.

This fix is partial. It only allows prepare to successfully
replay all file creations, deletions and renames. Full fix is to
parse redo logs when doing the backup and abort the backup when
MLOG_INDEX_LOAD record has been met.
