### PR TITLE
Bug 1633448: xtrabackup 2.4 doesn't check the log block checksums

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2630,8 +2630,7 @@ xtrabackup_scan_log_recs(
 	while (log_block < log_sys->buf + RECV_SCAN_SIZE && !*finished) {
 		ulint	no = log_block_get_hdr_no(log_block);
 		ulint	scanned_no = log_block_convert_lsn_to_no(scanned_lsn);
-		ibool	checksum_is_ok = true;
-			log_block_checksum_is_ok(log_block);
+		ibool	checksum_is_ok = log_block_checksum_is_ok(log_block);
 
 		if (no != scanned_no && checksum_is_ok) {
 			ulint blocks_in_group;

--- a/storage/innobase/xtrabackup/test/t/innodb_log_checksums.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_log_checksums.sh
@@ -1,0 +1,51 @@
+########################################################################
+# Test for innodb_log_checksums feature in MySQL 5.7
+########################################################################
+
+require_server_version_higher_than 5.7.9
+
+function test_with_checksums()
+{
+    vlog "################################################"
+    vlog "Testing with innodb_log_checksums=$1"
+    vlog "################################################"
+
+    MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_log_checksums=$1
+"
+    start_server
+
+    # Workaround for LP bug #1247586
+    $MYSQL $MYSQL_ARGS -e "SET GLOBAL innodb_log_checksums=$1"
+
+    load_sakila
+
+    innobackupex --no-timestamp $topdir/backup
+
+    egrep '^innodb_log_checksum_algorithm='$2'$' $topdir/backup/backup-my.cnf
+    cat $topdir/backup/backup-my.cnf
+
+    record_db_state sakila
+
+    stop_server
+
+    rm -rf $MYSQLD_DATADIR/*
+
+    run_cmd ${IB_BIN} \
+        ${IB_ARGS/\/--defaults-file=*my.cnf/$topdir\/backup\/backup-my.cnf} \
+        --apply-log $topdir/backup
+
+    innobackupex --copy-back $topdir/backup
+
+    start_server
+
+    verify_db_state sakila
+
+    stop_server
+
+    rm -rf $topdir/backup
+    rm -rf $MYSQLD_DATADIR
+}
+
+test_with_checksums ON strict_crc32
+test_with_checksums OFF none


### PR DESCRIPTION
Fixed the check and added new test case verifying 5.7's
`innodb_log_checksums' setting.