### PR TITLE
Blueprint: Update test framework to support MariaDB

### DIFF
--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -385,7 +385,10 @@ function get_version_info()
     fi
 
     # Determine InnoDB flavor
-    if [ -n "$XTRADB_VERSION" ]
+    if [[ "$MYSQL_VERSION" =~ "MariaDB" ]]
+    then
+	INNODB_FLAVOR="MariaDB"
+    elif [ -n "$XTRADB_VERSION" ]
     then
 	INNODB_FLAVOR="XtraDB"
     else

--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -3,7 +3,8 @@
 ########################################################################
 
 require_server_version_higher_than 5.6.0
-require_xtradb
+
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_file_per_table"

--- a/storage/innobase/xtrabackup/test/t/bug1182726.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1182726.sh
@@ -25,5 +25,5 @@ multi_row_insert incremental_sample.test \({1..100},100\)
 switch_server $slave_id
 
 innobackupex --no-timestamp --slave-info --safe-slave-backup --no-lock $topdir/backup
-egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
-    $topdir/backup/xtrabackup_slave_info
+
+check_slave_info $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/bug1227240.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1227240.sh
@@ -2,7 +2,7 @@
 # Bug #1227240: backups not working with archive logging enabled
 ########################################################################
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 require_server_version_higher_than 5.6.10
 
 init_server_variables 1

--- a/storage/innobase/xtrabackup/test/t/bug1239670.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1239670.sh
@@ -4,6 +4,10 @@
 
 require_server_version_higher_than 5.6.0
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 MYSQLD_EXTRA_MY_CNF_OPTS="
 gtid_mode=on
 log_slave_updates=on

--- a/storage/innobase/xtrabackup/test/t/bug1250375.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1250375.sh
@@ -3,6 +3,10 @@
 require_galera
 require_server_version_higher_than 5.6.0
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 ADDR=127.0.0.1
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/bug1372679.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1372679.sh
@@ -5,6 +5,10 @@
 
 require_server_version_higher_than 5.6.0
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 # Test that --slave-info with MTS enabled + GTID disabled fails
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/bug1391041.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1391041.sh
@@ -6,6 +6,10 @@
 
 require_server_version_higher_than 5.6.0
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 MYSQLD_EXTRA_MY_CNF_OPTS="
 gtid_mode=on
 log_slave_updates=on

--- a/storage/innobase/xtrabackup/test/t/bug1418584.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1418584.sh
@@ -4,6 +4,10 @@
 
 require_galera
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 ADDR=127.0.0.1
 
 if [[ -n ${WSREP_DEBUG:-} ]];then

--- a/storage/innobase/xtrabackup/test/t/bug759225.sh
+++ b/storage/innobase/xtrabackup/test/t/bug759225.sh
@@ -10,7 +10,7 @@ then
     skip_test "Requires Linux"
 fi
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_flush_method=ALL_O_DIRECT

--- a/storage/innobase/xtrabackup/test/t/bug810269.sh
+++ b/storage/innobase/xtrabackup/test/t/bug810269.sh
@@ -5,6 +5,11 @@
 
 . inc/common.sh
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691083 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 if [ -z "$INNODB_VERSION" ]; then
     skip_test "Requires InnoDB plugin or XtraDB"
 fi

--- a/storage/innobase/xtrabackup/test/t/bug976945.sh
+++ b/storage/innobase/xtrabackup/test/t/bug976945.sh
@@ -3,7 +3,7 @@
 ############################################################################
 . inc/common.sh
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_log_block_size=4096

--- a/storage/innobase/xtrabackup/test/t/bug977101.sh
+++ b/storage/innobase/xtrabackup/test/t/bug977101.sh
@@ -17,16 +17,16 @@ switch_server $slave_id
 
 # Check that binlog info is correct with --safe-slave-backup
 innobackupex --no-timestamp --safe-slave-backup $topdir/backup
+
 cat $topdir/backup/xtrabackup_binlog_info
-run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
-    $topdir/backup/xtrabackup_binlog_info
+check_binlog_info $topdir/backup/xtrabackup_binlog_info
 
 # Check that both binlog info and slave info are correct with 
 # --safe-slave-backup
 rm -rf $topdir/backup
 innobackupex --no-timestamp --slave-info --safe-slave-backup $topdir/backup
+
 cat $topdir/backup/xtrabackup_binlog_info
-run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
-    $topdir/backup/xtrabackup_binlog_info
-run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
-    $topdir/backup/xtrabackup_slave_info
+check_binlog_info $topdir/backup/xtrabackup_binlog_info
+
+check_slave_info $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/bug983720_galerainfo.sh
+++ b/storage/innobase/xtrabackup/test/t/bug983720_galerainfo.sh
@@ -6,6 +6,10 @@
 
 require_galera
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 ADDR=127.0.0.1
 
 debug=""

