### PR TITLE
Bug 1192834: Crash during apply with index compaction enabled

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -4118,6 +4118,8 @@ buf_page_io_complete(
 		if (srv_compact_backup && buf_page_is_compacted(frame)) {
 
 			bpage->is_compacted = TRUE;
+		} else {
+			bpage->is_compacted = FALSE;
 		}
 
 		/* If this page is not uninitialized and not in the

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1775,12 +1775,13 @@ recv_recover_page_func(
 				memset(FIL_PAGE_LSN + page_zip->data, 0, 8);
 			}
 
-			if (!block->page.is_compacted
-			    && block->page.is_compacted) {
+			if (block->page.is_compacted) {
 
 				ut_ad(srv_compact_backup);
 
 				block->page.is_compacted = FALSE;
+
+				memset(page, 0, UNIV_PAGE_SIZE);
 			}
 		}
 

--- a/storage/innobase/row/row0purge.cc
+++ b/storage/innobase/row/row0purge.cc
@@ -46,6 +46,7 @@ Created 3/14/1997 Heikki Tuuri
 #include "log0log.h"
 #include "srv0mon.h"
 #include "srv0start.h"
+#include "xb0xb.h"
 
 /*************************************************************************
 IMPORTANT NOTE: Any operation that generates redo MUST check that there
@@ -504,6 +505,11 @@ row_purge_remove_sec_if_poss(
 {
 	ibool	success;
 	ulint	n_tries		= 0;
+
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return;
+	}
 
 	/*	fputs("Purge: Removing secondary record\n", stderr); */
 

--- a/storage/innobase/row/row0uins.cc
+++ b/storage/innobase/row/row0uins.cc
@@ -46,6 +46,7 @@ Created 2/25/1997 Heikki Tuuri
 #include "que0que.h"
 #include "ibuf0ibuf.h"
 #include "log0log.h"
+#include "xb0xb.h"
 
 /*************************************************************************
 IMPORTANT NOTE: Any operation that generates redo MUST check that there
@@ -359,6 +360,11 @@ row_undo_ins_remove_sec_rec(
 	dberr_t		err	= DB_SUCCESS;
 	dict_index_t*	index	= node->index;
 	mem_heap_t*	heap;
+
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return(DB_SUCCESS);
+	}
 
 	heap = mem_heap_create(1024);
 

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -44,6 +44,7 @@ Created 2/27/1997 Heikki Tuuri
 #include "row0upd.h"
 #include "que0que.h"
 #include "log0log.h"
+#include "xb0xb.h"
 
 /* Considerations on undoing a modify operation.
 (1) Undoing a delete marking: all index records should be found. Some of
@@ -527,6 +528,11 @@ row_undo_mod_del_mark_or_remove_sec(
 {
 	dberr_t	err;
 
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return DB_SUCCESS;
+	}
+
 	err = row_undo_mod_del_mark_or_remove_sec_low(node, thr, index,
 						      entry, BTR_MODIFY_LEAF);
 	if (err == DB_SUCCESS) {
@@ -571,6 +577,11 @@ row_undo_mod_del_unmark_sec_and_undo_update(
 	enum row_search_result	search_result;
 
 	ut_ad(trx->id);
+
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return DB_SUCCESS;
+	}
 
 	log_free_check();
 	mtr_start(&mtr);
@@ -790,6 +801,11 @@ row_undo_mod_upd_del_sec(
 	ut_ad(node->rec_type == TRX_UNDO_UPD_DEL_REC);
 	ut_ad(!node->undo_row);
 
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return DB_SUCCESS;
+	}
+
 	heap = mem_heap_create(1024);
 
 	while (node->index != NULL) {
@@ -856,6 +872,11 @@ row_undo_mod_del_mark_sec(
 
 	ut_ad(!node->undo_row);
 
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return DB_SUCCESS;
+	}
+
 	heap = mem_heap_create(1024);
 
 	while (node->index != NULL) {
@@ -921,6 +942,11 @@ row_undo_mod_upd_exist_sec(
 {
 	mem_heap_t*	heap;
 	dberr_t		err	= DB_SUCCESS;
+
+	if (srv_compact_backup) {
+		/* we don't have secondary indexes, lets skip this */
+		return DB_SUCCESS;
+	}
 
 	if (node->index == NULL
 	    || ((node->cmpl_info & UPD_NODE_NO_ORD_CHANGE))) {

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2848,6 +2848,9 @@ files_checked:
 	os_fast_mutex_free(&srv_os_test_mutex);
 
 	if (srv_rebuild_indexes) {
+		while (trx_rollback_or_clean_is_active) {
+			os_thread_sleep(100000);
+		}
 		xb_compact_rebuild_indexes();
 	}
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -303,6 +303,7 @@ static char *xtrabackup_debug_sync = NULL;
 
 my_bool xtrabackup_compact = FALSE;
 my_bool xtrabackup_rebuild_indexes = FALSE;
+my_bool xtrabackup_compact_need_expand = FALSE;
 
 my_bool xtrabackup_incremental_force_scan = FALSE;
 
@@ -1962,9 +1963,11 @@ xtrabackup_read_metadata(char *filename)
 	/* Optional fields */
 
 	if (fscanf(fp, "compact = %d\n", &t) == 1) {
-		xtrabackup_compact = (t == 1);
+		xtrabackup_compact = (t != 0);
+		xtrabackup_compact_need_expand = (t == 1);
 	} else {
-		xtrabackup_compact = 0;
+		xtrabackup_compact = FALSE;
+		xtrabackup_compact_need_expand = FALSE;
 	}
 
 	if (fscanf(fp, "recover_binlog_info = %d\n", &t) == 1) {
@@ -1995,7 +1998,11 @@ xtrabackup_print_metadata(char *buf, size_t buf_len)
 		 metadata_from_lsn,
 		 metadata_to_lsn,
 		 metadata_last_lsn,
-		 MY_TEST(xtrabackup_compact == TRUE),
+		 /* compact = 1 means backup is compact, not expanded
+		    compact = 2 means backup is compact, expanded */
+		 xtrabackup_compact ?
+			(xtrabackup_backup ||
+				xtrabackup_compact_need_expand ? 1 : 2) : 0,
 		 MY_TEST(opt_binlog_info == BINLOG_INFO_LOCKLESS));
 }
 
