### PR TITLE
Bug 1582601: Getting "Can't find master key from keyring error" after

### DIFF
--- a/plugin/keyring/buffered_file_io.cc
+++ b/plugin/keyring/buffered_file_io.cc
@@ -46,7 +46,7 @@ std::string*Buffered_file_io::get_backup_filename()
   if(backup_filename.empty() == FALSE)
     return &backup_filename;
   backup_filename.append(keyring_filename);
-  backup_filename.append(".backup");
+  backup_filename.append(".xtrabackup");
   return &backup_filename;
 }
 


### PR DESCRIPTION
starting full backup

When MySQL server adds new key into keyring file it does it as
following:
1. Flush current keyring into backup file (adds .backup)
2. Flush modified keyring into keyring file
3. Remove backup file

When trying to open keyring file, keyring plugin checking if there is
a backup first. If backup found, keyring plugin will restore from the
backup.

Xtrabackup does the same because the code is shared with server. In
order to prevent xtrbackup from restoring the old keyring from the
backup, xtrabackup made to add .xtrabackup prefix instead of .backup.
