### PR TITLE
Bug 1665239: -h shortcut seems to be not working for xtrabackup

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6935,9 +6935,20 @@ handle_options(int argc, char **argv, char ***argv_client, char ***argv_server)
 
 		if (strncmp(opt, "--", 2) &&
 		    !(strlen(opt) == 2 && opt[0] == '-')) {
+			bool server_option = true;
 
-			msg("xtrabackup: Error: unknown argument: '%s'\n", opt);
-			exit(EXIT_FAILURE);
+			for (int j = 0; j < argc_server; j++) {
+				if (opt == (*argv_server)[j]) {
+					server_option = false;
+					break;
+				}
+			}
+
+			if (!server_option) {
+				msg("xtrabackup: Error:"
+				    " unknown argument: '%s'\n", opt);
+				exit(EXIT_FAILURE);
+			}
 		}
 	}
 }


### PR DESCRIPTION
    xtrabackup -h localhost

aborted with error message

    xtrabackup: Error: unknown argument: 'localhost'

Here is why. -h is a shortcut for --datadir, which is server option
and 'localhost' was recognized as it's argument and handled
correctly.

Then xtrabackup was trying to pick client options and 'localhost'
option was marked as not handled.

Then xtrabackup checked options which were not handled during
previous step and complained that 'localhost' is incorrect.

Fix is to abort only in case when option was not recognized as client
option neither as server option.