### PR TITLE
Bug 1639764: Test t/bug1254227.sh failing on PXC 5.7

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1254227.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1254227.sh
@@ -2,6 +2,8 @@
 # Bug #1254227: xtrabackup_56 does not roll back prepared XA transactions
 #########################################################################
 
+is_galera && skip_test "Requires a server without Galera support"
+
 start_server
 
 mkfifo $topdir/fifo


### PR DESCRIPTION
This test intended to check that xtrabackup rolls back prepared XA
transactions. Since PXC doesn't work well with XA transactions (and PXC
5.7 started to complain with error message "WSREP doesn't support XA
transaction"), this test has to be skipped for PXC.