### PR TITLE
Bug 1642826: incremental backup fails with relative path

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -135,6 +135,10 @@ char *xtrabackup_incremental_basedir = NULL; /* for --backup */
 char *xtrabackup_extra_lsndir = NULL; /* for --backup with --extra-lsndir */
 char *xtrabackup_incremental_dir = NULL; /* for --prepare */
 
+char xtrabackup_real_incremental_basedir[FN_REFLEN];
+char xtrabackup_real_extra_lsndir[FN_REFLEN];
+char xtrabackup_real_incremental_dir[FN_REFLEN];
+
 lsn_t xtrabackup_archived_to_lsn = 0; /* for --archived-to-lsn */
 
 char *xtrabackup_tables = NULL;
@@ -6792,6 +6796,8 @@ int main(int argc, char **argv)
 {
 	int ho_error;
 	char **argv_defaults;
+	char cwd[FN_REFLEN];
+	my_bool is_symdir;
 
 	setup_signals();
 
@@ -6946,9 +6952,40 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	/* Ensure target dir is not relative to datadir */
-	my_load_path(xtrabackup_real_target_dir, xtrabackup_target_dir, NULL);
+	/* Expand target-dir, incremental-basedir, etc. */
+
+	my_getwd(cwd, sizeof(cwd), MYF(0));
+
+	my_load_path(xtrabackup_real_target_dir,
+		     xtrabackup_target_dir, cwd);
+	unpack_dirname(xtrabackup_real_target_dir,
+		       xtrabackup_real_target_dir, &is_symdir);
 	xtrabackup_target_dir= xtrabackup_real_target_dir;
+
+	if (xtrabackup_incremental_basedir) {
+		my_load_path(xtrabackup_real_incremental_basedir,
+			     xtrabackup_incremental_basedir, cwd);
+		unpack_dirname(xtrabackup_real_incremental_basedir,
+			       xtrabackup_real_incremental_basedir, &is_symdir);
+		xtrabackup_incremental_basedir =
+			xtrabackup_real_incremental_basedir;
+	}
+
+	if (xtrabackup_incremental_dir) {
+		my_load_path(xtrabackup_real_incremental_dir,
+			     xtrabackup_incremental_dir, cwd);
+		unpack_dirname(xtrabackup_real_incremental_dir,
+			       xtrabackup_real_incremental_dir, &is_symdir);
+		xtrabackup_incremental_dir = xtrabackup_real_incremental_dir;
+	}
+
+	if (xtrabackup_extra_lsndir) {
+		my_load_path(xtrabackup_real_extra_lsndir,
+			     xtrabackup_extra_lsndir, cwd);
+		unpack_dirname(xtrabackup_real_extra_lsndir,
+			       xtrabackup_real_extra_lsndir, &is_symdir);
+		xtrabackup_extra_lsndir = xtrabackup_real_extra_lsndir;
+	}
 
 	/* get default temporary directory */
 	if (!opt_mysql_tmpdir || !opt_mysql_tmpdir[0]) {

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -246,7 +246,8 @@ function switch_server()
 
     IB_ARGS="--defaults-file=$MYSQLD_VARDIR/my.cnf \
 --no-version-check ${IB_EXTRA_OPTS:-}"
-    XB_ARGS="--defaults-file=$MYSQLD_VARDIR/my.cnf"
+    XB_ARGS="--defaults-file=$MYSQLD_VARDIR/my.cnf \
+--no-version-check ${XB_EXTRA_OPTS:-}"
 
     # Some aliases for compatibility, as tests use the following names
     topdir="$MYSQLD_VARDIR"

--- a/storage/innobase/xtrabackup/test/t/bug1642826.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1642826.sh
@@ -1,0 +1,26 @@
+#
+# Bug 1642826: incremental backup fails with relative path / xtrabackup doesn't expand tilde
+#
+
+start_server
+
+cd $topdir
+
+mkdir backup
+
+xtrabackup --backup --target-dir=backup/full --extra-lsndir=backup/lsn
+xtrabackup --backup --incremental-basedir=backup/full --target-dir=backup/inc_1
+xtrabackup --prepare --apply-log-only --target-dir=backup/full
+xtrabackup --prepare --target-dir=backup/full --incremental-dir=backup/inc_1
+
+rm -rf backup/*
+
+cd -
+
+export HOME=$topdir
+
+xtrabackup --backup --target-dir=~/backup/full --extra-lsndir=~/backup/lsn
+xtrabackup --backup --incremental-basedir=~/backup/full --target-dir=~/backup/inc_1
+xtrabackup --prepare --apply-log-only --target-dir=~/backup/full
+xtrabackup --prepare --target-dir=~/backup/full --incremental-dir=~/backup/inc_1
+


### PR DESCRIPTION
Fix is to expand not only `target-dir', but also `incremental-basedir',
`incremental-dir', `incremental-lsndir'.

Besides current directory expansion, also expand tilde.