### PR TITLE
Bug 1604299: InnoDB: Progress in percent: InnoDB: Trying to access pa…

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -5325,7 +5325,7 @@ retry:
 
 		os_has_said_disk_full = !(success = (end == node_start + len));
 
-		pages_added = static_cast<ulint>(end - node_start) / page_size;
+		pages_added = static_cast<ulint>(end - node->size * page_size) / page_size;
 
 	} else {
 		success = true;


### PR DESCRIPTION
…ge number 49664 in space 0, space name innodb_system, which is outside the tablespace bounds
1. The size (stored in cache) of system tablespace is roundeed downward
   to a megabyte in `SysTablespace::check_size`
2. When tablespace extended in `fil_space_extend`, its new size
   calculated as cached size + number of allocated pages, which gives
   wrong number of actual pages.

This patch fixes calculation of the new size in the `fil_space_extend`
for the case when the size in the cache doesn't math the physical file
size.
