### PR TITLE
Bug 1664405: Change default for innodb_checksum_algorithm in 2.4

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -32,6 +32,7 @@ typedef enum {REDO_LOG_V0, REDO_LOG_V1} redo_log_version_t;
 extern ulint redo_log_version;
 
 extern bool innodb_log_checksum_algorithm_specified;
+extern bool innodb_checksum_algorithm_specified;
 
 /******************************************************************************
 Callback used in buf_page_io_complete() to detect compacted pages.

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -389,6 +389,7 @@ get_mysql_vars(MYSQL *connection)
 	char *innodb_page_size_var = NULL;
 	char *innodb_log_checksums_var = NULL;
 	char *innodb_log_checksum_algorithm_var = NULL;
+	char *innodb_checksum_algorithm_var = NULL;
 
 	unsigned long server_version = mysql_get_server_version(connection);
 
@@ -420,6 +421,7 @@ get_mysql_vars(MYSQL *connection)
 		{"innodb_log_checksums", &innodb_log_checksums_var},
 		{"innodb_log_checksum_algorithm",
 			&innodb_log_checksum_algorithm_var},
+		{"innodb_checksum_algorithm", &innodb_checksum_algorithm_var},
 		{NULL, NULL}
 	};
 
@@ -573,6 +575,19 @@ get_mysql_vars(MYSQL *connection)
 			    innodb_checksum_algorithm_typelib.type_names[i])
 			    == 0) {
 				srv_log_checksum_algorithm = i;
+			}
+		}
+	}
+
+	if (!innodb_checksum_algorithm_specified &&
+		innodb_checksum_algorithm_var) {
+		for (uint i = 0;
+		     i < innodb_checksum_algorithm_typelib.count;
+		     i++) {
+			if (strcasecmp(innodb_checksum_algorithm_var,
+			    innodb_checksum_algorithm_typelib.type_names[i])
+			    == 0) {
+				srv_checksum_algorithm = i;
 			}
 		}
 	}


### PR DESCRIPTION
MySQL 5.6 using "INNODB" checksums for datafiles pages which is slow.
MySQL 5.7 using CRC32-C hecksums for datafiles pages which can be
accelerated using Intel's crc32 instructions. xtrabackup defaults to
INNODB. When xtrabackup found checksum mismatch it trying another
algorithm. As a result when xtrabackup copies MySQL 5.7 datafile it
calculates two checkums for each page.

With this patch xtrabackup in backup mode will try to read checksum
algorithm from running server. In prepare mode it will try to guess
checksum algorithm looking at redo log format when it is not found in
`backup-my.cnf`.