### PR TITLE
Bug 1623210: xtrabackup failed to write metadata but the backup still…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3858,7 +3858,7 @@ xtrabackup_backup_func(void)
 	/* create extra LSN dir if it does not exist. */
 	if (xtrabackup_extra_lsndir
 		&&!my_stat(xtrabackup_extra_lsndir,&stat_info,MYF(0))
-		&& (my_mkdir(xtrabackup_extra_lsndir,0777,MYF(0)) < 0)){
+		&& (my_mkdir(xtrabackup_extra_lsndir,0777,MYF(0)) < 0)) {
 		msg("xtrabackup: Error: cannot mkdir %d: %s\n",
 		    my_errno, xtrabackup_extra_lsndir);
 		exit(EXIT_FAILURE);
@@ -4136,17 +4136,19 @@ skip_last_cp:
 	metadata_last_lsn = log_copy_scanned_lsn;
 
 	if (!xtrabackup_stream_metadata(ds_meta)) {
-		msg("xtrabackup: error: "
-		    "xtrabackup_stream_metadata() failed.\n");
+		msg("xtrabackup: Error: failed to stream metadata.\n");
+		exit(EXIT_FAILURE);
 	}
 	if (xtrabackup_extra_lsndir) {
 		char	filename[FN_REFLEN];
 
 		sprintf(filename, "%s/%s", xtrabackup_extra_lsndir,
 			XTRABACKUP_METADATA_FILENAME);
-		if (!xtrabackup_write_metadata(filename))
-			msg("xtrabackup: error: "
-			    "xtrabackup_write_metadata() failed.\n");
+		if (!xtrabackup_write_metadata(filename)) {
+			msg("xtrabackup: Error: failed to write metadata "
+			    "to '%s'.\n", filename);
+			exit(EXIT_FAILURE);
+		}
 
 	}
 
@@ -6113,8 +6115,11 @@ xtrabackup_prepare_func(void)
 	sprintf(metadata_path, "%s/%s", xtrabackup_target_dir,
 		XTRABACKUP_METADATA_FILENAME);
 
-	if (!xtrabackup_read_metadata(metadata_path))
-		msg("xtrabackup: error: xtrabackup_read_metadata()\n");
+	if (!xtrabackup_read_metadata(metadata_path)) {
+		msg("xtrabackup: Error: failed to read metadata from '%s'\n",
+		    metadata_path);
+		exit(EXIT_FAILURE);
+	}
 
 	if (!innobase_log_arch_dir)
 	{
@@ -6131,6 +6136,7 @@ xtrabackup_prepare_func(void)
 		} else {
 			msg("xtrabackup: This target seems not to have correct "
 			    "metadata...\n");
+			exit(EXIT_FAILURE);
 		}
 
 		if (xtrabackup_incremental) {
@@ -6562,16 +6568,20 @@ next_node:
 		}
 
 		sprintf(filename, "%s/%s", xtrabackup_target_dir, XTRABACKUP_METADATA_FILENAME);
-		if (!xtrabackup_write_metadata(filename))
-			msg("xtrabackup: error: xtrabackup_write_metadata"
-			    "(xtrabackup_target_dir)\n");
+		if (!xtrabackup_write_metadata(filename)) {
+
+			msg("xtrabackup: Error: failed to write metadata "
+			    "to '%s'\n", filename);
+			exit(EXIT_FAILURE);
+		}
 
 		if(xtrabackup_extra_lsndir) {
 			sprintf(filename, "%s/%s", xtrabackup_extra_lsndir, XTRABACKUP_METADATA_FILENAME);
-			if (!xtrabackup_write_metadata(filename))
-				msg("xtrabackup: error: "
-				    "xtrabackup_write_metadata"
-				    "(xtrabackup_extra_lsndir)\n");
+			if (!xtrabackup_write_metadata(filename)) {
+				msg("xtrabackup: Error: failed to write "
+				    "metadata to '%s'\n", filename);
+				exit(EXIT_FAILURE);
+			}
 		}
 	}
 

--- a/storage/innobase/xtrabackup/test/t/bug1623210.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1623210.sh
@@ -1,0 +1,24 @@
+#
+# Bug 1623210: xtrabackup failed to write metadata but backup still succeeded
+# Bug 1557027: Error message about missing metadata is misleading
+#
+
+start_server
+
+mkdir $topdir/extra1
+mkdir $topdir/extra2
+chmod ugoa-w $topdir/extra1
+
+run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --backup --target-dir=$topdir/bak1 \
+					    --extra-lsndir=$topdir/extra1
+
+xtrabackup --backup --target-dir=$topdir/bak2 --extra-lsndir=$topdir/extra2
+
+echo -n > $topdir/bak2/xtrabackup_checkpoints
+run_cmd_expect_failure ${XB_BIN} --prepare --target-dir=$topdir/bak2
+
+rm $topdir/bak2/xtrabackup_checkpoints
+run_cmd_expect_failure ${XB_BIN} --prepare --target-dir=$topdir/bak2
+
+cp $topdir/extra2/xtrabackup_checkpoints $topdir/bak2/xtrabackup_checkpoints
+xtrabackup --prepare --target-dir=$topdir/bak2


### PR DESCRIPTION
… succeeded

Bug 1557027: Error message about missing metadata is misleading

Abort xtrabackup when it was unable to write or read metadata file.
