### PR TITLE
Bug 1272329: innobackupex dies if a directory is not readable. i.e.: …

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -59,6 +59,8 @@ Created 10/25/1995 Heikki Tuuri
 static ulint srv_data_read, srv_data_written;
 #endif /* !UNIV_HOTBACKUP */
 
+my_bool check_if_skip_database_by_path(const char* name);
+
 /*
 		IMPLEMENTATION OF THE TABLESPACE MEMORY CACHE
 		=============================================
@@ -4670,9 +4672,14 @@ fil_load_single_table_tablespaces(ibool (*pred)(const char*, const char*))
 			    "%s/%s", fil_path_to_mysql_datadir, dbinfo.name);
 		srv_normalize_path_for_win(dbpath);
 
-		/* We want wrong directory permissions to be a fatal error for
-		XtraBackup. */
-		dbdir = os_file_opendir(dbpath, TRUE);
+		if (check_if_skip_database_by_path(dbpath)) {
+			fprintf(stderr, "Skipping db: %s\n", dbpath);
+			dbdir = NULL;
+		} else {
+			/* We want wrong directory permissions to be a fatal
+			error for XtraBackup. */
+			dbdir = os_file_opendir(dbpath, TRUE);
+		}
 
 		if (dbdir != NULL) {
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -262,6 +262,11 @@ datadir_iter_next_database(datadir_iter_t *it)
 			return(true);
 		}
 
+		if (check_if_skip_database_by_path(it->dbpath)) {
+			msg("Skipping db: %s\n", it->dbpath);
+			continue;
+		}
+
 		/* We want wrong directory permissions to be a fatal error for
 		XtraBackup. */
 		it->dbdir = os_file_opendir(it->dbpath, TRUE);

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1454,8 +1454,10 @@ write_xtrabackup_info(MYSQL *connection)
 		incremental_lsn, /* innodb_from_lsn */
 		metadata_to_lsn, /* innodb_to_lsn */
 		(xtrabackup_tables /* partial */
+		 || xtrabackup_tables_exclude
 		 || xtrabackup_tables_file
 		 || xtrabackup_databases
+		 || xtrabackup_databases_exclude
 		 || xtrabackup_databases_file) ? "Y" : "N",
 		xtrabackup_incremental ? "Y" : "N", /* incremental */
 		xb_stream_name[xtrabackup_stream_fmt], /* format */
@@ -1582,8 +1584,10 @@ write_xtrabackup_info(MYSQL *connection)
 	/* partial (Y | N) */
 	bind[idx].buffer_type = MYSQL_TYPE_STRING;
 	bind[idx].buffer = (char*)((xtrabackup_tables
+				    || xtrabackup_tables_exclude
 				    || xtrabackup_tables_file
 				    || xtrabackup_databases
+				    || xtrabackup_databases_exclude
 				    || xtrabackup_databases_file) ? "Y" : "N");
 	bind[idx].buffer_length = 1;
 	++idx;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -67,6 +67,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <srv0start.h>
 #include <buf0dblwr.h>
 
+#include <list>
 #include <sstream>
 #include <set>
 #include <mysql.h>
@@ -142,23 +143,21 @@ char xtrabackup_real_incremental_dir[FN_REFLEN];
 lsn_t xtrabackup_archived_to_lsn = 0; /* for --archived-to-lsn */
 
 char *xtrabackup_tables = NULL;
-
-/* List of regular expressions for filtering */
-typedef struct xb_regex_list_node_struct xb_regex_list_node_t;
-struct xb_regex_list_node_struct {
-	UT_LIST_NODE_T(xb_regex_list_node_t)	regex_list;
-	xb_regex_t				regex;
-};
-static UT_LIST_BASE_NODE_T(xb_regex_list_node_t) regex_list;
-
-static xb_regmatch_t tables_regmatch[1];
-
 char *xtrabackup_tables_file = NULL;
-static hash_table_t* tables_hash = NULL;
+char *xtrabackup_tables_exclude = NULL;
+
+typedef std::list<xb_regex_t> regex_list_t;
+static regex_list_t regex_include_list;
+static regex_list_t regex_exclude_list;
+
+static hash_table_t* tables_include_hash = NULL;
+static hash_table_t* tables_exclude_hash = NULL;
 
 char *xtrabackup_databases = NULL;
 char *xtrabackup_databases_file = NULL;
