### PR TITLE
Bug 1526467: xtrabackup crashes with docker

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -68,6 +68,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <buf0dblwr.h>
 
 #include <sstream>
+#include <set>
 #include <mysql.h>
 
 #define G_PTR uchar*
@@ -324,15 +325,12 @@ static long	innobase_log_files_in_group_save;
 static char	*srv_log_group_home_dir_save;
 static longlong	innobase_log_file_size_save;
 
-/* set true if corresponding variable set as option config file or 
-command argument */
-bool innodb_data_file_path_specified = false;
-bool innodb_log_file_size_specified = false;
-bool datadir_specified = false;
-
 /* String buffer used by --print-param to accumulate server options as they are
 parsed from the defaults file */
 static std::ostringstream print_param_str;
+
+/* Set of specified parameters */
+std::set<std::string> param_set;
 
 static ulonglong global_max_value;
 
@@ -775,12 +773,11 @@ Disable with --skip-innodb-checksums.", (G_PTR*) &innobase_use_checksums,
    0, GET_ULONG, REQUIRED_ARG, 500L, 1L, ULONG_MAX, 0, 1L, 0},
 */
   {"innodb_data_file_path", OPT_INNODB_DATA_FILE_PATH,
-   "Path to individual files and their sizes.", (G_PTR*) &innobase_data_file_path,
-   (G_PTR*) &innobase_data_file_path, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+   "Path to individual files and their sizes.", &innobase_data_file_path,
+   &innobase_data_file_path, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"innodb_data_home_dir", OPT_INNODB_DATA_HOME_DIR,
-   "The common part for InnoDB table spaces.", (G_PTR*) &innobase_data_home_dir,
-   (G_PTR*) &innobase_data_home_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0,
-   0},
+   "The common part for InnoDB table spaces.", &innobase_data_home_dir,
+   &innobase_data_home_dir, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"innodb_doublewrite", OPT_INNODB_DOUBLEWRITE, "Enable InnoDB doublewrite buffer (enabled by default). \
 Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    (G_PTR*) &innobase_use_doublewrite, 0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
@@ -844,13 +841,13 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    GET_LL, REQUIRED_ARG, 48*1024*1024L, 1*1024*1024L, LONGLONG_MAX, 0,
    1024*1024L, 0},
   {"innodb_log_files_in_group", OPT_INNODB_LOG_FILES_IN_GROUP,
-   "Number of log files in the log group. InnoDB writes to the files in a circular fashion. Value 3 is recommended here.",
-   (G_PTR*) &innobase_log_files_in_group, (G_PTR*) &innobase_log_files_in_group,
+   "Number of log files in the log group. InnoDB writes to the files in a "
+   "circular fashion. Value 3 is recommended here.",
+   &innobase_log_files_in_group, &innobase_log_files_in_group,
    0, GET_LONG, REQUIRED_ARG, 2, 2, 100, 0, 1, 0},
   {"innodb_log_group_home_dir", OPT_INNODB_LOG_GROUP_HOME_DIR,
-   "Path to InnoDB log files.", (G_PTR*) &srv_log_group_home_dir,
-   (G_PTR*) &srv_log_group_home_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0,
-   0, 0},
+   "Path to InnoDB log files.", &srv_log_group_home_dir,
+   &srv_log_group_home_dir, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"innodb_max_dirty_pages_pct", OPT_INNODB_MAX_DIRTY_PAGES_PCT,
    "Percentage of dirty pages allowed in bufferpool.", (G_PTR*) &srv_max_buf_pool_modified_pct,
    (G_PTR*) &srv_max_buf_pool_modified_pct, 0, GET_ULONG, REQUIRED_ARG, 90, 0, 100, 0, 0, 0},
@@ -925,8 +922,8 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    REQUIRED_ARG, SRV_CHECKSUM_ALGORITHM_INNODB, 0, 0, 0, 0, 0},
   {"innodb_undo_directory", OPT_INNODB_UNDO_DIRECTORY,
    "Directory where undo tablespace files live, this path can be absolute.",
-   (G_PTR*) &srv_undo_dir, (G_PTR*) &srv_undo_dir,
-   0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+   &srv_undo_dir, &srv_undo_dir, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0,
+   0},
 
   {"innodb_undo_tablespaces", OPT_INNODB_UNDO_TABLESPACES,
    "Number of undo tablespaces to use.",
@@ -1287,7 +1284,19 @@ You can download full text of the license on http://www.gnu.org/licenses/gpl-2.0
 }
 
 #define ADD_PRINT_PARAM_OPT(value)              \
