### PR TITLE
Bug 1583954: Memory leak in fil_write_encryption_parse

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4561,6 +4561,8 @@ skip_last_cp:
 
 	xb_data_files_close();
 
+	recv_sys_debug_free();
+
 	log_shutdown();
 
 	trx_pool_close();


### PR DESCRIPTION
When doing a backup, every tablespace we met being stored in
recv_sys->encryption_list.

Invoke recv_sys_debug_free to free this list.
