### PR TITLE
Bug: 1678838: compilation error: format '%s' expects argument of type…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7559,7 +7559,7 @@ skip_check:
 				    "than 31 indexes, .exp file was not "
 				    "generated. Table will fail to import "
 				    "on server version prior to 5.6.\n",
-				    table->name);
+				    table_name);
 				goto next_node;
 			}
 


### PR DESCRIPTION
… 'char*'

Using table_name instead of table->name, issue was intriduced by merge from 2.3

Param-build http://jenkins.percona.com/view/PXB%202.3/job/percona-xtrabackup-2.4-param/153/