### PR TITLE
Bug 1394493: need warning when encountering TokuDB tables

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -376,6 +376,7 @@ my_bool opt_noversioncheck = FALSE;
 my_bool opt_no_backup_locks = FALSE;
 my_bool opt_decompress = FALSE;
 my_bool opt_remove_original = FALSE;
+my_bool opt_tables_compatibility_check = TRUE;
 
 static const char *binlog_info_values[] = {"off", "lockless", "on", "auto",
 					   NullS};
@@ -661,6 +662,8 @@ enum options_xtrabackup
 
   OPT_XTRA_TABLES_EXCLUDE,
   OPT_XTRA_DATABASES_EXCLUDE,
+
+  OPT_XTRA_TABLES_COMPATIBILITY_CHECK,
 };
 
 struct my_option xb_client_options[] =
@@ -905,6 +908,13 @@ struct my_option xb_client_options[] =
    (uchar *) &opt_noversioncheck,
    (uchar *) &opt_noversioncheck,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+  {"tables-compatibility-check", OPT_XTRA_TABLES_COMPATIBILITY_CHECK,
+   "This option enables engine compatibility warning.",
+   (uchar *) & opt_tables_compatibility_check,
+   (uchar *) & opt_tables_compatibility_check,
+   0, GET_BOOL, NO_ARG, TRUE, 0, 0, 0, 0, 0},
+
 
   {"no-backup-locks", OPT_NO_BACKUP_LOCKS, "This option controls if "
    "backup locks should be used instead of FLUSH TABLES WITH READ LOCK "
@@ -4325,6 +4335,41 @@ end:
 #endif
 }
 
+/**************************************************************************
+Prints a warning for every table that uses unsupported engine and
+hence will not be backed up. */
+static void
+xb_tables_compatibility_check()
+{
+	const char* query = "SELECT\n"
+			    "  CONCAT(table_schema, '/', table_name), engine\n"
+			    "FROM information_schema.tables\n"
+			    "WHERE engine NOT IN (\n"
+			    "  'MyISAM', 'InnoDB', 'CSV', 'MRG_MYISAM'\n"
+			    ")\n"
+			    "AND table_schema NOT IN (\n"
+			    "  'performance_schema', 'information_schema',"
+			    "  'mysql'\n"
+			    ");";
+
+	MYSQL_RES* result = xb_mysql_query(mysql_connection, query, true, true);
+	MYSQL_ROW row;
+	if (!result) {
+		return;
+	}
+
+	ut_a(mysql_num_fields(result) == 2);
+	while ((row = mysql_fetch_row(result))) {
+		if (!check_if_skip_table(row[0])) {
+			*strchr(row[0], '/') = '.';
+			msg("Warning: \"%s\" uses engine \"%s\" "
+			    "and will not be backed up.\n", row[0], row[1]);
+		}
+	}
+
+	mysql_free_result(result);
+}
+
 void
 xtrabackup_backup_func(void)
 {
@@ -4438,6 +4483,10 @@ xtrabackup_backup_func(void)
 	xb_keyring_init(xb_keyring_file_data);
 
 	xb_filters_init();
+
+	if (opt_tables_compatibility_check) {
+		xb_tables_compatibility_check();
+	}
 
 	{
 	ibool	log_file_created;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -133,6 +133,7 @@ extern my_bool		opt_noversioncheck;
 extern my_bool		opt_no_backup_locks;
 extern my_bool		opt_decompress;
 extern my_bool		opt_remove_original;
+extern my_bool		opt_no_tables_compatibility_check;
 
 extern char		*opt_incremental_history_name;
 extern char		*opt_incremental_history_uuid;

--- a/storage/innobase/xtrabackup/test/t/bug1394493.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1394493.sh
@@ -1,0 +1,51 @@
+############################################################################
+# Bug1394493: need warning when encountering TokuDB tables
+############################################################################
+
+. inc/common.sh
+
+require_tokudb
+
+start_server_with_tokudb
+
+mysql <<EOF
+CREATE DATABASE testdb;
+CREATE TABLE testdb.t (a INT PRIMARY KEY) ENGINE=TokuDB;
+INSERT INTO testdb.t VALUES (1), (2), (3);
+EOF
+
+vlog "Checking that warning is printed out"
+xtrabackup --backup --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb.log
+if ! grep -q 'Warning: "testdb.t" uses engine "TokuDB" and will not be backed up.' $topdir/pxb.log
+then
+	die "xtrabackup should print a warning."
+fi
+
+run_cmd rm -rf $topdir/backup
+
+vlog "Suppressing warning"
+xtrabackup --backup --target-dir=$topdir/backup \
+	--skip-tables-compatibility-check \
+	2>&1 \
+	| tee $topdir/pxb.log
+
+if grep -q 'Warning: "testdb.t" uses engine "TokuDB" and will not be backed up.' $topdir/pxb.log
+then
+	die "xtrabackup should NOT print a warning."
+fi
+
+run_cmd rm -rf $topdir/backup
+
+vlog "No warning when TokuDB table is not backed up"
+xtrabackup --backup \
+	--target-dir=$topdir/backup \
+	--databases=foo 2>&1 \
+	| tee $topdir/pxb.log
+
+if grep -q 'Warning: "testdb.t" uses engine "TokuDB" and will not be backed up.' $topdir/pxb.log
+then
+	die "xtrabackup should NOT print a warning."
+fi
+
+# All done, reset an $? set to 1 by grep.
+vlog "Done !"


### PR DESCRIPTION
Added a function that prints a warning and detailed info
if there are аny tables with unsupported engines.
Added an option no-tables-compatibility-check to suppress it.