### PR TITLE
Fix bug 1669592 in 2.4

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18684,7 +18684,7 @@ checkpoint_now_set(
 			log_make_checkpoint_at(LSN_MAX, TRUE);
 			fil_flush_file_spaces(FIL_TYPE_LOG);
 		}
-		fil_write_flushed_lsn(log_sys->lsn);
+		fil_write_flushed_lsn_to_data_files(log_sys->lsn);
 	}
 }
 

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -876,13 +876,24 @@ fil_set_max_space_id_if_bigger(
 /*===========================*/
 	ulint	max_id);/*!< in: maximum known id */
 #ifndef UNIV_HOTBACKUP
-/** Write the flushed LSN to the page header of the first page in the
+/****************************************************************//**
+Writes the flushed lsn to the page header of the first page of each
+data file in the system tablespace.
+@return	DB_SUCCESS or error number */
+dberr_t
+fil_write_flushed_lsn_to_data_files(
+/*================================*/
+	lsn_t	lsn);		/*!< in: lsn to write */
+
+/** Write the flushed LSN to the page header of the given page in the
 system tablespace.
 @param[in]	lsn	flushed LSN
+@param[in]	page_no	page number
 @return DB_SUCCESS or error number */
 dberr_t
 fil_write_flushed_lsn(
-	lsn_t	lsn);
+	lsn_t	lsn,
+	ulint	page_no);
 
 /** Acquire a tablespace when it could be dropped concurrently.
 Used by background threads that do not necessarily hold proper locks

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -2492,7 +2492,7 @@ loop:
 	srv_shutdown_lsn = lsn;
 
 	if (!srv_read_only_mode) {
-		fil_write_flushed_lsn(lsn);
+		fil_write_flushed_lsn_to_data_files(lsn);
 	}
 
 	fil_close_all_files();

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2138,7 +2138,7 @@ files_checked:
 
 		flushed_lsn = log_get_lsn();
 
-		fil_write_flushed_lsn(flushed_lsn);
+		fil_write_flushed_lsn_to_data_files(flushed_lsn);
 
 		create_log_files_rename(
 			logfilename, dirnamelen, flushed_lsn, logfile0);
@@ -2343,7 +2343,7 @@ files_checked:
 			RECOVERY_CRASH(3);
 
 			/* Stamp the LSN to the data files. */
-			fil_write_flushed_lsn(flushed_lsn);
+			fil_write_flushed_lsn_to_data_files(flushed_lsn);
 
 			RECOVERY_CRASH(4);
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7539,6 +7539,12 @@ next_node:
 
 	if (!xtrabackup_apply_log_only) {
 
+		/* xtrabackup_incremental_dir is used to indicate that
+		we are going to apply incremental backup. Here we already
+		applied incremental backup and are about to do final prepare
+		of the full backup */
+		xtrabackup_incremental_dir = NULL;
+
 		if(innodb_init_param()) {
 			goto error;
 		}

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6639,6 +6639,12 @@ next_node:
 
 	if (!xtrabackup_apply_log_only) {
 
+		/* xtrabackup_incremental_dir is used to indicate that
+		we are going to apply incremental backup. Here we already
+		applied incremental backup and are about to do final prepare
+		of the full backup */
+		xtrabackup_incremental_dir = NULL;
+
 		if(innodb_init_param()) {
 			goto error;
 		}

--- a/storage/innobase/xtrabackup/test/t/bug1669592.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1669592.sh
@@ -1,0 +1,37 @@
+#
+# Bug 1669592: xtrabackup --prepare --incremental-dir=... --target-dir=...
+#              creates redo logs in wrong directory
+#
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb-data-file-path=ibdata1:100M;ibdata2:10M:autoextend
+"
+
+start_server
+
+${MYSQL} ${MYSQL_ARGS} -e "CREATE TABLE t1 (id int primary key)" test
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (1)" test
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (2)" test
+
+xtrabackup --backup --target-dir=$topdir/backup-inc --incremental-basedir=$topdir/backup
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --incremental-dir=$topdir/backup-inc --target-dir=$topdir/backup
+
+test -f $topdir/backup/ib_logfile0 || die "Log files are not found in full backup directory"
+
+# force MySQL to check system tablespace for consistency
+rm -rf $topdir/backup/ib_logfile*
+
+stop_server
+
+rm -rf $mysql_datadir/*
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+${MYSQL} ${MYSQL_ARGS} -e "SELECT * FROM t1" test

--- a/storage/innobase/xtrabackup/test/t/bug1669592.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1669592.sh
@@ -1,0 +1,20 @@
+#
+# Bug 1669592: xtrabackup --prepare --incremental-dir=... --target-dir=...
+#              creates redo logs in wrong directory
+#
+
+start_server
+
+${MYSQL} ${MYSQL_ARGS} -e "CREATE TABLE t1 (id int primary key)" test
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (1)" test
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (2)" test
+
+xtrabackup --backup --target-dir=$topdir/backup-inc --incremental-basedir=$topdir/backup
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --incremental-dir=$topdir/backup-inc --target-dir=$topdir/backup
+
+test -f $topdir/backup/ib_logfile0 || die "Log files are not found in full backup directory"


### PR DESCRIPTION
Besides fixing the directory which xtrabackup creates redo logs in,
patch for 2.4 includes the changes in `fil_write_flushed_lsn` to make
it to write the flushed LSN to the page header of the first page of
**each** data file instead of 5.7's default behaviour when flushed LSN
is written to the first page of the first datafile only.

http://jenkins.percona.com/view/PXB%202.4/job/percona-xtrabackup-2.4-param/138/