### PR TITLE
Bug 1517629: xtrabackup fails with binlogs in non-standard directory

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1195,7 +1195,6 @@ write_current_binlog_file(MYSQL *connection)
 	char *gtid_binlog_state = NULL;
 	char *log_bin_file = NULL;
 	char *log_bin_dir = NULL;
-	char *datadir = NULL;
 	bool gtid_exists;
 	bool result = true;
 	char filepath[FN_REFLEN];
@@ -1213,7 +1212,6 @@ write_current_binlog_file(MYSQL *connection)
 	mysql_variable vars[] = {
 		{"gtid_binlog_state", &gtid_binlog_state},
 		{"log_bin_basename", &log_bin_dir},
-		{"datadir", &datadir},
 		{NULL, NULL}
 	};
 
@@ -1233,13 +1231,24 @@ write_current_binlog_file(MYSQL *connection)
 		read_mysql_variables(connection, "SHOW MASTER STATUS",
 			status_after_flush, false);
 
-		if (log_bin_dir == NULL) {
-			/* log_bin_basename does not exist in MariaDB,
-			fallback to datadir */
-			log_bin_dir = strdup(datadir);
+		if (opt_log_bin != NULL && strchr(opt_log_bin, FN_LIBCHAR)) {
+			/* If log_bin is set, it has priority */
+			if (log_bin_dir) {
+				free(log_bin_dir);
+			}
+			log_bin_dir = strdup(opt_log_bin);
+		} else if (log_bin_dir == NULL) {
+			/* Default location is MySQL datadir */
+			log_bin_dir = strdup("./");
 		}
 
 		dirname_part(log_bin_dir, log_bin_dir, &log_bin_dir_length);
+
+		/* strip final slash if it is not the only path component */
+		if (log_bin_dir_length > 1 &&
+		    log_bin_dir[log_bin_dir_length - 1] == FN_LIBCHAR) {
+			log_bin_dir[log_bin_dir_length - 1] = 0;
+		}
 
 		if (log_bin_dir == NULL || log_bin_file == NULL) {
 			msg("Failed to get master binlog coordinates from "
@@ -1248,8 +1257,8 @@ write_current_binlog_file(MYSQL *connection)
 			goto cleanup;
 		}
 
-		ut_snprintf(filepath, sizeof(filepath), "%s/%s",
-				log_bin_dir, log_bin_file);
+		ut_snprintf(filepath, sizeof(filepath), "%s%c%s",
+				log_bin_dir, FN_LIBCHAR, log_bin_file);
 		result = copy_file(ds_data, filepath, log_bin_file, 0);
 	}
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -362,6 +362,7 @@ char *opt_defaults_group = NULL;
 char *opt_socket = NULL;
 uint opt_port = 0;
 char *opt_login_path = NULL;
+char *opt_log_bin = NULL;
 
 const char *query_type_names[] = { "ALL", "UPDATE", "SELECT", NullS};
 
@@ -729,6 +730,9 @@ struct my_option xb_long_options[] =
    {"log", OPT_LOG, "Ignored option for MySQL option compatibility",
    (G_PTR*) &log_ignored_opt, (G_PTR*) &log_ignored_opt, 0,
    GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+
+   {"log_bin", OPT_LOG, "Base name for the log sequence",
+   &opt_log_bin, &opt_log_bin, 0, GET_STR_ALLOC, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
    {"innodb", OPT_INNODB, "Ignored option for MySQL option compatibility",
    (G_PTR*) &innobase_ignored_opt, (G_PTR*) &innobase_ignored_opt, 0,

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -144,6 +144,7 @@ extern char		*opt_defaults_group;
 extern char		*opt_socket;
 extern uint		opt_port;
 extern char		*opt_login_path;
+extern char		*opt_log_bin;
 
 extern const char 	*query_type_names[];
 


### PR DESCRIPTION
Bug is specific to `MariaDB' with`Galera' when binary logs are stored
outside of `datadir'.`MariaDB' doesn't expose variable
`log_bin_basename' which is used by`xtrabackup' to determine the
location of binary logs. When this variable isn't available,
`xtrabackup' falls back to`datadir'.

Fix changes behaviour as following:
1. Use `log-bin' if it is set in`my.cnf' or passed as command line
   argument and contains directory part.
2. Use `log_bin_basename' if present.
3. Fallback to `./' which is`datadir'.
