### PR TITLE
CVE-2016-6225: xtrabackup encryption is not setting the IV correctly

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcrypt.h
+++ b/storage/innobase/xtrabackup/src/xbcrypt.h
@@ -25,8 +25,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 
 #define XB_CRYPT_CHUNK_MAGIC1 "XBCRYP01"
-#define XB_CRYPT_CHUNK_MAGIC2 "XBCRYP02" /* must be same size as ^^ */
+#define XB_CRYPT_CHUNK_MAGIC2 "XBCRYP02"
+#define XB_CRYPT_CHUNK_MAGIC3 "XBCRYP03" /* must be same size as ^^ */
+#define XB_CRYPT_CHUNK_MAGIC_CURRENT XB_CRYPT_CHUNK_MAGIC3
 #define XB_CRYPT_CHUNK_MAGIC_SIZE (sizeof(XB_CRYPT_CHUNK_MAGIC1)-1)
+
+#define XB_CRYPT_HASH GCRY_MD_SHA256
+#define XB_CRYPT_HASH_LEN 32
 
 /******************************************************************************
 Write interface */
@@ -66,7 +71,7 @@ typedef enum {
 
 xb_rcrypt_result_t xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf,
 				       size_t *olen, size_t *elen, void **iv,
-				       size_t *ivlen);
+				       size_t *ivlen, my_bool *hash_appended);
 
 int xb_crypt_read_close(xb_rcrypt_t *crypt);
 

--- a/storage/innobase/xtrabackup/src/xbcrypt_read.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt_read.c
@@ -51,7 +51,7 @@ xb_crypt_read_open(void *userdata, xb_crypt_read_callback *onread)
 
 xb_rcrypt_result_t
 xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf, size_t *olen, size_t *elen,
