### PR TITLE
Bug 1651978: Unrecognized character \x01; marked by <-- HERE

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2041,7 +2041,7 @@ version_check()
 		return;
 	}
 
-	fputs((const char *)version_check_pl, pipe);
+	fwrite((const char *) version_check_pl, version_check_pl_len, 1, pipe);
 
 	pclose(pipe);
 }


### PR DESCRIPTION
`version_check_pl` does not contain trailing zero character and thus
cannot be safely output by `fputs` which adds garbage characters at the
end of the `version_check' code.

The fix is to use known length of `version_check_pl` and pass it to perl
interpreter by using `fwrite`.