-static hash_table_t* databases_hash = NULL;
+char *xtrabackup_databases_exclude = NULL;
+static hash_table_t* databases_include_hash = NULL;
+static hash_table_t* databases_exclude_hash = NULL;
 
 static hash_table_t* inc_dir_tables_hash;
 
@@ -607,6 +606,8 @@ enum options_xtrabackup
   OPT_SSL_VERIFY_SERVER_CERT,
   OPT_SERVER_PUBLIC_KEY,
 
+  OPT_XTRA_TABLES_EXCLUDE,
+  OPT_XTRA_DATABASES_EXCLUDE,
 };
 
 struct my_option xb_client_options[] =
@@ -677,6 +678,16 @@ struct my_option xb_client_options[] =
    "filtering by list of databases in the file.",
    (G_PTR*) &xtrabackup_databases_file, (G_PTR*) &xtrabackup_databases_file,
    0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"tables-exclude", OPT_XTRA_TABLES_EXCLUDE, "filtering by regexp for table names. "
+  "Operates the same way as --tables, but matched names are excluded from backup. "
+  "Note that this option has a higher priority than --tables.",
+    (G_PTR*) &xtrabackup_tables_exclude, (G_PTR*) &xtrabackup_tables_exclude,
+    0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"databases-exclude", OPT_XTRA_DATABASES_EXCLUDE, "Excluding databases based on name, "
+  "Operates the same way as --databases, but matched names are excluded from backup. "
+  "Note that this option has a higher priority than --databases.",
+    (G_PTR*) &xtrabackup_databases_exclude, (G_PTR*) &xtrabackup_databases_exclude,
+    0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"create-ib-logfile", OPT_XTRA_CREATE_IB_LOGFILE, "** not work for now** creates ib_logfile* also after '--prepare'. ### If you want create ib_logfile*, only re-execute this command in same options. ###",
    (G_PTR*) &xtrabackup_create_ib_logfile, (G_PTR*) &xtrabackup_create_ib_logfile,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -2150,43 +2161,139 @@ xtrabackup_io_throttling(void)
 	}
 }
 
