### PR TITLE
Bug 1551634: xtrabackup --slave-info does not handle multi-master replication

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -831,20 +831,33 @@ datafile_rsync_backup(const char *filepath, bool save_to_list, FILE *f)
 
 static
 bool
-backup_file_vprintf(const char *filename, const char *fmt, va_list ap)
+backup_ds_print(ds_file_t *dstfile, const char *message, int len)
+{
+	const char *action = xb_get_copy_action("Writing");
+	msg_ts("[%02u] %s %s\n", 0, action, dstfile->path);
+
+	if (ds_write(dstfile, message, len)) {
+		goto error;
+	}
+
+	msg_ts("[%02u]        ...done\n", 0);
+	return true;
+
+error:
+	msg("[%02u] Error: %s backup file failed.\n", 0, action);
+	return false;
+}
+
+static
+bool
+backup_file_print(const char *filename, const char *message, int len)
 {
 	ds_file_t	*dstfile	= NULL;
-	MY_STAT		 stat;			/* unused for now */
-	char		*buf		= 0;
-	int		 buf_len;
-	const char	*action;
+	MY_STAT		 stat;
 
 	memset(&stat, 0, sizeof(stat));
-
-	buf_len = vasprintf(&buf, fmt, ap);
-
-	stat.st_size = buf_len;
 	stat.st_mtime = my_time(0);
+	stat.st_size = len;
 
 	dstfile = ds_open(ds_data, filename, &stat);
 	if (dstfile == NULL) {
@@ -854,20 +867,9 @@ backup_file_vprintf(const char *filename, const char *fmt, va_list ap)
 		goto error;
 	}
 
-	action = xb_get_copy_action("Writing");
-	msg_ts("[%02u] %s %s\n", 0, action, filename);
-
-	if (buf_len == -1) {
+	if (!backup_ds_print(dstfile, message, len)) {
 		goto error;
 	}
-
-	if (ds_write(dstfile, buf, buf_len)) {
-		goto error;
-	}
-
-	/* close */
-	msg_ts("[%02u]        ...done\n", 0);
-	free(buf);
 
 	if (ds_close(dstfile)) {
 		goto error_close;
@@ -876,13 +878,11 @@ backup_file_vprintf(const char *filename, const char *fmt, va_list ap)
 	return(true);
 
 error:
-	free(buf);
 	if (dstfile != NULL) {
 		ds_close(dstfile);
 	}
 
 error_close:
-	msg("[%02u] Error: backup file failed.\n", 0);
 	return(false); /*ERROR*/
 }
 
@@ -890,15 +890,44 @@ error_close:
 bool
 backup_file_printf(const char *filename, const char *fmt, ...)
 {
-	bool result;
+	bool result  = false;
+	char *buf    = 0;
+	int  buf_len = 0;
 	va_list ap;
 
 	va_start(ap, fmt);
-
-	result = backup_file_vprintf(filename, fmt, ap);
-
+	buf_len = vasprintf(&buf, fmt, ap);
 	va_end(ap);
 
+	if (buf_len == -1) {
+		return false;
+	}
+
+	result = backup_file_print(filename, buf, buf_len);
+
+	free(buf);
+	return(result);
+}
+
+bool
+backup_ds_printf(ds_file_t *dstfile, const char *fmt, ...)
+{
+	bool result  = false;
+	char *buf    = 0;
+	int  buf_len = 0;
+	va_list ap;
+
+	va_start(ap, fmt);
+	buf_len = vasprintf(&buf, fmt, ap);
+	va_end(ap);
+
+	if (buf_len == -1) {
+		return false;
+	}
+
+	result = backup_ds_print(dstfile, buf, buf_len);
+
+	free(buf);
 	return(result);
 }
 
@@ -1448,9 +1477,9 @@ backup_finish()
 	if (mysql_binlog_position != NULL) {
 		msg("MySQL binlog position: %s\n", mysql_binlog_position);
 	}
-	if (mysql_slave_position && opt_slave_info) {
+	if (!mysql_slave_position.empty() && opt_slave_info) {
 		msg("MySQL slave binlog position: %s\n",
-			mysql_slave_position);
+			mysql_slave_position.c_str());
 	}
 
 	if (!write_backup_config_file()) {

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -17,6 +17,10 @@ bool
 backup_file_printf(const char *filename, const char *fmt, ...)
 		__attribute__((format(printf, 2, 0)));
 
+bool
+backup_ds_printf(ds_file_t *dstfile, const char *fmt, ...)
+		__attribute__((format(printf, 2, 0)));
+
 /************************************************************************
 Return true if first and second arguments are the same path. */
 bool

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -2,6 +2,7 @@
 #define XTRABACKUP_BACKUP_MYSQL_H
 
 #include <mysql.h>
+#include <string>
 
 /* mysql flavor and version */
 enum mysql_flavor_t { FLAVOR_UNKNOWN, FLAVOR_MYSQL,
@@ -26,7 +27,7 @@ extern time_t history_lock_time;
 
 
 extern bool sql_thread_started;
-extern char *mysql_slave_position;
+extern std::string mysql_slave_position;
 extern char *mysql_binlog_position;
 extern char *buffer_pool_filename;
 

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -477,25 +477,52 @@ function force_checkpoint()
 ########################################################################
 # Configure a specified server as a slave
 # Synopsis:
-#   setup_slave <slave_id> <master_id>
+#   setup_slave [GTID] [USE_CHANNELS] <slave_id> <master_id> ... <master_id>
 #########################################################################
 function setup_slave()
 {
-    local slave_id=$1
-    local master_id=$2
+    local extra=""
+    if [ "$1" == "GTID" ]
+    then
+        extra=", MASTER_AUTO_POSITION = 1"
+        shift
+        echo "Setting up slave in GTID mode"
+    fi
 
-    vlog "Setting up server #$slave_id as a slave of server #$master_id"
+    local use_channels=0
+    if [ "$1" == "USE_CHANNELS" ]
+    then
+        use_channels=1
+        shift
+        echo "Using channels"
+    fi
 
-    switch_server $slave_id
+    local -r slave_id_arg=$1
+    shift
 
-    run_cmd $MYSQL $MYSQL_ARGS <<EOF
+    switch_server $slave_id_arg
+    while [ "$#" -ne 0 ]
+    do
+        local master_id_arg=$1
+        shift
+
+        vlog "Setting up server #$slave_id_arg as a slave of server #$master_id_arg"
+        if [ "$use_channels" -eq 1 ]
+        then
+            local master_channel="FOR CHANNEL 'master-$master_id_arg'"
+        fi
+
+        run_cmd $MYSQL $MYSQL_ARGS <<EOF
 CHANGE MASTER TO
   MASTER_HOST='localhost',
   MASTER_USER='root',
-  MASTER_PORT=${SRV_MYSQLD_PORT[$master_id]};
-
-START SLAVE
+  MASTER_PORT=${SRV_MYSQLD_PORT[$master_id_arg]}
+  $extra
+  ${master_channel:-};
 EOF
+    done
+
+    mysql -e "START SLAVE"
 }
 
 ########################################################################

--- a/storage/innobase/xtrabackup/test/t/bug1182726.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1182726.sh
@@ -25,5 +25,5 @@ multi_row_insert incremental_sample.test \({1..100},100\)
 switch_server $slave_id
 
 innobackupex --no-timestamp --slave-info --safe-slave-backup --no-lock $topdir/backup
-egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
+egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+;$' \
     $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/bug1551634.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1551634.sh
@@ -1,0 +1,92 @@
+########################################################################
+# Bug #1551634: xtrabackup --slave-info does not handle multi-master replication
+########################################################################
+# Plan:
+#  Set up 2 masters and 1 slave.
+#  Insert some data on both masters
+#  Ensure that slave1 has the data
+#  Backup the slave1
+#  Verify that xtrabackup_slave_info contains info about 2 channels.
+
+. inc/common.sh
+
+require_server_version_higher_than 5.7.6
+
+function init_db()
+{
+  local db_name=$1
+  local table_name=$2
+
+mysql <<EOF
+CREATE DATABASE IF NOT EXISTS $db_name;
+USE $db_name;
+CREATE TABLE IF NOT EXISTS $table_name (
+  c int(11) NOT NULL PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+EOF
+}
+
+readonly master1_id=1
+readonly master2_id=2
+readonly slave_id=3
+
+function run_test()
+{
+    local slave_mode=$1
+
+    vlog "############################################################"
+    vlog "$slave_mode mode"
+
+    if [ $slave_mode = "GTID" ]
+    then
+        local extra_arguments="--gtid_mode=ON --enforce-gtid-consistency=ON"
+    else
+        local extra_arguments=
+        slave_mode=
+    fi
+
+    vlog "############################################################"
+    vlog "Setting up masters and slave"
+    start_server_with_id $master1_id $extra_arguments
+    init_db test m1
+    multi_row_insert test.m1 \({1..7}\)
+
+    start_server_with_id $master2_id $extra_arguments
+    init_db test m2
+    # number of rows differ from one for master1 to get different MASTER_LOG_POS in xtrabackup_slave_info
+    multi_row_insert test.m2 \({1..13}\)
+
+    start_server_with_id $slave_id \
+        --master-info-repository=TABLE \
+        --relay-log-info-repository=TABLE \
+        "$extra_arguments"
+
+    setup_slave $slave_mode USE_CHANNELS $slave_id $master1_id $master2_id
+
+    test `mysql -N -se "SHOW SLAVE STATUS" | wc -l` -eq 2
+
+    vlog "############################################################"
+    vlog "Backing up slave"
+    switch_server $slave_id
+
+    xtrabackup --backup \
+        --no-timestamp \
+        --slave-info \
+        --safe-slave-backup \
+        --target_dir $topdir/backup
+
+    cat $topdir/backup/xtrabackup_slave_info
+    vlog "Verifying that there are 2 different channels in xtrabackup_slave_info"
+    test `egrep -c '^CHANGE MASTER TO.*FOR CHANNEL '\''master-[0-9]+'\' \
+        $topdir/backup/xtrabackup_slave_info` -eq 2 || die
+
+    for i in ${SRV_MYSQLD_IDS[@]}
+    do
+        stop_server_with_id "$i"
+    done
+
+    remove_var_dirs
+}
+
+run_test BINLOG
+run_test GTID

--- a/storage/innobase/xtrabackup/test/t/bug977101.sh
+++ b/storage/innobase/xtrabackup/test/t/bug977101.sh
@@ -28,5 +28,5 @@ innobackupex --no-timestamp --slave-info --safe-slave-backup $topdir/backup
 cat $topdir/backup/xtrabackup_binlog_info
 run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
-run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
+run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+;$' \
     $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
@@ -24,5 +24,5 @@ run_cmd_expect_failure $IB_BIN $IB_ARGS --no-timestamp --slave-info --no-lock \
 innobackupex --no-timestamp --slave-info $topdir/backup
 egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
-egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
+egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+;$' \
     $topdir/backup/xtrabackup_slave_info


### PR DESCRIPTION
Writing master info for every channel to xtrabackup_slave_info;
Added a test case that verifies multi-source replication for both binlog and gtid mode.

https://bugs.launchpad.net/percona-xtrabackup/+bug/1551634