-		    void **iv, size_t *ivlen)
+		    void **iv, size_t *ivlen, my_bool *hash_appended)
 
 {
 	uchar		tmpbuf[XB_CRYPT_CHUNK_MAGIC_SIZE + 8 + 8 + 8 + 4];
@@ -77,10 +77,15 @@ xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf, size_t *olen, size_t *elen,
 
 	ptr = tmpbuf;
 
-	if (memcmp(ptr, XB_CRYPT_CHUNK_MAGIC1, XB_CRYPT_CHUNK_MAGIC_SIZE) == 0) {
-		version = 1;
-	} else if (memcmp(ptr, XB_CRYPT_CHUNK_MAGIC2, XB_CRYPT_CHUNK_MAGIC_SIZE) == 0) {
+	if (memcmp(ptr, XB_CRYPT_CHUNK_MAGIC3,
+		   XB_CRYPT_CHUNK_MAGIC_SIZE) == 0) {
+		version = 3;
+	} else if (memcmp(ptr, XB_CRYPT_CHUNK_MAGIC2,
+			  XB_CRYPT_CHUNK_MAGIC_SIZE) == 0) {
 		version = 2;
+	} else if (memcmp(ptr, XB_CRYPT_CHUNK_MAGIC1,
+			  XB_CRYPT_CHUNK_MAGIC_SIZE) == 0) {
+		version = 1;
 	} else {
 		msg("%s:%s: wrong chunk magic at offset 0x%llx.\n",
 		    my_progname, __FUNCTION__, crypt->offset);
@@ -152,25 +157,14 @@ xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf, size_t *olen, size_t *elen,
 	}
 
 	if (*ivlen > crypt->ivbufsize) {
-		if (crypt->ivbuffer) {
-			crypt->ivbuffer = my_realloc(crypt->ivbuffer, *ivlen,
-						   MYF(MY_WME));
-			if (crypt->ivbuffer == NULL) {
-				msg("%s:%s: failed to increase iv buffer to "
-				    "%llu bytes.\n", my_progname, __FUNCTION__,
-				    (ulonglong)*ivlen);
-				result = XB_CRYPT_READ_ERROR;
-				goto err;
-			}
-		} else {
-			crypt->ivbuffer = my_malloc(*ivlen, MYF(MY_WME));
-			if (crypt->ivbuffer == NULL) {
-				msg("%s:%s: failed to allocate iv buffer of "
-				    "%llu bytes.\n", my_progname, __FUNCTION__,
-				    (ulonglong)*ivlen);
-				result = XB_CRYPT_READ_ERROR;
-				goto err;
-			}
+		crypt->ivbuffer = my_realloc(crypt->ivbuffer, *ivlen,
+					     MYF(MY_WME | MY_ALLOW_ZERO_PTR));
+		if (crypt->ivbuffer == NULL) {
+			msg("%s:%s: failed to increase iv buffer to "
+			    "%llu bytes.\n", my_progname, __FUNCTION__,
+			    (ulonglong)*ivlen);
+			result = XB_CRYPT_READ_ERROR;
+			goto err;
 		}
 		crypt->ivbufsize = *ivlen;
 	}
@@ -187,26 +181,22 @@ xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf, size_t *olen, size_t *elen,
 		*iv = crypt->ivbuffer;
 	}
 
+	/* for version euqals 2 we need to read in the iv data but do not init
+	CTR with it */
+	if (version == 2) {
+		*ivlen = 0;
+		*iv = 0;
+	}
+
 	if (*olen > crypt->bufsize) {
-		if (crypt->buffer) {
-			crypt->buffer = my_realloc(crypt->buffer, *olen,
-						   MYF(MY_WME));
-			if (crypt->buffer == NULL) {
-				msg("%s:%s: failed to increase buffer to "
-				    "%llu bytes.\n", my_progname, __FUNCTION__,
-				    (ulonglong)*olen);
-				result = XB_CRYPT_READ_ERROR;
-				goto err;
-			}
-		} else {
-			crypt->buffer = my_malloc(*olen, MYF(MY_WME));
-			if (crypt->buffer == NULL) {
-				msg("%s:%s: failed to allocate buffer of "
-				    "%llu bytes.\n", my_progname, __FUNCTION__,
-				    (ulonglong)*olen);
-				result = XB_CRYPT_READ_ERROR;
-				goto err;
-			}
+		crypt->buffer = my_realloc(crypt->buffer, *olen,
+					   MYF(MY_WME | MY_ALLOW_ZERO_PTR));
+		if (crypt->buffer == NULL) {
+			msg("%s:%s: failed to increase buffer to "
+			    "%llu bytes.\n", my_progname, __FUNCTION__,
+			    (ulonglong)*olen);
+			result = XB_CRYPT_READ_ERROR;
+			goto err;
 		}
 		crypt->bufsize = *olen;
 	}
@@ -233,6 +223,9 @@ xb_crypt_read_chunk(xb_rcrypt_t *crypt, void **buf, size_t *olen, size_t *elen,
 
 	crypt->offset += *elen;
 	*buf = crypt->buffer;
+
+	*hash_appended = version > 2;
+
 	goto exit;
 
 err:

--- a/storage/innobase/xtrabackup/src/xbcrypt_write.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt_write.c
@@ -61,7 +61,7 @@ int xb_crypt_write_chunk(xb_wcrypt_t *crypt, const void *buf, size_t olen,
 
 	ptr = tmpbuf;
 
-	memcpy(ptr, XB_CRYPT_CHUNK_MAGIC2, XB_CRYPT_CHUNK_MAGIC_SIZE);
+	memcpy(ptr, XB_CRYPT_CHUNK_MAGIC_CURRENT, XB_CRYPT_CHUNK_MAGIC_SIZE);
 	ptr += XB_CRYPT_CHUNK_MAGIC_SIZE;
 
 	int8store(ptr, (ulonglong)0);	/* reserved */

--- a/storage/innobase/xtrabackup/test/inc/ib_local.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_local.sh
@@ -35,6 +35,7 @@ if [ -n "${data_decrypt_cmd:=""}" ] || [ -n "${data_decompress_cmd:=""}" ]; then
   vlog "###################################"
   vlog "# DECRYPTING AND/OR DECOMPRESSING #"
   vlog "###################################"
+  test -n "${data_decrypt_cmd_wrong_passphrase:=""}" && run_cmd_expect_failure bash -c "$data_decrypt_cmd_wrong_passphrase"
   test -n "${data_decrypt_cmd:=""}" && run_cmd bash -c "$data_decrypt_cmd"
   test -n "${data_decompress_cmd:-""}" && run_cmd bash -c "$data_decompress_cmd";
 fi

--- a/storage/innobase/xtrabackup/test/inc/xb_local.sh
+++ b/storage/innobase/xtrabackup/test/inc/xb_local.sh
@@ -35,6 +35,7 @@ if [ -n "${data_decrypt_cmd:=""}" ] || [ -n "${data_decompress_cmd:=""}" ]; then
   vlog "###################################"
   vlog "# DECRYPTING AND/OR DECOMPRESSING #"
   vlog "###################################"
+  test -n "${data_decrypt_cmd_wrong_passphrase:=""}" && run_cmd_expect_failure bash -c "$data_decrypt_cmd_wrong_passphrase"
   test -n "${data_decrypt_cmd:=""}" && run_cmd bash -c "$data_decrypt_cmd"
   test -n "${data_decompress_cmd:-""}" && run_cmd bash -c "$data_decompress_cmd";
 fi

--- a/storage/innobase/xtrabackup/test/t/ib_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_encrypt.sh
@@ -4,8 +4,10 @@
 
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
+wrong_encrypt_key="Percona_XtraBackup_Is_Awesome___"
 
 innobackupex_options="--encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 data_decrypt_cmd="innobackupex --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} ./"
+data_decrypt_cmd_wrong_passphrase="innobackupex --decrypt=${encrypt_algo} --encrypt-key=${wrong_encrypt_key} ./"
 
 . inc/ib_local.sh

--- a/storage/innobase/xtrabackup/test/t/xb_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_encrypt.sh
@@ -4,8 +4,10 @@
 
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
+wrong_encrypt_key="Percona_XtraBackup_Is_Awesome___"
 
 xtrabackup_options="--encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} --target-dir=./"
+data_decrypt_cmd_wrong_passphrase="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=${wrong_encrypt_key} --target-dir=./"
 
 . inc/xb_local.sh


### PR DESCRIPTION
Blueprint checksum-unencrypted-chunk

[https://blueprints.launchpad.net/percona-xtrabackup/+spec/checksum-unencrypted-chunk]

This patch changes xbcrypt format as following:

1. Bump XBCRYPT header version number, current is "XBCRYP03"

2. Append 32-byte SHA256 hash of the plaintext to the payload of each
   chunk

3. Encrypt plaintext payload and hash all together

4. Both original length and encrypted length fields of the chunk header
   are calculated including these extra 32 bytes.