### PR TITLE
Bug fix for https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1642329

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6804,8 +6804,8 @@ int main(int argc, char **argv)
 
 			optend = strcend(tmp_argv.c_str(), '=');
 
-			if (strncmp(argv[i], "--defaults-group",
-				    optend - argv[i]) == 0) {
+			if (strncmp(tmp_argv.c_str(), "--defaults-group",
+				    optend - tmp_argv.c_str()) == 0) {
 				defaults_group = optend + 1;
 				append_defaults_group(defaults_group);
 			}

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6800,19 +6800,23 @@ int main(int argc, char **argv)
 		for (i=1; i < argc; i++) {
 			
 			// Bug fix for https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1642329
-			std::string tmp_argv(argv[i]);
+			optend = strcend(argv[i], '=');
+                        
+                        char *new_optend = NULL;
+                        
+                        if(*optend != '\0') {
+                            new_optend = optend + 1;
+                        }
 
-			optend = strcend(tmp_argv.c_str(), '=');
-
-			if (strncmp(tmp_argv.c_str(), "--defaults-group",
-				    optend - tmp_argv.c_str()) == 0) {
-				defaults_group = optend + 1;
-				append_defaults_group(defaults_group);
+			if (strncmp(argv[i], "--defaults-group",
+				    optend - argv[i]) == 0) {
+				defaults_group = new_optend;
+                                append_defaults_group(defaults_group);
 			}
 
 			if (strncmp(argv[i], "--login-path",
 				    optend - argv[i]) == 0) {
-				append_defaults_group(optend + 1);
+				append_defaults_group(new_optend);
 			}
 
 			if (!strncmp(argv[i], "--prepare",
@@ -6827,7 +6831,7 @@ int main(int argc, char **argv)
 
 			if (!strncmp(argv[i], "--target-dir",
 				     optend - argv[i]) && *optend) {
-				target_dir = optend + 1;
+				target_dir = new_optend;
 			}
 
 			if (!*optend && argv[i][0] != '-') {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6798,18 +6798,11 @@ int main(int argc, char **argv)
 		char	conf_file[FN_REFLEN];
 
 		for (i=1; i < argc; i++) {
-
-			optend = strcend(argv[i], '=');
 			
-			/* bug fix for https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1642329 
-                         * when in the parameter client sends -- -- or -- * params then optent variable stays empty.
-                         * After this the third parameter of strncmp function is constructed with optent variable
-                         * and it makes unpredictable different problems on the result.
-                         */
-                        if(strlen(optend) == 0) {
-                            fprintf(stderr, "Parameter is wrong\n");
-                            exit(EXIT_FAILURE);
-                        }
+			// Bug fix for https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1642329
+			std::string tmp_argv(argv[i]);
+
+			optend = strcend(tmp_argv.c_str(), '=');
 
 			if (strncmp(argv[i], "--defaults-group",
 				    optend - argv[i]) == 0) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6800,6 +6800,16 @@ int main(int argc, char **argv)
 		for (i=1; i < argc; i++) {
 
 			optend = strcend(argv[i], '=');
+			
+			/* bug fix for https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1642329 
+                         * when in the parameter client sends -- -- or -- * params then optent variable stays empty.
+                         * After this the third parameter of strncmp function is constructed with optent variable
+                         * and it makes unpredictable different problems on the result.
+                         */
+                        if(strlen(optend) == 0) {
+                            fprintf(stderr, "Parameter is wrong\n");
+                            exit(EXIT_FAILURE);
+                        }
 
 			if (strncmp(argv[i], "--defaults-group",
 				    optend - argv[i]) == 0) {


### PR DESCRIPTION
The reason of the bug was that, strcend function puts the pointer to the end of the string in argv: optend = strcend(argv[i], '=');
If we send only -- -- string at the parameter than we enter the first if: 
if (strncmp(argv[i], "--defaults-group",
 optend - argv[i]) == 0) {
 defaults_group = optend + 1;
 append_defaults_group(defaults_group);
}

As you see the value of the defaults_group is optend + 1. This makes a problem, because after the argv massive in the RAM comes some system ENV strings like TERM_PROGRAM=Apple_Terminal, SHELL=/bin/bash and etc. If you print defaults_group you can see this result. It seems OS keeps argv massive near the system environment strings in the RAM. 
For this reason I copied the argv strings to the temporary string object to keep them in the secure place of RAM, then I gave this string to the strcend function like first parameter. After that, program worked correctly.