### PR TITLE
Bug #1600656: Feature request: Include xtrabackup_info to extra-lsn-dir

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -67,6 +67,9 @@ write_current_binlog_file(MYSQL *connection);
 bool
 write_binlog_info(MYSQL *connection);
 
+char*
+get_xtrabackup_info(MYSQL *connection);
+
 bool
 write_xtrabackup_info(MYSQL *connection);
 

--- a/storage/innobase/xtrabackup/test/t/bug1600656.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1600656.sh
@@ -1,0 +1,27 @@
+########################################################################
+# Bug #1600656: Include xtrabackup_info to extra-lsn-dir
+########################################################################
+
+. inc/common.sh
+
+start_server
+
+load_dbase_schema incremental_sample
+multi_row_insert incremental_sample.test \({1..100},100\)
+
+mkdir $topdir/backup
+
+vlog "#########################################################################"
+vlog "Taking a backup and stream stuff, saving extra stuff into lsndir"
+
+xtrabackup --backup \
+    --stream=tar \
+    --extra-lsndir=$topdir/lsndir \
+    > $topdir/backup/stream.tar
+
+tar -xf $topdir/backup/stream.tar -C $topdir/backup
+
+vlog "#########################################################################"
+vlog "Verifying that streamed and 'extra copy' of xtrabackup_info do not differ"
+
+diff -q $topdir/backup/xtrabackup_info $topdir/lsndir/xtrabackup_info


### PR DESCRIPTION
Creating an extra copy of the xtrabackup_info in the directory specified with --extra-lsndir
And a test that verifies that it matches the one from the stream.

https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1600656