### PR TITLE
Bug 1648322: xtrabackup --move-back is not always restoring out-of-da…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -58,7 +58,9 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 
 /* list of files to sync for --rsync mode */
-std::set<std::string> rsync_list;
+static std::set<std::string> rsync_list;
+/* locations of tablespaces read from .isl files */
+static std::map<std::string, std::string> tablespace_locations;
 
 /* Whether LOCK BINLOG FOR BACKUP has been issued during backup */
 bool binlog_locked;
@@ -1072,6 +1074,57 @@ move_file(ds_ctxt_t *datasink,
 
 
 /************************************************************************
+Read link from .isl file if any and store it in the global map associated
+with given tablespace. */
+static
+void
+read_link_file(const char *ibd_filepath, const char *link_filepath)
+{
+	char *filepath= NULL;
+
+	FILE *file = fopen(link_filepath, "r+b");
+	if (file) {
+		filepath = static_cast<char*>(malloc(OS_FILE_MAX_PATH));
+
+		os_file_read_string(file, filepath, OS_FILE_MAX_PATH);
+		fclose(file);
+
+		if (strlen(filepath)) {
+			/* Trim whitespace from end of filepath */
+			ulint lastch = strlen(filepath) - 1;
+			while (lastch > 4 && filepath[lastch] <= 0x20) {
+				filepath[lastch--] = 0x00;
+			}
+			srv_normalize_path_for_win(filepath);
+		}
+
+		tablespace_locations[ibd_filepath] = filepath;
+	}
+	free(filepath);
+}
+
+
+/************************************************************************
+Return the location of given .ibd if it was previously read
+from .isl file.
+@return NULL or destination .ibd file path. */
+static
+const char *
+tablespace_filepath(const char *ibd_filepath)
+{
+	std::map<std::string, std::string>::iterator it;
+
+	it = tablespace_locations.find(ibd_filepath);
+
+	if (it != tablespace_locations.end()) {
+		return it->second.c_str();
+	}
+
+	return NULL;
+}
+
+
+/************************************************************************
 Copy or move file depending on current mode.
 @return true in case of success. */
 static
@@ -1082,34 +1135,35 @@ copy_or_move_file(const char *src_file_path,
 		  uint thread_n)
 {
 	ds_ctxt_t *datasink = ds_data;		/* copy to datadir by default */
-	char *filepath = NULL;
 	char filedir[FN_REFLEN];
 	size_t filedir_len;
 	bool ret;
 
+	/* read the link from .isl file */
+	if (ends_with(src_file_path, ".isl")) {
+		char *ibd_filepath;
+
+		ibd_filepath = strdup(src_file_path);
+		strcpy(ibd_filepath + strlen(ibd_filepath) - 3, "ibd");
+
+		read_link_file(ibd_filepath, src_file_path);
+
+		free(ibd_filepath);
+	}
+
 	/* check if there is .isl file */
 	if (ends_with(src_file_path, ".ibd")) {
 		char *link_filepath;
+		const char *filepath;
 
 		link_filepath = strdup(src_file_path);
 		strcpy(link_filepath + strlen(link_filepath) - 3, "isl");
 
-		FILE *file = fopen(link_filepath, "r+b");
-		if (file) {
-			filepath = static_cast<char*>(malloc(OS_FILE_MAX_PATH));
+		read_link_file(src_file_path, link_filepath);
 
-			os_file_read_string(file, filepath, OS_FILE_MAX_PATH);
-			fclose(file);
+		filepath = tablespace_filepath(src_file_path);
 
-			if (strlen(filepath)) {
-				/* Trim whitespace from end of filepath */
-				ulint lastch = strlen(filepath) - 1;
-				while (lastch > 4 && filepath[lastch] <= 0x20) {
-					filepath[lastch--] = 0x00;
-				}
-				srv_normalize_path_for_win(filepath);
-			}
-
+		if (filepath != NULL) {
 			dirname_part(filedir, filepath, &filedir_len);
 
 			dst_file_path = filepath + filedir_len;
@@ -1122,6 +1176,7 @@ copy_or_move_file(const char *src_file_path,
 
 			datasink = ds_create(dst_dir, DS_TYPE_LOCAL);
 		}
+
 		free(link_filepath);
 	}
 
@@ -1131,7 +1186,6 @@ copy_or_move_file(const char *src_file_path,
 			  dst_dir, thread_n));
 
 cleanup:
-	free(filepath);
 
 	if (datasink != ds_data) {
 		ds_destroy(datasink);

--- a/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
@@ -16,6 +16,14 @@ CREATE TABLE t(id INT AUTO_INCREMENT PRIMARY KEY, c INT)
 INSERT INTO t(c) VALUES (1), (2), (3), (4), (5), (6), (7), (8);
 EOF
 
+for ((i=0; i<12; i++))
+do
+    $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE t$i(id INT AUTO_INCREMENT PRIMARY KEY, c INT)
+  DATA DIRECTORY = '$remote_dir' ENGINE=InnoDB;
+EOF
+done
+
 # Generate some log data, as we also want to test recovery of remote tablespaces
 for ((i=0; i<12; i++))
 do
@@ -34,22 +42,39 @@ rm -rf $mysql_datadir/*
 rm -rf $remote_dir
 
 innobackupex --apply-log $topdir/backup
-innobackupex --copy-back $topdir/backup
 
-if [ ! -f $remote_dir/test/t.ibd ] ; then
-	vlog "Tablepace $remote_dir/t.ibd is missing!"
-	exit -1
-fi
+for cmd in "--copy-back" "--move-back" ; do
 
-start_server
+    innobackupex $cmd $topdir/backup
 
-checksum_b=`checksum_table test t`
+    if [ ! -f $remote_dir/test/t.ibd ] ; then
+        vlog "Tablepace $remote_dir/t.ibd is missing!"
+        exit -1
+    fi
 
-vlog "Old checksum: $checksum_a"
-vlog "New checksum: $checksum_b"
+    for ((i=0; i<12; i++)) ; do
+        if [ ! -f $remote_dir/test/t$i.ibd ] ; then
+            vlog "Tablepace $remote_dir/t$i.ibd is missing!"
+            exit -1
+        fi
+    done
 
-if [ "$checksum_a" != "$checksum_b"  ]
-then
-    vlog "Checksums do not match"
-    exit -1
-fi
+    start_server
+
+    checksum_b=`checksum_table test t`
+
+    vlog "Old checksum: $checksum_a"
+    vlog "New checksum: $checksum_b"
+
+    if [ "$checksum_a" != "$checksum_b"  ]
+    then
+        vlog "Checksums do not match"
+        exit -1
+    fi
+
+    stop_server
+
+    rm -rf $mysql_datadir/*
+    rm -rf $remote_dir
+
+done


### PR DESCRIPTION
…tadir tablespaces to their original directories

When copy-back walks files and copies them back to datadir, it is
looking for corresponding .isl files as it passing by .ibd file. If .isl
file is found, .ibd will be copied to the destination pointed by .isl.

It works for copy-back, but it doesn't work for move-back, because we
have no control over the order in which files are handled. It can happen
that .isl file already moved when we are handling corresponding .ibd
file.

To fix this, map has been introduced to store association between .ibd
files and their destinations. Now when we stumble upon .ibd or .isl file
we store destination path for .ibd file as been read from .isl. And when
we handle .ibd, we simply lookup the destination from that map.