@@ -6409,13 +6416,13 @@ skip_check:
 	if (xtrabackup_compact) {
 		srv_compact_backup = TRUE;
 
-		if (!xb_expand_datafiles()) {
+		if (xtrabackup_compact_need_expand && !xb_expand_datafiles()) {
 			goto error_cleanup;
 		}
 
-		/* Reset the 'compact' flag in xtrabackup_checkpoints so we
+		/* Update 'compact' flag in xtrabackup_checkpoints so we
 		don't expand on subsequent invocations. */
-		xtrabackup_compact = FALSE;
+		xtrabackup_compact_need_expand = FALSE;
 		if (!xtrabackup_write_metadata(metadata_path)) {
 			msg("xtrabackup: error: xtrabackup_write_metadata() "
 			    "failed\n");

--- a/storage/innobase/xtrabackup/test/t/bug1192834-purge.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1192834-purge.sh
@@ -1,0 +1,31 @@
+##########################################################################
+# Bug 1192834: Crash during apply with index compaction enabled          #
+##########################################################################
+
+. inc/common.sh
+
+start_server --innodb_file_per_table
+load_dbase_schema sakila
+load_dbase_data sakila
+
+mysql -e "DELETE FROM payment LIMIT 100" sakila
+
+backup_dir="$topdir/backup"
+
+xtrabackup --backup --compact --target-dir=$backup_dir
+vlog "Backup created in directory $backup_dir"
+
+stop_server
+
+# Remove datadir
+rm -r $mysql_datadir
+
+# Restore sakila
+
+xtrabackup --prepare --rebuild-indexes --target-dir=$backup_dir
+
+vlog "Restoring MySQL datadir"
+mkdir -p $mysql_datadir
+xtrabackup --copy-back --target-dir=$backup_dir
+
+start_server

--- a/storage/innobase/xtrabackup/test/t/bug1192834-rollback.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1192834-rollback.sh
@@ -1,0 +1,44 @@
+##########################################################################
+# Bug 1192834: Crash during apply with index compaction enabled          #
+##########################################################################
+
+. inc/common.sh
+
+start_server --innodb_file_per_table
+load_dbase_schema sakila
+load_dbase_data sakila
+
+function start_uncomitted_transaction()
+{
+    mysql sakila <<EOF
+START TRANSACTION;
+DELETE FROM payment;
+SELECT SLEEP(10000);
+EOF
+}
+
+start_uncomitted_transaction &
+job_master=$!
+
+sleep 2
+
+backup_dir="$topdir/backup"
+
+xtrabackup --backup --compact --target-dir=$backup_dir
+vlog "Backup created in directory $backup_dir"
+
+kill -SIGKILL $job_master
+stop_server
+
+# Remove datadir
+rm -r $mysql_datadir
+
+# Restore sakila
+
+xtrabackup --prepare --rebuild-indexes --target-dir=$backup_dir
+
+vlog "Restoring MySQL datadir"
+mkdir -p $mysql_datadir
+xtrabackup --copy-back --target-dir=$backup_dir
+
+start_server

--- a/storage/innobase/xtrabackup/test/t/compact.sh
+++ b/storage/innobase/xtrabackup/test/t/compact.sh
@@ -10,7 +10,7 @@ load_dbase_data sakila
 
 backup_dir="$topdir/backup"
 
-innobackupex --no-timestamp --compact $backup_dir
+xtrabackup --backup --compact --target-dir=$backup_dir
 vlog "Backup created in directory $backup_dir"
 
 record_db_state sakila
@@ -22,11 +22,12 @@ rm -r $mysql_datadir
 
 # Restore sakila
 
-innobackupex --apply-log --rebuild-indexes $backup_dir
+xtrabackup --prepare --apply-log-only --target-dir=$backup_dir
+xtrabackup --prepare --rebuild-indexes --target-dir=$backup_dir
 
 vlog "Restoring MySQL datadir"
 mkdir -p $mysql_datadir
-innobackupex --copy-back $backup_dir
+xtrabackup --copy-back --target-dir=$backup_dir
 
 start_server
 
@@ -38,7 +39,7 @@ verify_db_state sakila
 
 rm -rf $backup_dir
 
-innobackupex --no-timestamp --compact $backup_dir
+xtrabackup --backup --compact --target-dir=$backup_dir
 vlog "Backup created in directory $backup_dir"
 
 record_db_state sakila
@@ -50,13 +51,13 @@ rm -r $mysql_datadir
 
 # Restore sakila
 
-innobackupex --apply-log --rebuild-indexes --rebuild-threads=16 $backup_dir
+xtrabackup --prepare --rebuild-indexes --rebuild-threads=16 --target-dir=$backup_dir
 
 grep -q "Starting 16 threads to rebuild indexes" $OUTFILE
 
 vlog "Restoring MySQL datadir"
 mkdir -p $mysql_datadir
-innobackupex --copy-back $backup_dir
+xtrabackup --copy-back --target-dir=$backup_dir
 
 start_server
 


### PR DESCRIPTION
There were several issues with compact backups:

1. Prepare failed on rollback and purge phases because secondary indexes
   are not rebuilt by the time of rollback/purge. Fixed by skipping
   rollback and purge for all secondary indexes.
2. Pages in buffer pool could mistakenly be marked as compacted and redo
   log would not be replayed on such pages which led to corrupt backups
   and crashes. Fixed by clearing `is_compacted' for every page read
   into the buffer pool.
3. Compacted pages which have been freed up and repurposed by server
   were not fully reset during prepare which let to corrupt backups.
4. Index rebuild process could start in parallel with rollback phase
   which led to crashes and corrupt backups. Fix makes sure that index
   rebuild process isn't started until rollback is fully complete.