### PR TITLE
Bug 1624473: Issue with --safe-slave-backup option in 2.4.4

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1035,7 +1035,7 @@ wait_for_safe_slave(MYSQL *connection)
 		       "remaining)...\n", sleep_time, n_attempts);
 
 		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
-		os_thread_sleep(sleep_time * 1000);
+		os_thread_sleep(sleep_time * 1000000);
 		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
 
 		open_temp_tables = get_open_temp_tables(connection);


### PR DESCRIPTION
Safe slave backup algorithm performed too short delays between retries.
Original interval was 3 seconds, but 2.3 and 2.4 version performed 3
milliseconds delays.