-/************************************************************************
-Checks if a given table name matches any of specifications in the --tables or
---tables-file options.
-
-@return TRUE on match. */
-static my_bool
-check_if_table_matches_filters(const char *name)
+static
+my_bool regex_list_check_match(
+	const regex_list_t& list,
+	const char* name)
 {
-	int 			regres;
-	xb_filter_entry_t*	table;
-	xb_regex_list_node_t*	node;
+	xb_regmatch_t tables_regmatch[1];
+	for (regex_list_t::const_iterator i = list.begin(), end = list.end();
+	     i != end; ++i) {
+		const xb_regex_t& regex = *i;
+		int regres = xb_regexec(&regex, name, 1, tables_regmatch, 0);
 
-	if (UT_LIST_GET_LEN(regex_list)) {
-		/* Check against regular expressions list */
-		for (node = UT_LIST_GET_FIRST(regex_list); node;
-		     node = UT_LIST_GET_NEXT(regex_list, node)) {
-			regres = xb_regexec(&node->regex, name, 1,
-					    tables_regmatch, 0);
-			if (regres != REG_NOMATCH) {
-
-				return(TRUE);
-			}
-		}
-	}
-
-	if (tables_hash) {
-		HASH_SEARCH(name_hash, tables_hash, ut_fold_string(name),
-			    xb_filter_entry_t*,
-			    table, (void) 0,
-			    !strcmp(table->name, name));
-		if (table) {
-
+		if (regres != REG_NOMATCH) {
 			return(TRUE);
 		}
 	}
-
 	return(FALSE);
+}
+
+static
+my_bool
+find_filter_in_hashtable(
+	const char* name,
+	hash_table_t* table,
+	xb_filter_entry_t** result
+)
+{
+	xb_filter_entry_t* found = NULL;
+	HASH_SEARCH(name_hash, table, ut_fold_string(name),
+		    xb_filter_entry_t*,
+		    found, (void) 0,
+		    !strcmp(found->name, name));
+
+	if (found && result) {
+		*result = found;
+	}
+	return (found != NULL);
+}
+
+/************************************************************************
+Checks if a given table name matches any of specifications given in
+regex_list or tables_hash.
+
+@return TRUE on match or both regex_list and tables_hash are empty.*/
+static my_bool
+check_if_table_matches_filters(const char *name,
+	const regex_list_t& regex_list,
+	hash_table_t* tables_hash)
+{
+	if (regex_list.empty() && !tables_hash) {
+		return(FALSE);
+	}
+
+	if (regex_list_check_match(regex_list, name)) {
+		return(TRUE);
+	}
+
+	if (tables_hash && find_filter_in_hashtable(name, tables_hash, NULL)) {
+		return(TRUE);
+	}
+
+	return FALSE;
+}
+
+enum skip_database_check_result {
+	DATABASE_SKIP,
+	DATABASE_SKIP_SOME_TABLES,
+	DATABASE_DONT_SKIP,
+	DATABASE_DONT_SKIP_UNLESS_EXPLICITLY_EXCLUDED,
+};
+
+/************************************************************************
+Checks if a database specified by name should be skipped from backup based on
+the --databases, --databases_file or --databases_exclude options.
+
+@return TRUE if entire database should be skipped,
+	FALSE otherwise.
+*/
+static
+skip_database_check_result
+check_if_skip_database(
+	const char* name  /*!< in: path to the database */
+)
+{
+	/* There are some filters for databases, check them */
+	xb_filter_entry_t*	database = NULL;
+
+	if (databases_exclude_hash &&
+		find_filter_in_hashtable(name, databases_exclude_hash,
+					 &database) &&
+		!database->has_tables) {
+		/* Database is found and there are no tables specified,
+		   skip entire db. */
+		return DATABASE_SKIP;
+	}
+
+	if (databases_include_hash) {
+		if (!find_filter_in_hashtable(name, databases_include_hash,
+					      &database)) {
+		/* Database isn't found, skip the database */
+			return DATABASE_SKIP;
+		} else if (database->has_tables) {
+			return DATABASE_SKIP_SOME_TABLES;
+		} else {
+			return DATABASE_DONT_SKIP_UNLESS_EXPLICITLY_EXCLUDED;
+		}
+	}
+
+	return DATABASE_DONT_SKIP;
+}
+
+/************************************************************************
+Checks if a database specified by path should be skipped from backup based on
+the --databases, --databases_file or --databases_exclude options.
+
+@return TRUE if the table should be skipped. */
+my_bool
+check_if_skip_database_by_path(
+	const char* path /*!< in: path to the db directory. */
+)
+{
+	if (databases_include_hash == NULL &&
+		databases_exclude_hash == NULL) {
+		return(FALSE);
+	}
+
+	const char* db_name = strrchr(path, SRV_PATH_SEPARATOR);
+	if (db_name == NULL) {
+		db_name = path;
+	} else {
+		++db_name;
+	}
+
+	return check_if_skip_database(db_name) == DATABASE_SKIP;
 }
 
 /************************************************************************
@@ -2205,9 +2312,12 @@ check_if_skip_table(
 	const char *ptr;
 	char *eptr;
 
-	if (UT_LIST_GET_LEN(regex_list) == 0 &&
-	    tables_hash == NULL &&
-	    databases_hash == NULL) {
+	if (regex_exclude_list.empty() &&
+		regex_include_list.empty() &&
+		tables_include_hash == NULL &&
+		tables_exclude_hash == NULL &&
+		databases_include_hash == NULL &&
+		databases_exclude_hash == NULL) {
 		return(FALSE);
 	}
 
@@ -2225,23 +2335,10 @@ check_if_skip_table(
 	strncpy(buf, dbname, FN_REFLEN);
 	buf[tbname - 1 - dbname] = 0;
 
-	if (databases_hash) {
-		/* There are some filters for databases, check them */
-		xb_filter_entry_t*	database;
-
-		HASH_SEARCH(name_hash, databases_hash, ut_fold_string(buf),
-			    xb_filter_entry_t*,
-			    database, (void) 0,
-			    !strcmp(database->name, buf));
-		/* Table's database isn't found, skip the table */
-		if (!database) {
-			return(TRUE);
-		}
-		/* There aren't tables specified for the database,
-		it should be backed up entirely */
-		if (!database->has_tables) {
-			return(FALSE);
-		}
+	const skip_database_check_result skip_database =
+			check_if_skip_database(buf);
+	if (skip_database == DATABASE_SKIP) {
+		return (TRUE);
 	}
 
 	buf[FN_REFLEN - 1] = '\0';
@@ -2258,21 +2355,43 @@ check_if_skip_table(
 	/* For partitioned tables first try to match against the regexp
 	without truncating the #P#... suffix so we can backup individual
 	partitions with regexps like '^test[.]t#P#p5' */
-	if (check_if_table_matches_filters(buf)) {
-
+	if (check_if_table_matches_filters(buf, regex_exclude_list,
+					   tables_exclude_hash)) {
+		return(TRUE);
+	}
+	if (check_if_table_matches_filters(buf, regex_include_list,
+					   tables_include_hash)) {
 		return(FALSE);
 	}
 	if ((eptr = strstr(buf, "#P#")) != NULL) {
-
 		*eptr = 0;
 
-		if (check_if_table_matches_filters(buf)) {
-
+		if (check_if_table_matches_filters(buf, regex_exclude_list,
+						   tables_exclude_hash)) {
+			return (TRUE);
+		}
+		if (check_if_table_matches_filters(buf, regex_include_list,
+						   tables_include_hash)) {
 			return(FALSE);
 		}
 	}
 
-	return(TRUE);
+	if (skip_database == DATABASE_DONT_SKIP_UNLESS_EXPLICITLY_EXCLUDED) {
+		/* Database is in include-list, and qualified name wasn't
+		   found in any of exclusion filters.*/
+		return (FALSE);
+	}
+
+	if (skip_database == DATABASE_SKIP_SOME_TABLES ||
+		!regex_include_list.empty() ||
+		tables_include_hash) {
+
+		/* Include lists are present, but qualified name
+		   failed to match any.*/
+		return(TRUE);
+	}
+
+	return(FALSE);
 }
 
 /***********************************************************************
@@ -3345,7 +3464,10 @@ static
 void
 xb_register_filter_entry(
 /*=====================*/
-	const char*	name)	/*!< in: name */
+	const char*	name,	/*!< in: name */
+	hash_table_t** databases_hash,
+	hash_table_t** tables_hash
+	)
 {
 	const char*		p;
 	size_t			namelen;
@@ -3361,23 +3483,43 @@ xb_register_filter_entry(
 		strncpy(dbname, name, p - name);
 		dbname[p - name] = 0;
 
-		if (databases_hash) {
-			HASH_SEARCH(name_hash, databases_hash,
+		if (*databases_hash) {
+			HASH_SEARCH(name_hash, (*databases_hash),
 					ut_fold_string(dbname),
 					xb_filter_entry_t*,
 					db_entry, (void) 0,
 					!strcmp(db_entry->name, dbname));
 		}
 		if (!db_entry) {
-			db_entry = xb_add_filter(dbname, &databases_hash);
+			db_entry = xb_add_filter(dbname, databases_hash);
 		}
 		db_entry->has_tables = TRUE;
-		xb_add_filter(name, &tables_hash);
+		xb_add_filter(name, tables_hash);
 	} else {
 		xb_validate_name(name, namelen);
 
-		xb_add_filter(name, &databases_hash);
+		xb_add_filter(name, databases_hash);
 	}
+}
+
+static
+void
+xb_register_include_filter_entry(
+	const char* name
+)
+{
+	xb_register_filter_entry(name, &databases_include_hash,
+				 &tables_include_hash);
+}
+
+static
+void
+xb_register_exclude_filter_entry(
+	const char* name
+)
+{
+	xb_register_filter_entry(name, &databases_exclude_hash,
+				 &tables_exclude_hash);
 }
 
 /***********************************************************************
@@ -3393,33 +3535,52 @@ xb_register_table(
 		exit(EXIT_FAILURE);
 	}
 
-	xb_register_filter_entry(name);
+	xb_register_include_filter_entry(name);
 }
 
-/***********************************************************************
-Register new regex for the filter.  */
 static
 void
-xb_register_regex(
-/*==============*/
-	const char* regex)	/*!< in: regex */
+xb_add_regex_to_list(
+	const char* regex,  /*!< in: regex */
+	const char* error_context,  /*!< in: context to error message */
+	regex_list_t* list) /*! in: list to put new regex to */
 {
-	xb_regex_list_node_t*	node;
 	char			errbuf[100];
 	int			ret;
 
-	node = static_cast<xb_regex_list_node_t *>
-		(ut_malloc(sizeof(xb_regex_list_node_t)));
+	xb_regex_t compiled_regex;
+	ret = xb_regcomp(&compiled_regex, regex, REG_EXTENDED);
 
-	ret = xb_regcomp(&node->regex, regex, REG_EXTENDED);
 	if (ret != 0) {
-		xb_regerror(ret, &node->regex, errbuf, sizeof(errbuf));
-		msg("xtrabackup: error: tables regcomp(%s): %s\n",
-			regex, errbuf);
+		xb_regerror(ret, &compiled_regex, errbuf, sizeof(errbuf));
+		msg("xtrabackup: error: %s regcomp(%s): %s\n",
+			error_context, regex, errbuf);
 		exit(EXIT_FAILURE);
 	}
 
-	UT_LIST_ADD_LAST(regex_list, regex_list, node);
+	list->push_back(compiled_regex);
+}
+
+/***********************************************************************
+Register new regex for the include filter.  */
+static
+void
+xb_register_include_regex(
+/*==============*/
+	const char* regex)	/*!< in: regex */
+{
+	xb_add_regex_to_list(regex, "tables", &regex_include_list);
+}
+
+/***********************************************************************
+Register new regex for the exclude filter.  */
+static
+void
+xb_register_exclude_regex(
+/*==============*/
+	const char* regex)	/*!< in: regex */
+{
+	xb_add_regex_to_list(regex, "tables-exclude", &regex_exclude_list);
 }
 
 typedef void (*insert_entry_func_t)(const char*);
@@ -3485,25 +3646,33 @@ static
 void
 xb_filters_init()
 {
-	UT_LIST_INIT(regex_list);
-
 	if (xtrabackup_databases) {
 		xb_load_list_string(xtrabackup_databases, " \t",
-					xb_register_filter_entry);
+				    xb_register_include_filter_entry);
 	}
 
 	if (xtrabackup_databases_file) {
 		xb_load_list_file(xtrabackup_databases_file,
-					xb_register_filter_entry);
+				  xb_register_include_filter_entry);
+	}
+
+	if (xtrabackup_databases_exclude) {
+		xb_load_list_string(xtrabackup_databases_exclude, " \t",
+				    xb_register_exclude_filter_entry);
 	}
 
 	if (xtrabackup_tables) {
 		xb_load_list_string(xtrabackup_tables, ",",
-					xb_register_regex);
+				    xb_register_include_regex);
 	}
 
 	if (xtrabackup_tables_file) {
 		xb_load_list_file(xtrabackup_tables_file, xb_register_table);
+	}
+
+	if (xtrabackup_tables_exclude) {
+		xb_load_list_string(xtrabackup_tables_exclude, ",",
+				    xb_register_exclude_regex);
 	}
 }
 
@@ -3536,25 +3705,37 @@ xb_filter_hash_free(hash_table_t* hash)
 	hash_table_free(hash);
 }
 
