### PR TITLE
Bug 1643803: incremental backups do not include `xtrabackup_binlog_in…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1480,11 +1480,11 @@ ibx_copy_incremental_over_full()
 				xtrabackup_incremental_dir,
 				sup_files[i]);
 
-			if (file_exists(sup_files[i])) {
-				unlink(sup_files[i]);
-			}
-
-			if (file_exists(path)) {
+			if (file_exists(path))
+			{
+				if (file_exists(sup_files[i])) {
+					unlink(sup_files[i]);
+				}
 				copy_file(ds_data, path, sup_files[i], 0);
 			}
 		}

--- a/storage/innobase/xtrabackup/src/wsrep.cc
+++ b/storage/innobase/xtrabackup/src/wsrep.cc
@@ -161,7 +161,7 @@ wsrep_uuid_print(
 Store Galera checkpoint info in the 'xtrabackup_galera_info' file, if that
 information is present in the trx system header. Otherwise, do nothing. */
 void
-xb_write_galera_info()
+xb_write_galera_info(bool incremental_prepare)
 /*==================*/
 {
 	FILE*		fp;
@@ -172,7 +172,8 @@ xb_write_galera_info()
 
 	/* Do not overwrite existing an existing file to be compatible with
 	servers with older server versions */
-	if (my_stat(XB_GALERA_INFO_FILENAME, &statinfo, MYF(0)) != NULL) {
+	if (!incremental_prepare &&
+		my_stat(XB_GALERA_INFO_FILENAME, &statinfo, MYF(0)) != NULL) {
 
 		return;
 	}

--- a/storage/innobase/xtrabackup/src/wsrep.h
+++ b/storage/innobase/xtrabackup/src/wsrep.h
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 Store Galera checkpoint info in the 'xtrabackup_galera_info' file, if that
 information is present in the trx system header. Otherwise, do nothing. */
 void
-xb_write_galera_info();
+xb_write_galera_info(bool incremental_prepare);
 /*==================*/
 
 #endif

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6559,7 +6559,7 @@ next_node:
 		exit(EXIT_FAILURE);
 	}
 
-	xb_write_galera_info();
+	xb_write_galera_info(xtrabackup_incremental);
 
 	if(innodb_end())
 		goto error_cleanup;


### PR DESCRIPTION
…fo' and `xtrabackup_galera_info'

There were two issues:

- xtrabackup did not generate `xtrabackup_galera_info' if one was found
  already. It was done to prevent overwriting `xtrabackup_galera_info'
  taken for servers without backup locks. Solution is to overwrite the
  file if we preparing incremental backup. It is OK because if
  incremental backup contains `xtrabackup_galera_info', it will be
  overwritten by `apply_log_finish'.
- `apply_log_finish' removed `xtrabackup_galera_info' and
  `xtrabackup_binlog_info' even if these files were missing from
  incremental directory. Fix is to remove files only if there are files
  to replace them.