### PR TITLE
Parallel extraction for xbstream

### DIFF
--- a/storage/innobase/xtrabackup/src/xbstream.h
+++ b/storage/innobase/xtrabackup/src/xbstream.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2013 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2017 Percona LLC and/or its affiliates.
 
 The xbstream format interface.
 
@@ -89,8 +89,10 @@ typedef struct {
 	char		path[FN_REFLEN];
 	size_t		length;
 	my_off_t	offset;
+	my_off_t	checksum_offset;
 	void		*data;
 	ulong		checksum;
+	size_t		buflen;
 } xb_rstream_chunk_t;
 
 xb_rstream_t *xb_stream_read_new(void);
@@ -99,5 +101,7 @@ xb_rstream_result_t xb_stream_read_chunk(xb_rstream_t *stream,
 					 xb_rstream_chunk_t *chunk);
 
 int xb_stream_read_done(xb_rstream_t *stream);
+
+int xb_stream_validate_checksum(xb_rstream_chunk_t *chunk);
 
 #endif

--- a/storage/innobase/xtrabackup/src/xbstream_read.c
+++ b/storage/innobase/xtrabackup/src/xbstream_read.c
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2013 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2017 Percona LLC and/or its affiliates.
 
 The xbstream format reader implementation.
 
@@ -34,8 +34,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 struct xb_rstream_struct {
 	my_off_t	offset;
 	File 		fd;
-	void 		*buffer;
-	size_t		buflen;
 };
 
 xb_rstream_t *
@@ -44,9 +42,6 @@ xb_stream_read_new(void)
 	xb_rstream_t *stream;
 
 	stream = (xb_rstream_t *) my_malloc(sizeof(xb_rstream_t), MYF(MY_FAE));
-
-	stream->buffer = my_malloc(INIT_BUFFER_LEN, MYF(MY_FAE));
-	stream->buflen = INIT_BUFFER_LEN;
 
 	stream->fd = fileno(stdin);
 	stream->offset = 0;
@@ -71,6 +66,23 @@ validate_chunk_type(uchar code)
 	}
 }
 
