### PR TITLE
Bug 1647340: xtrabackup 2.4: xb_stream_read_chunk(): wrong chunk magi…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -440,9 +440,9 @@ ulint opt_encrypt_server_id = 0;
 bool opt_encrypt_for_server_id_specified = false;
 
 #define CLIENT_WARN_DEPRECATED(opt, new_opt) \
-  printf("WARNING: " opt \
-         " is deprecated and will be removed in a future version. " \
-         "Use " new_opt " instead.\n")
+  msg("WARNING: " opt \
+      " is deprecated and will be removed in a future version. " \
+      "Use " new_opt " instead.\n")
 
 /* Simple datasink creation tracking...add datasinks in the reverse order you
 want them destroyed. */

--- a/storage/innobase/xtrabackup/test/t/bug1647340.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1647340.sh
@@ -1,0 +1,14 @@
+#
+# Bug 1647340: warning "option --ssl is deprecated" printed to stdout
+#
+
+XB_EXTRA_MY_CNF_OPTS="
+ssl
+"
+
+start_server
+
+mkdir $topdir/backup
+
+xtrabackup --backup --target-dir=$topdir/backup --stream=xbstream > $topdir/backup/b.xbs
+run_cmd xbstream -C $topdir/backup -x < $topdir/backup/b.xbs


### PR DESCRIPTION
…c at offset 0x35630d1.

Option deprecation warning has been written to stdout and messed up with
stream output.

Fix is to print message to stderr.