### PR TITLE
Bug 1671437: Waiting for master thread to be suspended

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3371,7 +3371,7 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 	ut_ad(srv_shutdown_state > 0);
 	if (srv_fast_shutdown == 2
-	    || srv_shutdown_state < SRV_SHUTDOWN_FLUSH_PHASE) {
+	    || srv_shutdown_state == SRV_SHUTDOWN_EXIT_THREADS) {
 		/* In very fast shutdown or when innodb failed to start, we
 		simulate a crash of the buffer pool. We are not required to do
 		any flushing. */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -2303,7 +2303,9 @@ loop:
 
 	active_thd = srv_get_active_thread_type();
 
-	if (active_thd != SRV_NONE) {
+	if (active_thd != SRV_NONE
+		|| (srv_fast_shutdown != 2
+			&& trx_rollback_or_clean_is_active)) {
 
 		if (active_thd == SRV_PURGE) {
 			srv_purge_wakeup();
@@ -2319,11 +2321,8 @@ loop:
 
 			switch (active_thd) {
 			case SRV_NONE:
-				/* This shouldn't happen because we've
-				already checked for this case before
-				entering the if(). We handle it here
-				to avoid a compiler warning. */
-				ut_error;
+				thread_type = "rollback";
+				break;
 			case SRV_WORKER:
 				thread_type = "worker threads";
 				break;


### PR DESCRIPTION
Commit c5aca380511 attempted to fix assertion
`srv_get_active_thread_type() == SRV_NONE', but did it wrong way by
exiting purge thread while there was still some work to do. It caused
transaction not being able to rollback and xtrabackup would loop
indefinitely.

This commit reverts that change and instead makes server don't switch to
`SRV_SHUTDOWN_FLUSH_PHASE' until there is no active transactions.