### PR TITLE
Bug 1690823: streaming backups of large databases fail when receiving

### DIFF
--- a/storage/innobase/xtrabackup/src/xbstream.c
+++ b/storage/innobase/xtrabackup/src/xbstream.c
@@ -493,7 +493,11 @@ extract_worker_thread_func(void *arg)
 		}
 
 		if (chunk.type == XB_CHUNK_TYPE_EOF) {
+			pthread_mutex_lock(ctxt->mutex);
 			pthread_mutex_unlock(&entry->mutex);
+			my_hash_delete(ctxt->filehash, (uchar *) entry);
+			pthread_mutex_unlock(ctxt->mutex);
+
 			continue;
 		}
 


### PR DESCRIPTION
side runs pxb 2.3.8

xbstream does not close file descriptors when EOF chunk encountered.

`my_hash_delete' has been lost when patch adding parallel extract for
xbstream has been implemented. Fix is to simply put it back.