+static void xb_regex_list_free(regex_list_t* list)
+{
+	while (list->size() > 0) {
+		xb_regfree(&list->front());
+		list->pop_front();
+	}
+}
+
 /************************************************************************
 Destroy table filters for partial backup. */
 static
 void
 xb_filters_free()
 {
-	while (UT_LIST_GET_LEN(regex_list) > 0) {
-		xb_regex_list_node_t*	node = UT_LIST_GET_FIRST(regex_list);
-		UT_LIST_REMOVE(regex_list, regex_list, node);
-		xb_regfree(&node->regex);
-		ut_free(node);
+	xb_regex_list_free(&regex_include_list);
+	xb_regex_list_free(&regex_exclude_list);
+
+	if (tables_include_hash) {
+		xb_filter_hash_free(tables_include_hash);
 	}
 
-	if (tables_hash) {
-		xb_filter_hash_free(tables_hash);
+	if (tables_exclude_hash) {
+		xb_filter_hash_free(tables_exclude_hash);
 	}
 
-	if (databases_hash) {
-		xb_filter_hash_free(databases_hash);
+	if (databases_include_hash) {
+		xb_filter_hash_free(databases_include_hash);
+	}
+
+	if (databases_exclude_hash) {
+		xb_filter_hash_free(databases_exclude_hash);
 	}
 }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -79,6 +79,8 @@ extern char		*xtrabackup_tables;
 extern char		*xtrabackup_tables_file;
 extern char		*xtrabackup_databases;
 extern char		*xtrabackup_databases_file;
+extern char		*xtrabackup_tables_exclude;
+extern char		*xtrabackup_databases_exclude;
 
 extern my_bool		xtrabackup_compact;
 extern ibool		xtrabackup_compress;
@@ -210,6 +212,17 @@ my_bool
 check_if_skip_table(
 /******************/
 	const char*	name);	/*!< in: path to the table */
+
+
+/************************************************************************
+Checks if a database specified by path should be skipped from backup based on
+the --databases, --databases_file or --databases_exclude options.
+
+@return TRUE if the table should be skipped. */
+my_bool
+check_if_skip_database_by_path(
+	const char* path /*!< in: path to the db directory. */
+);
 
 /************************************************************************
 Check if parameter is set in defaults file or via command line argument

--- a/storage/innobase/xtrabackup/test/t/xb_databases_options.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_databases_options.sh
@@ -3,9 +3,11 @@
 #
 # Test following xtrabackup options
 # --databases
+# --databases-exclude
 # --databases-file
 # --tables
 # --tables-file
+# --tables-exclude
 ########################################################################
 
 . inc/common.sh
@@ -14,96 +16,78 @@ start_server --innodb-file-per-table
 
 function setup_test {
 
-	cat <<EOF | run_cmd $MYSQL $MYSQL_ARGS
+	local databases="database1 database2 test1 test2 thisisadatabase testdatabase"
+	local tables="thisisatable t t1 t2 ancor glow"
 
-		create database database1;
-		create database database2;
-		create database test1;
-		create database test2;
-		create database thisisadatabase;
-		create database testdatabase;
-
-		create table database1.thisisatable (a int primary key) engine=InnoDB;
-		create table database1.t (a int primary key) engine=InnoDB;
-		create table database1.t1 (a int primary key) engine=InnoDB;
-		create table database1.t2 (a int primary key) engine=InnoDB;
-		create table database1.ancor (a int primary key) engine=InnoDB;
-		create table database1.glow (a int primary key) engine=InnoDB;
-
-		create table database2.thisisatable (a int primary key) engine=InnoDB;
-		create table database2.t (a int primary key) engine=InnoDB;
-		create table database2.t1 (a int primary key) engine=InnoDB;
-		create table database2.t2 (a int primary key) engine=InnoDB;
-		create table database2.ancor (a int primary key) engine=InnoDB;
-		create table database2.glow (a int primary key) engine=InnoDB;
-
-		create table test1.thisisatable (a int primary key) engine=InnoDB;
-		create table test1.t (a int primary key) engine=InnoDB;
-		create table test1.t1 (a int primary key) engine=InnoDB;
-		create table test1.t2 (a int primary key) engine=InnoDB;
-		create table test1.ancor (a int primary key) engine=InnoDB;
-		create table test1.glow (a int primary key) engine=InnoDB;
-
-		create table test2.thisisatable (a int primary key) engine=InnoDB;
-		create table test2.t (a int primary key) engine=InnoDB;
-		create table test2.t1 (a int primary key) engine=InnoDB;
-		create table test2.t2 (a int primary key) engine=InnoDB;
-		create table test2.ancor (a int primary key) engine=InnoDB;
-		create table test2.glow (a int primary key) engine=InnoDB;
-
-		create table thisisadatabase.thisisatable (a int primary key) engine=InnoDB;
-		create table thisisadatabase.t (a int primary key) engine=InnoDB;
-		create table thisisadatabase.t1 (a int primary key) engine=InnoDB;
-		create table thisisadatabase.t2 (a int primary key) engine=InnoDB;
-		create table thisisadatabase.ancor (a int primary key) engine=InnoDB;
-		create table thisisadatabase.glow (a int primary key) engine=InnoDB;
-
-		create table testdatabase.thisisatable (a int primary key) engine=InnoDB;
-		create table testdatabase.t (a int primary key) engine=InnoDB;
-		create table testdatabase.t1 (a int primary key) engine=InnoDB;
-		create table testdatabase.t2 (a int primary key) engine=InnoDB;
-		create table testdatabase.ancor (a int primary key) engine=InnoDB;
-		create table testdatabase.glow (a int primary key) engine=InnoDB;
-
-EOF
-
+	NEWLINE=$(printf '\n')
+	for db in $databases
+	do
+		cmd="create database $db;$NEWLINE$NEWLINE"
+		for table in $tables
+		do
+			cmd+="create table $db.$table (a int primary key) engine=InnoDB;$NEWLINE"
+		done
+		echo "$cmd" | run_cmd $MYSQL $MYSQL_ARGS
+	done
 }
 
 function ls_dir {
 	( cd $1 ; find . -name '*.ibd' -type f | sort -d )
 }
 
+function expect_dir_contents {
+	local contents_diff
+	contents_diff=`diff -U0 --label "expected" <(cat /dev/stdin) --label "actual" <(ls_dir "$1")`
+	if [ $? -ne 0 ]; then
+		echo "Actual contents of $1 does not match expected, diff: $contents_diff"
+		exit -1
+	fi
+}
+
 setup_test
 
+very_long_name=verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow
 backup_dir=$topdir/backup_dir
+ignored_dir=to_be_ignored_on_backup
+ignored_dir_full_path=$mysql_datadir/$ignored_dir
+
 mkdir -p $backup_dir
 
 # invalid characters
 xtrabackup --backup --databases=a/b/c --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is not valid'
 
 # too long name
-xtrabackup --backup --databases=verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
+xtrabackup --backup --databases=$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
 
 # too long name
-xtrabackup --backup --databases=test1.verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
+xtrabackup --backup --databases=test1.$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
+
+# too long name
+xtrabackup --backup --databases-exclude=$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
+
+# too long name
+xtrabackup --backup --databases-exclude=test1.$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
 
 # not fully qualified name
-xtrabackup --backup --tables-file=<(echo verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow) --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is not fully qualified'
+xtrabackup --backup --tables-file=<(echo $very_long_name) --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is not fully qualified'
 
 # again too long name
-xtrabackup --backup --tables-file=<(echo test1.verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow) --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
+xtrabackup --backup --tables-file=<(echo test1.$very_long_name) --target-dir=$backup_dir --datadir=$mysql_datadir 2>&1 | grep 'is too long'
 
 # should go fine, we cannot validate regex against length
-xtrabackup --backup --tables=verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow --target-dir=$backup_dir --datadir=$mysql_datadir
+xtrabackup --backup --tables=$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir
 rm -rf $backup_dir/*
 
 # should go fine, we cannot validate regex against length
-xtrabackup --backup --tables=test1.verylonglonglongname111111skjhkdjhfkjdhgkjdfh1555555555555511stillnotlongenoughsowilladdmore1111111111111111111114848484848484fkjhdjfhkdjfhd8484848aaaaaaaaaancnvjvifmifjhfkmfkfnbfifnfkfik4848484841111111prettyenoughnow --target-dir=$backup_dir --datadir=$mysql_datadir
+xtrabackup --backup --tables=test1.$very_long_name --target-dir=$backup_dir --datadir=$mysql_datadir
 rm -rf $backup_dir/*
 
 vlog "Testing with --databases=..."
-$XB_BIN $XB_ARGS --backup --databases='database database2 test1.t test1.ancor thisisadatabase testdatabase.t testdatabase.t7' --target-dir=$backup_dir --datadir=$mysql_datadir
-diff -u <(ls_dir $backup_dir) - <<EOF
+xtrabackup --backup \
+	--databases='database database2 test1.t test1.ancor thisisadatabase testdatabase.t testdatabase.t7' \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+
+expect_dir_contents $backup_dir <<EOF
 ./database2/ancor.ibd
 ./database2/glow.ibd
 ./database2/t1.ibd
@@ -132,8 +116,10 @@ thisisadatabase
 testdatabase.t
 testdatabase.t7
 EOF
-xtrabackup --backup --databases-file=$topdir/list --target-dir=$backup_dir --datadir=$mysql_datadir
-diff -u <(ls_dir $backup_dir) - <<EOF
+xtrabackup --backup \
+	--databases-file=$topdir/list \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
 ./database2/ancor.ibd
 ./database2/glow.ibd
 ./database2/t1.ibd
@@ -162,8 +148,10 @@ thisisadatabase
 testdatabase.t
 testdatabase.t7
 EOF
-run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --tables-file=$topdir/list --target-dir=$backup_dir --datadir=$mysql_datadir
-diff -u <(ls_dir $backup_dir) - <<EOF
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup \
+	--tables-file=$topdir/list \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
 EOF
 rm -rf $backup_dir/*
 
@@ -174,8 +162,10 @@ test1.ancor
 testdatabase.t
 testdatabase.t7
 EOF
-xtrabackup --backup --tables-file=$topdir/list --target-dir=$backup_dir --datadir=$mysql_datadir
-diff -u <(ls_dir $backup_dir) - <<EOF
+xtrabackup --backup \
+	--tables-file=$topdir/list \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
 ./test1/ancor.ibd
 ./test1/t.ibd
 ./testdatabase/t.ibd
@@ -183,8 +173,10 @@ EOF
 rm -rf $backup_dir/*
 
 vlog "Testing with --tables=..."
-xtrabackup --backup --tables='dat.base,test1.t,test1.a' --target-dir=$backup_dir --datadir=$mysql_datadir
-diff -u <(ls_dir $backup_dir) - <<EOF
+xtrabackup --backup \
+	--tables='dat.base,test1.t,test1.a' \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
 ./database1/ancor.ibd
 ./database1/glow.ibd
 ./database1/t1.ibd
@@ -216,3 +208,69 @@ diff -u <(ls_dir $backup_dir) - <<EOF
 ./thisisadatabase/t.ibd
 EOF
 rm -rf $backup_dir/*
+
+vlog "Testing with --tables-exclude=..."
+xtrabackup --backup \
+	--tables-exclude='ancor,glow,test,thisisa.*,ignore,mysql.*' \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
+./database1/t1.ibd
+./database1/t2.ibd
+./database1/t.ibd
+./database2/t1.ibd
+./database2/t2.ibd
+./database2/t.ibd
+EOF
+rm -rf $backup_dir/*
+
+vlog "Testing with both --tables and --tables-exclude=..."
+xtrabackup --backup \
+	--tables='ancor,glow,test,thisisa.*,ignore,t.*,mysql.*' \
+	--tables-exclude='ancor,glow,test,thisisa.*,ignore,mysql.*' \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+expect_dir_contents $backup_dir <<EOF
+./database1/t1.ibd
+./database1/t2.ibd
+./database1/t.ibd
+./database2/t1.ibd
+./database2/t2.ibd
+./database2/t.ibd
+EOF
+rm -rf $backup_dir/*
+
+
+# Bug #1272329: innobackupex dies if a directory is not readable. i.e.: lost+found
+# https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1272329
+vlog "Adding unreadable directory"
+mkdir $ignored_dir_full_path
+chmod 000 $ignored_dir_full_path
+
+vlog "Testing failure with ureadable directory"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+rm -rf $backup_dir/*
+
+vlog "Testing with --databases-exclude=..."
+xtrabackup --backup \
+	--databases-exclude=$ignored_dir \
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+rm -rf $backup_dir/*
+
+vlog "Testing with both --databases=... and --databases-exclude=..."
+xtrabackup --backup \
+	--databases="database database2 ignore_db $ignored_dir" \
+	--databases-exclude="ignore_db $ignored_dir database2.ancor"\
+	--target-dir=$backup_dir --datadir=$mysql_datadir
+
+expect_dir_contents $backup_dir <<EOF
+./database2/glow.ibd
+./database2/t1.ibd
+./database2/t2.ibd
+./database2/thisisatable.ibd
+./database2/t.ibd
+EOF
+rm -rf $backup_dir/*
+
+vlog "Removing unreadable directory"
+chmod 777 $ignored_dir_full_path
+rm -rf $ignored_dir_full_path/*


### PR DESCRIPTION
…lost+found

Introducing new options: --tables-exclude and --databases-exclude that work
similary to --tables and --databases, but exclude given names/paths from backup.
Updated a xb_databases_options test to verify new options interoperation with existing ones.

Unreadable directory can now be excluded with --databases-exclude=path, see test for details.

Param-build: http://jenkins.percona.com/view/PXB%202.3/job/percona-xtrabackup-2.3-param/245/