### PR TITLE
apply patch from timesys to remove htd_lib refs

### DIFF
--- a/mysys/stacktrace.c
+++ b/mysys/stacktrace.c
@@ -291,8 +291,11 @@ inline uint32* find_prev_pc(uint32* pc, uchar** fp)
 
 void my_print_stacktrace(uchar* stack_bottom, ulong thread_stack)
 {
+  /* We are 1 frame above signal frame with NPTL */
+  const uint sigreturn_frame_count = 1;
   uchar** fp;
-  uint frame_count = 0, sigreturn_frame_count;
+  uint frame_count = 0;
+
 #if defined(__alpha__) && defined(__GNUC__)
   uint32* pc;
 #endif
@@ -353,9 +356,6 @@ void my_print_stacktrace(uchar* stack_bottom, ulong thread_stack)
 		      :"=r"(pc)
 		      :"r"(pc));
 #endif  /* __alpha__ */
-
-  /* We are 1 frame above signal frame with NPTL and 2 frames above with LT */
-  sigreturn_frame_count = thd_lib_detected == THD_LIB_LT ? 2 : 1;
 
   while (fp < (uchar**) stack_bottom)
   {


### PR DESCRIPTION
patch: http://repository.timesys.com/buildsources/m/mysql/mysql-5.6.23/mysql-5.6.23-remove-thd_lib-refs.patch

this fixes my alpine build from breaking:

```
    mysys/stacktrace.c:358:27: error: 'thd_lib_detected' undeclared (first use in this function)
    sigreturn_frame_count = thd_lib_detected == THD_LIB_LT ? 2 : 1;
                            ^
    /mysys/stacktrace.c:358:27: note: each undeclared identifier is reported only once for each function it appears in
    /.../mysys/stacktrace.c:358:47: error: 'THD_LIB_LT' undeclared (first use in this function)
    sigreturn_frame_count = thd_lib_detected == THD_LIB_LT ? 2 : 1;
```