### PR TITLE
Bug 1611568: target-dir no longer relative to current directory

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7658,6 +7658,7 @@ int main(int argc, char **argv)
 {
 	int ho_error;
 	char **argv_defaults;
+	char cwd[FN_REFLEN];
 
 	setup_signals();
 
@@ -7820,8 +7821,8 @@ int main(int argc, char **argv)
 	}
 
 	/* Ensure target dir is not relative to datadir */
-	fn_format(xtrabackup_real_target_dir, xtrabackup_target_dir,
-		  "", "", MY_UNPACK_FILENAME | MY_RETURN_REAL_PATH);
+	my_getwd(cwd, sizeof(cwd), MYF(0));
+	my_load_path(xtrabackup_real_target_dir, xtrabackup_target_dir, cwd);
 	xtrabackup_target_dir= xtrabackup_real_target_dir;
 
 	/* get default temporary directory */

--- a/storage/innobase/xtrabackup/test/t/bug489290.sh
+++ b/storage/innobase/xtrabackup/test/t/bug489290.sh
@@ -1,25 +1,36 @@
 ########################################################################
 # Bug #489290: xtrabackup defaults to mysql datadir
+# Bug 1611568: target-dir no longer relative to current directory
 ########################################################################
 
 . inc/common.sh
 
 start_server
 
-backup_dir=$topdir/backup
-mkdir -p $backup_dir
-vlog "Backup created in directory $backup_dir"
-
 cwd=`pwd`
 cd $topdir
 
 # Backup
-xtrabackup --datadir=$mysql_datadir --backup --target-dir=backup
+mkdir $topdir/backup1
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=backup1
 
-# Assure that directory is correct
-if [ ! -f $backup_dir/ibdata1 ] ; then
-	vlog "Backup not found in $backup_dir"
-	exit -1
-fi
+mkdir $topdir/backup2
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=./backup2
+
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=backup3
+
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=./backup4
+
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=$topdir/backup5
+
+cd backup5
+xtrabackup --datadir=$mysql_datadir --backup --target-dir=../backup6
+cd ..
+
+# Test
+for i in {1..6} ; do
+  test -f $topdir/backup$i/ibdata1 || die "Backup not found in $topdir/backup$i"
+  rm -rf $topdir/backup$i
+done
 
 cd $cwd


### PR DESCRIPTION
`my_load_path` changed its behavior in 5.7, when directory name is not
started with "./", it doesn't expand it.

During the merge, `my_load_path` has been replaced with `fn_format`
which doesn't work as expected when directory name isn't started with
"./" and is not exists (`fn_format` expands directory when it is exists,
that is why `bug489290.sh` test passed).

This patch reverts back to `my_realpath`, but now we pass current
working directory as prefix, so it will be prepended to the path when it
isn't started with "./".

Test case `bug489290.sh` expanded to check various combinations of
relative and absolute paths, including directories starting with "./"
and "../", existing and non-existing directories.