-  print_param_str << opt->name << "=" << value << "\n";
+  { \
+    print_param_str << opt->name << "=" << value << "\n"; \
+    param_set.insert(opt->name); \
+  }
+
+/************************************************************************
+Check if parameter is set in defaults file or via command line argument
+@return true if parameter is set. */
+bool
+check_if_param_set(const char *param)
+{
+	return param_set.find(param) != param_set.end();
+}
 
 my_bool
 xb_get_one_option(int optid,
@@ -1300,7 +1309,6 @@ xb_get_one_option(int optid,
     mysql_data_home= mysql_real_data_home;
 
     ADD_PRINT_PARAM_OPT(mysql_real_data_home);
-    datadir_specified = true;
     break;
 
   case 't':
@@ -1316,7 +1324,6 @@ xb_get_one_option(int optid,
   case OPT_INNODB_DATA_FILE_PATH:
 
     ADD_PRINT_PARAM_OPT(innobase_data_file_path);
-    innodb_data_file_path_specified = true;
     break;
 
   case OPT_INNODB_LOG_GROUP_HOME_DIR:
@@ -1332,7 +1339,6 @@ xb_get_one_option(int optid,
   case OPT_INNODB_LOG_FILE_SIZE:
 
     ADD_PRINT_PARAM_OPT(innobase_log_file_size);
-    innodb_log_file_size_specified = true;
     break;
 
   case OPT_INNODB_FLUSH_METHOD:
@@ -1785,7 +1791,8 @@ mem_free_and_error:
 	directory. */
 
 	if (!srv_undo_dir || !xtrabackup_backup) {
-		srv_undo_dir = (char *) ".";
+		my_free(srv_undo_dir);
+		srv_undo_dir = my_strdup(".", MYF(MY_FAE));
 	}
 
 	innodb_log_checksum_func_update(srv_log_checksum_algorithm);
@@ -7050,7 +7057,7 @@ int main(int argc, char **argv)
 		xtrabackup_prepare_func();
 
 	if (xtrabackup_copy_back || xtrabackup_move_back) {
-		if (!datadir_specified) {
+		if (!check_if_param_set("datadir")) {
 			msg("Error: datadir must be specified.\n");
 			exit(EXIT_FAILURE);
 		}

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -100,13 +100,10 @@ extern char		*xtrabackup_encrypt_key;
 extern char		*xtrabackup_encrypt_key_file;
 extern longlong		innobase_log_file_size;
 extern long		innobase_log_files_in_group;
+extern longlong		innobase_page_size;
 
 extern const char	*xtrabackup_encrypt_algo_names[];
 extern TYPELIB		xtrabackup_encrypt_algo_typelib;
-
-extern bool		innodb_data_file_path_specified;
-extern bool		innodb_log_file_size_specified;
-extern bool		datadir_specified;
 
 extern int		xtrabackup_parallel;
 
@@ -206,6 +203,13 @@ my_bool
 check_if_skip_table(
 /******************/
 	const char*	name);	/*!< in: path to the table */
+
+/************************************************************************
+Check if parameter is set in defaults file or via command line argument
+@return true if parameter is set. */
+bool
+check_if_param_set(const char *param);
+
 
 void
 xtrabackup_backup_func(void);

--- a/storage/innobase/xtrabackup/test/t/bug1343722.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1343722.sh
@@ -12,7 +12,7 @@ start_server_with_id 2
 $IB_BIN $IB_ARGS --socket=$socket --no-timestamp $topdir/backup 2>&1 |
     grep 'has different values'
 
-if [[ ${PIPESTATUS[0]} == 0 ]]
+if [[ ${PIPESTATUS[0]} != 0 ]]
 then
-    die "innobackupex did not fail as expected"
+    die "innobackupex failed"
 fi


### PR DESCRIPTION
Allow datadir specified as command line argument or in defaults file to
override the one obtained from server variables.

Following parameters changed to follow the same pattern:
-   datadir
-   innodb_data_file_path
-   innodb_data_home_dir
-   innodb_log_group_home_dir
-   innodb_undo_directory
-   innodb_log_files_in_group
-   innodb_log_file_size
-   innodb_page_size
