### PR TITLE
Bug 1651505: GTID position not recorded when --binlog-info=AUTO

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -407,16 +407,6 @@ get_mysql_vars(MYSQL *connection)
 		have_backup_locks = true;
 	}
 
-	if (opt_binlog_info == BINLOG_INFO_AUTO) {
-
-		if (have_backup_safe_binlog_info_var != NULL)
-			opt_binlog_info = BINLOG_INFO_LOCKLESS;
-		else if (log_bin_var != NULL && !strcmp(log_bin_var, "ON"))
-			opt_binlog_info = BINLOG_INFO_ON;
-		else
-			opt_binlog_info = BINLOG_INFO_OFF;
-	}
-
 	if (have_backup_safe_binlog_info_var == NULL &&
 	    opt_binlog_info == BINLOG_INFO_LOCKLESS) {
 
@@ -457,6 +447,17 @@ get_mysql_vars(MYSQL *connection)
 	if ((gtid_mode_var && strcmp(gtid_mode_var, "ON") == 0) ||
 	    (gtid_slave_pos_var && *gtid_slave_pos_var)) {
 		have_gtid_slave = true;
+	}
+
+	if (opt_binlog_info == BINLOG_INFO_AUTO) {
+
+		if (have_backup_safe_binlog_info_var != NULL &&
+		    !have_gtid_slave)
+			opt_binlog_info = BINLOG_INFO_LOCKLESS;
+		else if (log_bin_var != NULL && !strcmp(log_bin_var, "ON"))
+			opt_binlog_info = BINLOG_INFO_ON;
+		else
+			opt_binlog_info = BINLOG_INFO_OFF;
 	}
 
 	msg("Using server version %s\n", version_var);

--- a/storage/innobase/xtrabackup/test/t/binlog_info.sh
+++ b/storage/innobase/xtrabackup/test/t/binlog_info.sh
@@ -4,27 +4,84 @@
 
 xtrabackup --help 2>&1 | grep 'binlog-info *auto'
 
-start_server
+function test_binlog_info() {
 
-has_backup_locks && bl_avail=1 || bl_avail=0
-has_backup_safe_binlog_info && bsbi_avail=1 || bsbi_avail=0
+    start_server $@
 
-load_sakila
+    has_backup_locks && bl_avail=1 || bl_avail=0
+    has_backup_safe_binlog_info && bsbi_avail=1 || bsbi_avail=0
+    is_gtid_mode && gtid=1 || gtid=0
 
-binlog_file_innodb=`get_binlog_file`
-binlog_pos_innodb=`get_binlog_pos`
-
-# Generate some non-InnoDB entries in the binary log
-run_cmd $MYSQL $MYSQL_ARGS test <<EOF
-CREATE TABLE t (a INT) ENGINE=MyISAM;
-INSERT INTO t VALUES (1), (2), (3);
+    # Generate some InnoDB entries in the binary log
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+    CREATE TABLE p (a INT) ENGINE=InnoDB;
+    INSERT INTO p VALUES (1), (2), (3);
 EOF
 
-binlog_file=`get_binlog_file`
-binlog_pos=`get_binlog_pos`
+    binlog_file_innodb=`get_binlog_file`
+    binlog_pos_innodb=`get_binlog_pos`
+    binlog_info_innodb="$binlog_file_innodb	$binlog_pos_innodb"
 
-xb_binlog_info=$topdir/backup/xtrabackup_binlog_info
-xb_binlog_info_innodb=$topdir/backup/xtrabackup_binlog_pos_innodb
+    # Generate some non-InnoDB entries in the binary log
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+    CREATE TABLE t (a INT) ENGINE=MyISAM;
+    INSERT INTO t VALUES (1), (2), (3);
+EOF
+
+    binlog_file=`get_binlog_file`
+    binlog_pos=`get_binlog_pos`
+
+    if [ $gtid = 1 ] ; then
+        gtid_executed=`get_gtid_executed`
+    fi
+
+    xb_binlog_info=$topdir/backup/xtrabackup_binlog_info
+    xb_binlog_info_innodb=$topdir/backup/xtrabackup_binlog_pos_innodb
+
+    # --binlog-info=auto
+    xtrabackup --backup --binlog-info=auto --target-dir=$topdir/backup
+
+    if [ $bsbi_avail = 1 ] && [ $gtid = 0 ]
+    then
+        verify_binlog_info_lockless
+    else
+        verify_binlog_info_on
+    fi
+
+    rm -rf $topdir/backup
+
+    # --binlog-info=off
+    xtrabackup --backup --binlog-info=off --target-dir=$topdir/backup
+
+    verify_binlog_info_off
+
+    rm -rf $topdir/backup
+
+    # --binlog-info=on
+    xtrabackup --backup --binlog-info=on --target-dir=$topdir/backup
+
+    verify_binlog_info_on
+
+    rm -rf $topdir/backup
+
+    # --binlog-info=lockless
+
+    if [ $bsbi_avail = 0 ]
+    then
+       run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --binlog-info=lockless \
+                              --target-dir=$topdir/backup
+    else
+        xtrabackup --backup --binlog-info=lockless --target-dir=$topdir/backup
+        verify_binlog_info_lockless
+    fi
+
+    rm -rf $topdir/backup
+
+    stop_server
+
+    rm -rf $mysql_datadir
+
+}
 
 function normalize_path()
 {
@@ -37,9 +94,16 @@ function verify_binlog_info_on()
 
     normalize_path $xb_binlog_info
 
-    diff $xb_binlog_info - <<EOF
+    if [ $gtid = 1 ]
+    then
+		diff $xb_binlog_info - <<EOF
+$binlog_file	$binlog_pos	$gtid_executed
+EOF
+	else
+		diff $xb_binlog_info - <<EOF
 $binlog_file	$binlog_pos
 EOF
+	fi
     xtrabackup --prepare --target-dir=$topdir/backup
 
     normalize_path $xb_binlog_info_innodb
@@ -93,39 +157,9 @@ function verify_binlog_info_off()
     true
 }
 
-# --binlog-info=auto
-xtrabackup --backup --binlog-info=auto --target-dir=$topdir/backup
+test_binlog_info
 
-if [ $bsbi_avail = 1 ]
-then
-    verify_binlog_info_lockless
-else
-    verify_binlog_info_on
-fi
-
-rm -rf $topdir/backup
-
-# --binlog-info=off
-xtrabackup --backup --binlog-info=off --target-dir=$topdir/backup
-
-verify_binlog_info_off
-
-rm -rf $topdir/backup
-
-# --binlog-info=on
-xtrabackup --backup --binlog-info=on --target-dir=$topdir/backup
-
-verify_binlog_info_on
-
-rm -rf $topdir/backup
-
-# --binlog-info=lockless
-
-if [ $bsbi_avail = 0 ]
-then
-   run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --binlog-info=lockless \
-                          --target-dir=$topdir/backup
-else
-    xtrabackup --backup --binlog-info=lockless --target-dir=$topdir/backup
-    verify_binlog_info_lockless
+if is_server_version_higher_than 5.6.0 ; then
+    test_binlog_info --gtid-mode=ON --enforce-gtid-consistency=ON \
+                     --log-bin --log-slave-updates
 fi


### PR DESCRIPTION
With introduction of lockless binlog info support in xtrabackup, binary
log coordinates are no longer saved into `xtrabackup_binlog_info' file if
support of safe binlog info by server detected. Instead, binlog
coordinates are restored during prepare from information saved by InnoDB.

It causes trouble in case when GTIDs are in use instead of binlog
coordinates. Since InnoDB doesn't save GTID executed set, xtrabackup has
no place to restore it from.

This patch makes xtrabackup to fallback to `binlog-info=ON' and save
GTID coordinates during the backup when GTID mode is ON.