### PR TITLE
Re-encrypt feature

### DIFF
--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -72,7 +72,6 @@ SET(SQL_SHARED_SOURCES
   auth/password_policy_service.cc
   auth/sql_security_ctx.cc
   auth/service_security_context.cc
-  keyring_service.cc
   bootstrap.cc
   conn_handler/connection_handler_manager.cc 
   datadict.cc

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -82,11 +82,6 @@ bool	innodb_calling_exit;
 #include <mysqld.h>
 #include <mysql/service_mysql_keyring.h>
 
-#define my_key_fetch mysql_key_fetch
-
-my_bool mysql_key_fetch(const char *key_id, char **key_type, const char *user_id,
-                        void **key, size_t *key_len);
-
 /** Insert buffer segment id */
 static const ulint IO_IBUF_SEGMENT = 0;
 

--- a/storage/innobase/xtrabackup/src/keyring.cc
+++ b/storage/innobase/xtrabackup/src/keyring.cc
@@ -38,8 +38,19 @@ bool
 xb_keyring_init(const char *file_path)
 {
 	const char *keyring_file_data_value = file_path;
+	MY_STAT stat_arg;
 
 	if (file_path == NULL) {
+		return(false);
+	}
+
+	if (!my_stat(file_path, &stat_arg, MYF(0))) {
+		logger->log(MY_ERROR_LEVEL, "Could not find keyring file.");
+		return(false);
+	}
+
+	if (stat_arg.st_size == 0) {
+		logger->log(MY_ERROR_LEVEL, "Keyring file is empty.");
 		return(false);
 	}
 
@@ -82,3 +93,58 @@ xb_keyring_init(const char *file_path)
 	}
 }
 
+int my_key_fetch(const char *key_id, char **key_type, const char *user_id,
+                 void **key, size_t *key_len)
+{
+  try
+  {
+    return mysql_key_fetch(key_id, key_type, user_id, key,
+                           key_len);
+  }
+  catch (...)
+  {
+    return TRUE;
+  }
+}
+
+int my_key_store(const char *key_id, const char *key_type, const char *user_id,
+                 const void *key, size_t key_len)
+{
+  try
+  {
+    Buffered_file_io keyring_io(logger.get());
+    return mysql_key_store(&keyring_io, key_id, key_type, user_id, key,
+                           key_len);
+  }
+  catch (...)
+  {
+    return TRUE;
+  }
+}
+
+int my_key_remove(const char *key_id, const char *user_id)
+{
+  try
+  {
+    Buffered_file_io keyring_io(logger.get());
+    return mysql_key_remove(&keyring_io, key_id, user_id);
+  }
+  catch (...)
+  {
+    return TRUE;
+  }
+}
+
+int my_key_generate(const char *key_id, const char *key_type,
+                    const char *user_id, size_t key_len)
+{
+  try
+  {
+    Buffered_file_io keyring_io(logger.get());
+    return mysql_key_generate(&keyring_io, key_id, key_type, user_id, key_len);
+  }
+  catch (...)
+  {
+    return TRUE;
+  }
+}

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -412,6 +412,10 @@ static bool recover_binlog_info;
 /* Redo log format version */
 ulint redo_log_version = REDO_LOG_V1;
 
+/* New server-id to encrypt tablespace keys for */
+ulint opt_encrypt_server_id = 0;
+bool opt_encrypt_for_server_id_specified = false;
+
 /* Simple datasink creation tracking...add datasinks in the reverse order you
 want them destroyed. */
 #define XTRABACKUP_MAX_DATASINKS	10
@@ -532,6 +536,7 @@ enum options_xtrabackup
   OPT_XTRA_ENCRYPT_THREADS,
   OPT_XTRA_ENCRYPT_CHUNK_SIZE,
   OPT_XTRA_SERVER_ID,
+  OPT_XTRA_ENCRYPT_FOR_SERVER_ID,
   OPT_LOG,
   OPT_INNODB,
   OPT_INNODB_CHECKSUMS,
@@ -1223,6 +1228,12 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    &server_id, &server_id, 0, GET_UINT, REQUIRED_ARG, 0, 0, UINT_MAX32,
    0, 0, 0},
 