+int
+xb_stream_validate_checksum(xb_rstream_chunk_t *chunk)
+{
+	ulong	checksum;
+
+	checksum = crc32(0, chunk->data, chunk->length);
+	if (checksum != chunk->checksum) {
+		msg("xb_stream_read_chunk(): invalid checksum at offset "
+		    "0x%llx: expected 0x%lx, read 0x%lx.\n",
+		    (ulonglong) chunk->checksum_offset, chunk->checksum,
+		    checksum);
+		return XB_STREAM_READ_ERROR;
+	}
+
+	return XB_STREAM_READ_CHUNK;
+}
+
 #define F_READ(buf,len)                                       	\
 	do {                                                      	\
 		if (xb_read_full(fd, buf, len) < len) {	\
@@ -87,8 +99,6 @@ xb_stream_read_chunk(xb_rstream_t *stream, xb_rstream_chunk_t *chunk)
 	uint		pathlen;
 	size_t		tbytes;
 	ulonglong	ullval;
-	ulong		checksum_exp;
-	ulong		checksum;
 	File		fd = stream->fd;
 
 	xb_ad(sizeof(tmpbuf) >= CHUNK_HEADER_CONSTANT_LEN);
@@ -178,38 +188,29 @@ xb_stream_read_chunk(xb_rstream_t *stream, xb_rstream_chunk_t *chunk)
 	stream->offset += 8;
 
 	/* Reallocate the buffer if needed */
-	if (chunk->length > stream->buflen) {
-		stream->buffer = my_realloc(stream->buffer, chunk->length,
-					    MYF(MY_WME));
-		if (stream->buffer == NULL) {
+	if (chunk->length > chunk->buflen) {
+		chunk->data = my_realloc(chunk->data, chunk->length,
+					 MYF(MY_WME | MY_ALLOW_ZERO_PTR));
+		if (chunk->data == NULL) {
 			msg("xb_stream_read_chunk(): failed to increase buffer "
 			    "to %lu bytes.\n", (ulong) chunk->length);
 			goto err;
 		}
-		stream->buflen = chunk->length;
+		chunk->buflen = chunk->length;
 	}
 
 	/* Checksum */
 	F_READ(tmpbuf, 4);
-	checksum_exp = uint4korr(tmpbuf);
+	chunk->checksum = uint4korr(tmpbuf);
+	chunk->checksum_offset = stream->offset;
 
 	/* Payload */
 	if (chunk->length > 0) {
-		F_READ(stream->buffer, chunk->length);
+		F_READ(chunk->data, chunk->length);
 		stream->offset += chunk->length;
 	}
 
-	checksum = crc32(0, stream->buffer, chunk->length);
-	if (checksum != checksum_exp) {
-		msg("xb_stream_read_chunk(): invalid checksum at offset "
-		    "0x%llx: expected 0x%lx, read 0x%lx.\n",
-		    (ulonglong) stream->offset, checksum_exp, checksum);
-		goto err;
-	}
 	stream->offset += 4;
-
-	chunk->data = stream->buffer;
-	chunk->checksum = checksum;
 
 	return XB_STREAM_READ_CHUNK;
 
@@ -220,7 +221,6 @@ err:
 int
 xb_stream_read_done(xb_rstream_t *stream)
 {
-	my_free(stream->buffer);
 	my_free(stream);
 
 	return 0;

--- a/storage/innobase/xtrabackup/src/xbstream_write.c
+++ b/storage/innobase/xtrabackup/src/xbstream_write.c
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2013 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2017 Percona LLC and/or its affiliates.
 
 The xbstream format writer implementation.
 
@@ -203,12 +203,13 @@ xb_stream_write_chunk(xb_wstream_file_t *file, const void *buf, size_t len)
 	int8store(ptr, len);                     /* Payload length */
 	ptr += 8;
 
+	checksum = crc32(0, buf, len);           /* checksum */
+
 	pthread_mutex_lock(&stream->mutex);
 
 	int8store(ptr, file->offset);            /* Payload offset */
 	ptr += 8;
 
-	checksum = crc32(0, buf, len);           /* checksum */
 	int4store(ptr, checksum);
 	ptr += 4;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1,6 +1,6 @@
 /******************************************************
 XtraBackup: hot backup tool for InnoDB
-(c) 2009-2015 Percona LLC and/or its affiliates
+(c) 2009-2017 Percona LLC and/or its affiliates
 Originally Created 3/3/2009 Yasufumi Kinoshita
 Written by Alexey Kopytov, Aleksandr Kuzminsky, Stewart Smith, Vadim Tkachenko,
 Yasufumi Kinoshita, Ignacio Nin and Baron Schwartz.
@@ -1028,8 +1028,8 @@ struct my_option xb_server_options[] =
    (G_PTR*) &opt_mysql_tmpdir,
    (G_PTR*) &opt_mysql_tmpdir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"parallel", OPT_XTRA_PARALLEL,
-   "Number of threads to use for parallel datafiles transfer. Does not have "
-   "any effect in the stream mode. The default value is 1.",
+   "Number of threads to use for parallel datafiles transfer. "
+   "The default value is 1.",
    (G_PTR*) &xtrabackup_parallel, (G_PTR*) &xtrabackup_parallel, 0, GET_INT,
    REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
 

--- a/storage/innobase/xtrabackup/test/t/ib_stream_parallel.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_stream_parallel.sh
@@ -3,7 +3,7 @@
 ############################################################################
 
 stream_format=xbstream
-stream_extract_cmd="xbstream -xv <"
+stream_extract_cmd="xbstream -xv --parallel=16 <"
 innobackupex_options="--parallel=16"
 
 . inc/ib_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/ib_stream_parallel_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_stream_parallel_encrypt.sh
@@ -6,7 +6,7 @@
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 stream_format=xbstream
-stream_extract_cmd="(xbstream -xv ; innobackupex --decrypt=$encrypt_algo --encrypt-key=$encrypt_key ./) <"
+stream_extract_cmd="(xbstream -xv --parallel=16; innobackupex --decrypt=$encrypt_algo --encrypt-key=$encrypt_key ./) <"
 innobackupex_options="--parallel=16 --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
 . inc/ib_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_parallel.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_parallel.sh
@@ -3,7 +3,7 @@
 ############################################################################
 
 stream_format=xbstream
-stream_extract_cmd="xbstream -xv <"
+stream_extract_cmd="xbstream -xv --parallel=16 <"
 xtrabackup_options="--parallel=16"
 
 . inc/xb_stream_common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_stream_parallel_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stream_parallel_encrypt.sh
@@ -6,7 +6,7 @@
 encrypt_algo="AES256"
 encrypt_key="percona_xtrabackup_is_awesome___"
 stream_format=xbstream
-stream_extract_cmd="(xbstream -xv ; xtrabackup --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --target-dir=./) <"
+stream_extract_cmd="(xbstream -xv --parallel=16; xtrabackup --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --target-dir=./) <"
 xtrabackup_options="--parallel=16 --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
 . inc/xb_stream_common.sh


### PR DESCRIPTION
This patch added `--parallel=N` option for `xbstream`. When
specified, N worker threads are created, each reading next chunk from
input stream and writing it to destination file. While reading from
input stream is serialized, writing in two different files can be
done it parallel, which allows to squeeze maximum out of SSD/HDD
given that input pipe is fast enough.