### PR TITLE
Bug 1671722: 6th page is not initialized

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -918,6 +918,20 @@ buf_flush_init_for_writing(
 					reset_type = FIL_PAGE_TYPE_TRX_SYS;
 				}
 				break;
+			case 3:
+			case 6:
+			case 7:
+				if (block->page.id.page_no() < 16384 &&
+				    block->page.id.space() == TRX_SYS_SPACE) {
+					reset_type = FIL_PAGE_TYPE_SYS;
+				}
+				break;
+			case 4:
+				if (block->page.id.page_no() == 4 &&
+				    block->page.id.space() == TRX_SYS_SPACE) {
+					reset_type = FIL_PAGE_INDEX;
+				}
+				break;
 			default:
 				switch (page_type) {
 				case FIL_PAGE_INDEX:

--- a/storage/innobase/xtrabackup/test/t/bug1671722.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1671722.sh
@@ -1,0 +1,36 @@
+#
+# Check that xtrabackup don't fail when pages with
+# fixed purpose have wrong page type
+#
+
+################################################################################
+# Start an uncommitted transaction pause "indefinitely" to keep the connection
+# open
+################################################################################
+function start_uncomitted_transaction()
+{
+    run_cmd $MYSQL $MYSQL_ARGS sakila <<EOF
+START TRANSACTION;
+DELETE FROM payment;
+SELECT SLEEP(10000);
+EOF
+}
+
+start_server
+load_sakila
+
+start_uncomitted_transaction &
+transaction=$!
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+kill -SIGKILL $transaction
+stop_server
+
+# set page type (FIL_PAGE_TYPE field) of pages 6 and 7 to FIL_PAGE_TYPE_UNKNOWN
+for page in 6 7 ; do
+	offs=$(( 16384 * page + 24 ))
+	printf '\x00\x0d' | dd of=$topdir/backup/ibdata1 bs=1 seek=$offs count=2 conv=notrunc
+done
+
+xtrabackup --prepare --target-dir=$topdir/backup --innodb-checksum-algorithm=NONE


### PR DESCRIPTION
Fix initializes following pages if they were not initialized by
server properly:

-   Page 3, type SYS: Headers and bookkeeping information related to
    insert buffering.
-   Page 4, type INDEX: The root page of the index structure used for
    insert buffering.
-   Page 5, type TRX_SYS: Information related to the operation of
    InnoDB’s transaction system, such as the latest transaction ID,
    MySQL binary log information, and the location of the double write
    buffer extents.
-   Page 6, type SYS: The first rollback segment page. Additional pages
    (or whole extents) are allocated as needed to store rollback
    segment data.
-   Page 7, type SYS: Headers related to the data dictionary,
    containing root page numbers for the indexes that make up the data
    dictionary. This information is required to be able to find any
    other indexes (tables), as their root page numbers are stored in
    the data dictionary itself.

