### PR TITLE
Bug 1618555: undo_tablespaces.sh failures

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3365,7 +3365,7 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 	ut_ad(srv_shutdown_state > 0);
 	if (srv_fast_shutdown == 2
-	    || srv_shutdown_state == SRV_SHUTDOWN_EXIT_THREADS) {
+	    || srv_shutdown_state < SRV_SHUTDOWN_FLUSH_PHASE) {
 		/* In very fast shutdown or when innodb failed to start, we
 		simulate a crash of the buffer pool. We are not required to do
 		any flushing. */


### PR DESCRIPTION
Assertion "srv_get_active_thread_type() == SRV_NONE" fails during
shutdown when master thread is performing checkpoint and purge thread
expecting that all other threads completed or are idle.

This fix allows master thread to perform shutdown tasks only until the
flush phase, as described in the comment to the `enum srv_shutdown_t'.
