### PR TITLE
Bug1658692: Missing .isl file for general tablespace from backup

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1228,7 +1228,7 @@ backup_files(const char *from, bool prep_mode)
 	       prep_mode ? "prep copy of" : "to backup");
 
 	datadir_node_init(&node);
-	it = datadir_iter_new(from);
+	it = datadir_iter_new(from, false);
 
 	while (datadir_iter_next(it, &node)) {
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3272,6 +3272,12 @@ xb_load_single_table_tablespace(
 	const char *filname,
 	bool is_remote)
 {
+	/* Ignore .isl files on XtraBackup recovery. All tablespaces must be
+	local. */
+	if (is_remote && !srv_backup_mode) {
+		return;
+	}
+
 	/* The name ends in .ibd or .isl;
 	try opening the file */
 	char*	name;
@@ -3455,7 +3461,6 @@ xb_load_single_table_tablespaces(bool (*pred)(const char*, const char*))
 				bool is_remote;
 
 				if (fileinfo.type == OS_FILE_TYPE_DIR) {
-
 					goto next_file_item;
 				}
 
@@ -3467,11 +3472,7 @@ xb_load_single_table_tablespaces(bool (*pred)(const char*, const char*))
 				if (strlen(fileinfo.name) > 4
 				    && (0 == strcmp(fileinfo.name
 						   + strlen(fileinfo.name) - 4,
-						   ".ibd")
-					/* Ignore .isl files on XtraBackup
-					recovery, all tablespaces must be
-					local. */
-					|| (srv_backup_mode && is_remote))
+						   ".ibd"))
 				    && (!pred
 					|| pred(dbinfo.name, fileinfo.name))) {
 					xb_load_single_table_tablespace(

--- a/storage/innobase/xtrabackup/test/t/create_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/t/create_tablespace.sh
@@ -29,6 +29,10 @@ INSERT INTO test.t2_2 VALUES (10), (20), (30);
 INSERT INTO test.t2_3 VALUES (100), (200), (300);
 EOF
 
+count=`ls $mysql_datadir/*.isl | wc -l`
+vlog  "$count .isl files in datadir, expecting 1"
+test $count -eq 1
+
 xtrabackup --backup --target-dir=$topdir/full
 
 run_cmd $MYSQL $MYSQL_ARGS <<EOF
@@ -121,3 +125,7 @@ $MYSQL $MYSQL_ARGS -e "SELECT * FROM test.t3_2"
 $MYSQL $MYSQL_ARGS -e "SELECT * FROM test.t3_3"
 
 verify_db_state test
+
+count=`ls $mysql_datadir/*.isl | wc -l`
+vlog  "$count .isl files in datadir after restore, expecting 1"
+test $count -eq 1


### PR DESCRIPTION
Considering files inside datadir itself for backup, since the general tablespace .isl file is located there.