+  {"reencrypt-for-server-id", OPT_XTRA_ENCRYPT_FOR_SERVER_ID,
+   "Re-encrypt tablespace keys for given server-id.",
+   &opt_encrypt_server_id, &opt_encrypt_server_id, 0,
+   GET_UINT, REQUIRED_ARG, 0, 0, UINT_MAX32,
+   0, 0, 0},
+
   { 0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
 
@@ -1479,6 +1490,9 @@ xb_get_one_option(int optid,
     } else {
       opt_history = "";
     }
+    break;
+  case OPT_XTRA_ENCRYPT_FOR_SERVER_ID:
+    opt_encrypt_for_server_id_specified = true;
     break;
   case '?':
     usage();
@@ -6745,6 +6759,57 @@ xb_export_cfp_write(
 	return(err);
 }
 
+/*********************************************************************//**
+Re-encrypt tablespace keys with newly generated master key having ID
+based on new server-id.
+@return true in case of success otherwise false. */
+static
+bool
+reencrypt_tablespace_keys(
+	ulint new_server_id)
+{
+	xb_keyring_init(xb_keyring_file_data);
+
+	/* re-encrypt for new server-id */
+	byte*	master_key = NULL;
+
+	/* Check if keyring loaded and the currently master key
+	can be fetched. */
+	if (Encryption::master_key_id != 0) {
+		Encryption::get_master_key(Encryption::master_key_id,
+					   &master_key);
+		if (master_key == NULL) {
+			msg("xtrabackup: error: Can't find master key.\n");
+			goto error;
+		}
+		my_free(master_key);
+	}
+
+	master_key = NULL;
+
+	/* Generate the new master key. */
+	server_id = new_server_id;
+	Encryption::create_master_key(&master_key);
+
+        if (master_key == NULL) {
+		msg("xtrabackup: error: Can't create master key.\n");
+		goto error;
+        }
+
+	/* If rotation failure, return error */
+	if (!fil_encryption_rotate()) {
+		msg("xtrabackup: error: Can't rotate master key.\n");
+		goto error;
+	}
+
+	return(true);
+
+error:
+	my_free(master_key);
+
+	return(false);
+}
+
 #if 0
 /********************************************************************//**
 Searches archived log files in archived log directory. The min and max
@@ -7349,6 +7414,12 @@ next_node:
 
 		if(innodb_init())
 			goto error;
+
+		if (opt_encrypt_for_server_id_specified) {
+			reencrypt_tablespace_keys(opt_encrypt_server_id);
+			msg("xtrabackup: error: "
+			    "Tablespace keys are not reencrypted.\n");
+		}
 
 		if(innodb_end())
 			goto error;

--- a/storage/innobase/xtrabackup/test/t/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption_export.sh
@@ -5,7 +5,7 @@
 
 require_server_version_higher_than 5.7.10
 
-keyring_file=$topdir/keyring_file
+keyring_file=${TEST_VAR_ROOT}/keyring_file
 
 start_server --keyring-file-data=$keyring_file --server-id=10
 

--- a/storage/innobase/xtrabackup/test/t/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/reencrypt.sh
@@ -1,5 +1,5 @@
 #
-# Basic test of InnoDB encryption support
+# Test for reencrypt feature
 #
 
 require_server_version_higher_than 5.7.10
@@ -66,7 +66,8 @@ ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --keyring-file-data=$keyring_file
 ${XB_BIN} --prepare --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file
+	  --keyring-file-data=$keyring_file \
+	  --reencrypt-for-server-id=200
 
 stop_server
 
@@ -74,7 +75,7 @@ rm -rf $mysql_datadir
 
 xtrabackup --copy-back --target-dir=$topdir/backup
 
-start_server --keyring_file_data=$keyring_file --server_id=10
+start_server --keyring_file_data=$keyring_file --server_id=200
 
 run_cmd $MYSQL $MYSQL_ARGS -e "SELECT @@server_id" test
 run_cmd $MYSQL $MYSQL_ARGS -e "SELECT @@keyring_file_data" test


### PR DESCRIPTION
https://blueprints.launchpad.net/percona-xtrabackup/+spec/reencrypt-tablespace-keys

Added option --reencrypt-for-server-id = N. When this option
specified for --prepare, then xtrabackup will generate new master key
for given server-id and re-encrypt tablespace keys using newly
generated key. Process is similar to InnoDB master key rotation.

Added test case for this option.

Encryption test cases adjusted to store keyring file inside worker
var directory.

Keyring plugin is used in more graceful way.
