### PR TITLE
PXB-193: When GTID_MODE=ON and slave uses MASTER_AUTO_POSITION=0, GTID is used in --slave-info

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1102,6 +1102,8 @@ write_slave_info(MYSQL *connection)
 	char *gtid_executed = NULL;
 	char *position = NULL;
 	char *gtid_slave_pos = NULL;
+	char *auto_position = NULL;
+	char *using_gtid = NULL;
 	char *ptr;
 	bool result = false;
 
@@ -1110,6 +1112,8 @@ write_slave_info(MYSQL *connection)
 		{"Relay_Master_Log_File", &filename},
 		{"Exec_Master_Log_Pos", &position},
 		{"Executed_Gtid_Set", &gtid_executed},
+		{"Auto_Position", &auto_position},
+		{"Using_Gtid", &using_gtid},
 		{NULL, NULL}
 	};
 
@@ -1135,7 +1139,7 @@ write_slave_info(MYSQL *connection)
 	/* Print slave status to a file.
 	If GTID mode is used, construct a CHANGE MASTER statement with
 	MASTER_AUTO_POSITION and correct a gtid_purged value. */
-	if (gtid_executed != NULL && *gtid_executed) {
+	if (auto_position != NULL && !strcmp(auto_position, "1")) {
 		/* MySQL >= 5.6 with GTID enabled */
 
 		for (ptr = strchr(gtid_executed, '\n');
@@ -1152,7 +1156,7 @@ write_slave_info(MYSQL *connection)
 		ut_a(asprintf(&mysql_slave_position,
 			"master host '%s', purge list '%s'",
 			master, gtid_executed) != -1);
-	} else if (gtid_slave_pos && *gtid_slave_pos) {
+	} else if (using_gtid && !strcasecmp(using_gtid, "yes")) {
 		/* MariaDB >= 10.0 with GTID enabled */
 		result = backup_file_printf(XTRABACKUP_SLAVE_INFO,
 			"SET GLOBAL gtid_slave_pos = '%s';\n"

--- a/storage/innobase/xtrabackup/test/t/bug1239670.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1239670.sh
@@ -15,7 +15,7 @@ slave_id=2
 start_server_with_id $master_id
 start_server_with_id $slave_id
 
-setup_slave $slave_id $master_id
+setup_slave GTID $slave_id $master_id
 
 switch_server $master_id
 

--- a/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
@@ -2,6 +2,8 @@
 
 master_id=1
 slave_id=2
+slave2_id=3
+slave3_id=4
 
 start_server_with_id $master_id
 start_server_with_id $slave_id
@@ -14,15 +16,58 @@ load_dbase_schema incremental_sample
 # Adding initial rows
 multi_row_insert incremental_sample.test \({1..100},100\)
 
-# Full backup of the slave server
 switch_server $slave_id
 
 vlog "Check that --slave-info with --no-lock and no --safe-slave-backup fails"
 run_cmd_expect_failure $IB_BIN $IB_ARGS --no-timestamp --slave-info --no-lock \
   $topdir/backup
 
-innobackupex --no-timestamp --slave-info $topdir/backup
-egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
+vlog "Full backup of the slave server"
+xtrabackup --backup --no-timestamp --slave-info --binlog-info=on --target-dir=$topdir/backup
+
+run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
-egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
+
+run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
     $topdir/backup/xtrabackup_slave_info
+
+if is_server_version_higher_than 5.6.9
+then
+    rm -rf $topdir/backup
+
+    MYSQLD_EXTRA_MY_CNF_OPTS="
+    gtid_mode=on
+    enforce_gtid_consistency=on
+    "
+    if is_server_version_lower_than 5.7.0
+    then
+       MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS}
+       log-slave-updates=on"
+    fi
+
+    start_server_with_id $slave2_id
+    setup_slave GTID $slave2_id $master_id
+
+    vlog "Full backup of the GTID with AUTO_POSITION slave server"
+    xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
+
+    run_cmd egrep -q '^SET GLOBAL gtid_purged=.*$' \
+        $topdir/backup/xtrabackup_slave_info
+    run_cmd egrep -q '^CHANGE MASTER TO MASTER_AUTO_POSITION=1$' \
+        $topdir/backup/xtrabackup_slave_info
+
+    rm -rf $topdir/backup
+
+    # Restarting master in GTID mode, but not setting AUTO_POSITION on slave
+    # so it uses binlog.
+    stop_server_with_id $master_id
+    start_server_with_id $master_id
+    start_server_with_id $slave3_id
+    setup_slave $slave3_id $master_id
+
+    vlog "Full backup of the GTID slave server"
+    xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
+
+    run_cmd egrep -q '^CHANGE MASTER TO MASTER_LOG_FILE='\''mysql-bin.[0-9]+'\'', MASTER_LOG_POS=[0-9]+$' \
+        $topdir/backup/xtrabackup_slave_info
+fi


### PR DESCRIPTION
Using 'Auto_Position' and 'Using_Gtid' variables to determine GTID mode status for MySQL and MariaDB respectively.

param-build: http://jenkins.percona.com/job/percona-xtrabackup-2.4-param/219/
bug: https://jira.percona.com/browse/PXB-193