### PR TITLE
Bug 1701736: XtraBackup 2.4.7 not backing up remote file per table

### DIFF
--- a/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/remote_tablespaces.sh
@@ -41,6 +41,11 @@ stop_server
 rm -rf $mysql_datadir/*
 rm -rf $remote_dir
 
+for ((i=0; i<12; i++))
+do
+    test -f $topdir/backup/test/t${i}.ibd || die "Remote tablespace is missing from backup!"
+done
+
 innobackupex --apply-log $topdir/backup
 
 for cmd in "--copy-back" "--move-back" ; do


### PR DESCRIPTION
tablespaces

Xtrabackup 2.4 was not loading remote tablespaces into tablespace
dictionary and thus not copying corresponding `.ibd' files to the backup
directory.