### PR TITLE
Bug 1582456: Incremental restore in XB 2.4 requires 1+GB of RAM

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -5931,13 +5931,12 @@ xtrabackup_apply_delta(
 
 	os_file_set_nocache(dst_file, dst_path, "OPEN");
 
-	/* allocate buffer for incremental backup (4096 pages) */
+	/* allocate buffer for incremental backup */
 	incremental_buffer_base = static_cast<byte *>
-		(ut_malloc_nokey((UNIV_PAGE_SIZE_MAX / 4 + 1) *
-			   UNIV_PAGE_SIZE_MAX));
+		(ut_malloc_nokey((page_size / 4 + 1) * page_size +
+			UNIV_PAGE_SIZE_MAX));
 	incremental_buffer = static_cast<byte *>
-		(ut_align(incremental_buffer_base,
-			  UNIV_PAGE_SIZE_MAX));
+		(ut_align(incremental_buffer_base, UNIV_PAGE_SIZE_MAX));
 
 	msg("Applying %s to %s...\n", src_path, dst_path);
 


### PR DESCRIPTION
With upstream change of `UNIV_PAGE_SIZE_MAX` from 16K to 64K, the size
of `incremental_buffer` in `xtrabackup_apply_delta` becomes 1G. In fact,
we don't need to allocate such a large buffer for smaller pages. What we
really need is `page_size / 4` pages.

The fix doesn't address the issue for tablespaces with 64K page size,
but it works better in default case.
