### PR TITLE
Bug 1639767: Test t/innodb_page_size.sh failing on PXC

### DIFF
--- a/storage/innobase/xtrabackup/test/t/innodb_page_size.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_page_size.sh
@@ -4,7 +4,7 @@
 
 . inc/common.sh
 
-if ! is_server_version_higher_than 5.6.0 && ! is_xtradb
+if is_galera || ( ! is_server_version_higher_than 5.6.0 && ! is_xtradb )
 then
     skip_test "Requires either XtraDB or a 5.6 server"
 fi


### PR DESCRIPTION
Disable test on PXC, since `innodb_page_size' is not supported. See
PXC-556 for reference.