### PR TITLE
Bug 1446487: Feature request: add option to remove *.qp files on deco…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1859,6 +1859,13 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
 	 	if (system(cmd.str().c_str()) != 0) {
 	 		return(false);
 	 	}
+
+	 	if (opt_remove_original) {
+	 		msg_ts("[%02u] removing %s\n", thread_n, filepath);
+	 		if (my_delete(filepath, MYF(MY_WME)) != 0) {
+	 			return(false);
+	 		}
+	 	}
 	 }
 
  	return(true);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -345,6 +345,7 @@ my_bool opt_force_non_empty_dirs = FALSE;
 my_bool opt_noversioncheck = FALSE;
 my_bool opt_no_backup_locks = FALSE;
 my_bool opt_decompress = FALSE;
+my_bool opt_remove_original = FALSE;
 
 static const char *binlog_info_values[] = {"off", "lockless", "on", "auto",
 					   NullS};
@@ -591,6 +592,7 @@ enum options_xtrabackup
   OPT_INCREMENTAL_HISTORY_NAME,
   OPT_INCREMENTAL_HISTORY_UUID,
   OPT_DECRYPT,
+  OPT_REMOVE_ORIGINAL,
   OPT_LOCK_WAIT_QUERY_TYPE,
   OPT_KILL_LONG_QUERY_TYPE,
   OPT_HISTORY,
@@ -1130,6 +1132,12 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    &opt_decrypt_algo, &opt_decrypt_algo,
    &xtrabackup_encrypt_algo_typelib, GET_ENUM, REQUIRED_ARG,
    0, 0, 0, 0, 0, 0},
+
+  {"remove-original", OPT_REMOVE_ORIGINAL, "Remove .qp and .xbcrypt files "
+   "after decryption and decompression.",
+   (uchar *) &opt_remove_original,
+   (uchar *) &opt_remove_original,
+   0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
   {"ftwrl-wait-query-type", OPT_LOCK_WAIT_QUERY_TYPE,
    "This option specifies which types of queries are allowed to complete "

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -133,6 +133,7 @@ extern my_bool		opt_force_non_empty_dirs;
 extern my_bool		opt_noversioncheck;
 extern my_bool		opt_no_backup_locks;
 extern my_bool		opt_decompress;
+extern my_bool		opt_remove_original;
 
 extern char		*opt_incremental_history_name;
 extern char		*opt_incremental_history_uuid;

--- a/storage/innobase/xtrabackup/test/t/xb_remove_original.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_remove_original.sh
@@ -1,0 +1,42 @@
+#
+# Test for --remove-original option
+#
+
+start_server --innodb_file_per_table
+
+$MYSQL $MYSQL_ARGS -e "CREATE TABLE t1 (a INT) engine=InnoDB" test
+$MYSQL $MYSQL_ARGS -e "INSERT INTO t1 VALUES (1), (2), (3), (4)" test
+
+xtrabackup --backup --encrypt=AES256 \
+	   --encrypt-key=percona_xtrabackup_is_awesome___ \
+	   --encrypt-threads=4 --encrypt-chunk-size=8K \
+	   --compress --target-dir=$topdir/backup
+
+cp -r $topdir/backup $topdir/backup1
+
+run_cmd $XB_BIN --decrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___ \
+		--parallel=4 --encrypt-chunk-size=8K \
+		--target-dir=$topdir/backup1
+
+test -f $topdir/backup1/test/t1.ibd.qp.xbcrypt || die "Files removed"
+
+rm -rf $topdir/backup1
+cp -r $topdir/backup $topdir/backup1
+
+run_cmd $XB_BIN --decrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___ \
+		--parallel=4 --encrypt-chunk-size=8K \
+		--remove-original \
+		--target-dir=$topdir/backup1
+
+test -f $topdir/backup1/test/t1.ibd.qp.xbcrypt && die "Files not removed"
+
+rm -rf $topdir/backup1
+cp -r $topdir/backup $topdir/backup1
+
+run_cmd_expect_failure $XB_BIN --decrypt=AES256 \
+			       --encrypt-key=percona_xtrabackup_Is_awesome___ \
+			       --parallel=4 --encrypt-chunk-size=8K \
+			       --remove-original \
+			       --target-dir=$topdir/backup1
+
+test -f $topdir/backup1/test/t1.ibd.qp.xbcrypt || die "Files removed"


### PR DESCRIPTION
…mpress

Add option `--remove-original` to remove `.qp`, `.xbcrypt` and
`.qp.xbcrypt` files after decryption and decompression.