### PR TITLE
Bug 1641426: Initialize page 5th page of ibdata1 as FIL_PAGE_TYPE_TRX…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -912,6 +912,12 @@ buf_flush_init_for_writing(
 			case 1:
 				reset_type = FIL_PAGE_IBUF_BITMAP;
 				break;
+			case 5:
+				if (block->page.id.page_no() == 5 &&
+				    block->page.id.space() == TRX_SYS_SPACE) {
+					reset_type = FIL_PAGE_TYPE_TRX_SYS;
+				}
+				break;
 			default:
 				switch (page_type) {
 				case FIL_PAGE_INDEX:


### PR DESCRIPTION
…_SYS if it has wrong page type

Some older versions of MySQL did not bother to initialise page type
field for pages which are not index pages. See MySQL bug #76262 for some
insight. The patch included into server does its best to properly
initialise some of the pages which came from older mysql versions
through the multiple upgrade processes.