### PR TITLE
Bug 1582345: Handle MLOG_INDEX_LOAD during the backup

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2502,7 +2502,7 @@ fil_op_log_parse_or_replay(
 	printf("new name %s\n", new_name);
 	}
 	*/
-	if (!space_id) {
+	if (!space_id || recv_is_making_a_backup) {
 		return(ptr);
 	}
 


### PR DESCRIPTION
xtrabackup now parse log files while copying. When MLOG_INDEX_LOAD
has been met and latest flushed LSN taken at the backup start is
less than LSN of this record, then backup is aborted because it is
almost zero chance that correct data file made it to backup.

Later we might want to add possibility to retry copying of affected
tablespace, but we will need to find out how not to break streaming
in this case.