--- a/storage/innobase/xtrabackup/test/t/gtid.sh
+++ b/storage/innobase/xtrabackup/test/t/gtid.sh
@@ -4,6 +4,10 @@
 
 . inc/common.sh
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 require_server_version_higher_than 5.6.0
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/ib_incremental_bitmap.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_incremental_bitmap.sh
@@ -1,6 +1,6 @@
 # Test for incremental backups that use changed page bitmaps
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 is_64bit || skip_test "Disabled on 32-bit hosts due to LP bug #1359182"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/ib_incremental_bitmap_lsn.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_incremental_bitmap_lsn.sh
@@ -1,6 +1,6 @@
 # Test for fast incremental backups with the --incremental-lsn option
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 is_64bit || skip_test "Disabled on 32-bit hosts due to LP bug #1359182"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/ib_incremental_force_full_scan.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_incremental_force_full_scan.sh
@@ -1,6 +1,6 @@
 # Test for incremental backups that use forced full scan even when bitmaps are present
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 is_64bit || skip_test "Disabled on 32-bit hosts due to LP bug #1359182"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/ib_part_include.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_part_include.sh
@@ -9,6 +9,11 @@
 . inc/common.sh
 . inc/ib_part.sh
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691102 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 start_server --innodb_file_per_table
 
 require_partitioning

--- a/storage/innobase/xtrabackup/test/t/ib_part_tf_innodb.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_part_tf_innodb.sh
@@ -9,6 +9,11 @@
 . inc/common.sh
 . inc/ib_part.sh
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691102 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 start_server --innodb_file_per_table
 
 require_partitioning

--- a/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
@@ -22,7 +22,7 @@ run_cmd_expect_failure $IB_BIN $IB_ARGS --no-timestamp --slave-info --no-lock \
   $topdir/backup
 
 innobackupex --no-timestamp --slave-info $topdir/backup
-egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
-    $topdir/backup/xtrabackup_binlog_info
-egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
-    $topdir/backup/xtrabackup_slave_info
+
+check_binlog_info $topdir/backup/xtrabackup_binlog_info
+
+check_slave_info $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/innodb_fast_checksum.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_fast_checksum.sh
@@ -2,7 +2,7 @@
 # Test for XtraDB innodb_fast_checksum option
 ########################################################################
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 require_server_version_lower_than 5.6.0
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/innodb_log_checksum_algorithm.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_log_checksum_algorithm.sh
@@ -2,7 +2,7 @@
 # Test for innodb_log_checksum_algorithm feature in Percona Server 5.6
 ########################################################################
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 require_server_version_higher_than 5.6.13
 
 function test_with_algorithm()

--- a/storage/innobase/xtrabackup/test/t/xb_apply_archived_logs.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_apply_archived_logs.sh
@@ -1,5 +1,9 @@
 . inc/common.sh
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 #The result to return
 RESULT=0
 

--- a/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
@@ -2,6 +2,10 @@
 
 require_galera
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 ADDR=127.0.0.1
 
 if [[ -n ${WSREP_DEBUG:-} ]];then 

--- a/storage/innobase/xtrabackup/test/t/xb_galera_sst.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_galera_sst.sh
@@ -6,6 +6,10 @@
 
 require_galera
 
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 node1=1
 # node2 will be getting SST
 node2=901

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_bitmap_misc.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_bitmap_misc.sh
@@ -1,6 +1,6 @@
 # Test diagnostics for missing bitmap data and --incremental-force-scan option
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 is_64bit || skip_test "Disabled on 32-bit hosts due to LP bug #1359182"
 
 . inc/common.sh

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_bitmap_16kb.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_bitmap_16kb.sh
@@ -1,6 +1,6 @@
 # Test incremental backups that use bitmaps with 16KB compressed pages
 
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 is_64bit || skip_test "Disabled on 32-bit hosts due to LP bug #1359182"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_1kb.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_1kb.sh
@@ -1,5 +1,10 @@
 # Test incremental backups that do full data scans with 1KB compressed pages
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691083 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 first_inc_suspend_command=
 
 source t/xb_incremental_compressed.inc

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_2kb.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_2kb.sh
@@ -1,5 +1,10 @@
 # Test incremental backups that do full data scans with 2KB compressed pages
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691083 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 first_inc_suspend_command=
 
 source t/xb_incremental_compressed.inc

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_4kb.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_4kb.sh
@@ -1,5 +1,10 @@
 # Test incremental backups that do full data scans with 4KB compressed pages
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691083 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 first_inc_suspend_command=
 
 source t/xb_incremental_compressed.inc

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_8kb.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed_full_scan_8kb.sh
@@ -1,5 +1,10 @@
 # Test incremental backups that do full data scans with 8KB compressed pages
 
+# Skip until https://bugs.launchpad.net/percona-xtrabackup/+bug/1691083 is fixed.
+# For details please see:
+# https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
+is_mariadb && skip_test "disabled for MariaDB"
+
 first_inc_suspend_command=
 
 source t/xb_incremental_compressed.inc

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -15,7 +15,7 @@
 . inc/common.sh
 
 # run this test only when backing up PS 5.6
-require_xtradb
+is_xtradb || is_mariadb || skip_test "Requires XtraDB or MariaDB"
 require_server_version_lower_than 5.7.0
 require_server_version_higher_than 5.6.0
 is_galera && skip_test "skipping"


### PR DESCRIPTION
Added is_mariadb and require_mariadb functions in ./inc/common.sh;
Skipping some test when run against MariaDB server;
Updated other tests to pass.

Blueprint: https://blueprints.launchpad.net/percona-xtrabackup/+spec/test-framework-mariadb-support
param-build: http://jenkins.percona.com/job/percona-xtrabackup-2.3-param/302/