### PR TITLE
Bug 1669592: MySQL 5.6 fails to start on the incremental backup prepa…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6639,6 +6639,12 @@ next_node:
 
 	if (!xtrabackup_apply_log_only) {
 
+		/* xtrabackup_incremental_dir is used to indicate that
+		we are going to apply incremental backup. Here we already
+		applied incremental backup and are about to do final prepare
+		of the full backup */
+		xtrabackup_incremental_dir = NULL;
+
 		if(innodb_init_param()) {
 			goto error;
 		}

--- a/storage/innobase/xtrabackup/test/t/bug1669592.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1669592.sh
@@ -1,0 +1,20 @@
+#
+# Bug 1669592: xtrabackup --prepare --incremental-dir=... --target-dir=...
+#              creates redo logs in wrong directory
+#
+
+start_server
+
+${MYSQL} ${MYSQL_ARGS} -e "CREATE TABLE t1 (id int primary key)" test
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (1)" test
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (2)" test
+
+xtrabackup --backup --target-dir=$topdir/backup-inc --incremental-basedir=$topdir/backup
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --incremental-dir=$topdir/backup-inc --target-dir=$topdir/backup
+
+test -f $topdir/backup/ib_logfile0 || die "Log files are not found in full backup directory"


### PR DESCRIPTION
…red with 2.4 and non-default `innodb_data_file_path`

This is 2.3 part of the fix. The problem is that command

    xtrabackup --prepare --incremental-dir=... --target-dir=...

creates redo logs inside of the `incremental-dir`.

The directory to look redo logs for is set up inside of the
`innodb_init_param`. When `incremental-dir` is set, we consider that
we are going to apply redo log from incremental backup on top of the
full backup, but InnoDB engine is started twice, first one indeed to
apply incremental log, the second one to create log files.

The fix is to reset `incremental-dir` before the second start, as we
are no longer going to work with the incremental backup.

http://jenkins.percona.com/view/PXB%202.3/job/percona-xtrabackup-2.3-param/241/