### PR TITLE
Bug 1702694: jenkins build fails due to privilege check test failure

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7208,8 +7208,8 @@ check_all_privileges()
 	if (!opt_no_lock
 		/* LOCK TABLES FOR BACKUP */
 		/* UNLOCK TABLES */
-		|| (have_backup_locks && !opt_no_lock) || opt_slave_info
-		|| opt_binlog_info == BINLOG_INFO_ON) {
+		&& ((have_backup_locks && !opt_no_lock) || opt_slave_info
+		|| opt_binlog_info == BINLOG_INFO_ON)) {
 		check_result |= check_privilege(
 			granted_privileges,
 			"LOCK TABLES", "*", "*");


### PR DESCRIPTION
Updated test case to correctly handle case of innodb51
Fixed a minor bug in check_all_privileges()

bug: https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1702694
param-build: http://jenkins.percona.com/view/PXB%202.3/job/percona-xtrabackup-2.3-param/312/