### PR TITLE
Bug 1604367: Failed to take full backup -> CORRUPT LOG RECORD FOUND

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1689,7 +1689,8 @@ fil_write_encryption_parse(
 		fprintf(stderr, "Got %lu from redo log:", space->id);
 	}
 #endif
-	if (!fsp_header_decode_encryption_info(key,
+	if (!recv_is_making_a_backup &&
+	    !fsp_header_decode_encryption_info(key,
 					       iv,
 					       ptr)) {
 		recv_sys->found_corrupt_log = TRUE;
@@ -1702,6 +1703,10 @@ fil_write_encryption_parse(
 	      || len == ENCRYPTION_INFO_SIZE_V2);
 
 	ptr += len;
+
+	if (recv_is_making_a_backup) {
+		return(ptr);
+	}
 
 	if (space == NULL) {
 		if (is_new) {


### PR DESCRIPTION
During the backup when master key rotated, one could see the warning:

"############### CORRUPT LOG RECORD FOUND ##################"

It means the MySQL server is trying to store the key into the tablespace
header. This key is encrypted with newly generated master key, which is
not accessible by xtrabackup yet.

The fix is to omit this check. Xtrabackup does quick integrity checks of
the log file when copying which are sufficient.
