### PR TITLE
Add options to block DDLs for the duration of backup

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -34,6 +34,8 @@ extern ulint redo_log_version;
 extern bool innodb_log_checksum_algorithm_specified;
 extern bool innodb_checksum_algorithm_specified;
 
+extern my_bool opt_lock_ddl_per_table;
+
 /******************************************************************************
 Callback used in buf_page_io_complete() to detect compacted pages.
 @return TRUE if the page is marked as compacted, FALSE otherwise. */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1786,7 +1786,7 @@ recv_parse_or_apply_log_rec_body(
 		of offline backup and continue.
 		*/
 		if (!recv_recovery_on) {
-			if (is_online_redo_copy) {
+			if (!opt_lock_ddl_per_table) {
 				if (backup_redo_log_flushed_lsn
 				    < recv_sys->recovered_lsn) {
 					ib::info() << "Last flushed lsn: "
@@ -1799,14 +1799,15 @@ recv_parse_or_apply_log_rec_body(
 							"able to determine the"
 							"InnoDB Engine Status";
 
-					ib::fatal() << "An optimized(without"
+					ib::error() << "An optimized (without"
 						" redo logging) DDLoperation"
 						" has been performed. All"
 						" modified pages may not have"
 						" been flushed to the disk yet."
-						" \n    PXB will not be able"
+						" \nPXB will not be able"
 						" take a consistent backup."
 						" Retry the backup operation";
+					exit(EXIT_FAILURE);
 				}
 				/** else the index is flushed to disk before
 				backup started hence no error */
@@ -1817,12 +1818,10 @@ recv_parse_or_apply_log_rec_body(
 					<< " load_index lsn "
 					<< recv_sys->recovered_lsn;
 
-				ib::warn() << "An optimized(without redo"
+				ib::warn() << "An optimized (without redo"
 					" logging) DDL operation has been"
 					" performed. All modified pages may not"
-					" have been flushed to the disk yet."
-					" \n    This offline backup may not"
-					" be consistent";
+					" have been flushed to the disk yet.";
 			}
 		}
 #endif /* UNIV_HOTBACKUP */

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -67,9 +67,6 @@ static std::set<std::string> rsync_list;
 /* locations of tablespaces read from .isl files */
 static std::map<std::string, std::string> tablespace_locations;
 
-/* Whether LOCK BINLOG FOR BACKUP has been issued during backup */
-bool binlog_locked;
-
 /************************************************************************
 Struct represents file or directory. */
 struct datadir_node_t {
@@ -1386,7 +1383,7 @@ backup_start()
 
 		history_lock_time = time(NULL);
 
-		if (!lock_tables(mysql_connection)) {
+		if (!lock_tables_maybe(mysql_connection)) {
 			return(false);
 		}
 	}

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -11,8 +11,6 @@
 #define XTRABACKUP_BINLOG_INFO "xtrabackup_binlog_info"
 #define XTRABACKUP_INFO "xtrabackup_info"
 
-extern bool binlog_locked;
-
 bool
 backup_file_printf(const char *filename, const char *fmt, ...)
 		__attribute__((format(printf, 2, 0)));

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -94,6 +94,13 @@ const char *xb_stream_format_name[] = {"file", "tar", "xbstream"};
 
 MYSQL *mysql_connection;
 
+/* Whether LOCK BINLOG FOR BACKUP has been issued during backup */
+static bool binlog_locked;
+
+/* Whether LOCK TABLES FOR BACKUP / FLUSH TABLES WITH READ LOCK has been issued
+during backup */
+static bool tables_locked;
+
 extern "C" {
 MYSQL * STDCALL
 cli_mysql_real_connect(MYSQL *mysql,const char *host, const char *user,
@@ -313,7 +320,6 @@ const char* get_backup_uuid(MYSQL *connection)
 	return backup_uuid;
 }
 
-static
 void
 parse_show_engine_innodb_status(MYSQL *connection)
 {
@@ -629,8 +635,6 @@ get_mysql_vars(MYSQL *connection)
 				SRV_CHECKSUM_ALGORITHM_NONE;
 		}
 	}
-
-	parse_show_engine_innodb_status(connection);
 
 out:
 	free_mysql_variables(mysql_vars);
@@ -983,26 +987,57 @@ stop_query_killer()
 	os_event_wait_time(kill_query_thread_stopped, 60000);
 }
 
+
+/*********************************************************************//**
+Function acquires a backup tables lock if supported by the server.
+Allows to specify timeout in seconds for attempts to acquire the lock.
+@returns true if lock acquired */
+bool
+lock_tables_for_backup(MYSQL *connection, int timeout)
+{
+	if (have_lock_wait_timeout) {
+		char query[200];
+
+		ut_snprintf(query, sizeof(query),
+			    "SET SESSION lock_wait_timeout=%d", timeout);
+
+		xb_mysql_query(connection, query, false);
+	}
+
+	if (have_backup_locks) {
+		msg_ts("Executing LOCK TABLES FOR BACKUP...\n");
+		xb_mysql_query(connection, "LOCK TABLES FOR BACKUP", true);
+		tables_locked = true;
+		return(true);
+	}
+
+	msg_ts("Error: LOCK TABLES FOR BACKUP is not supported.\n");
+
+	return(false);
+}
+
 /*********************************************************************//**
 Function acquires either a backup tables lock, if supported
 by the server, or a global read lock (FLUSH TABLES WITH READ LOCK)
 otherwise.
 @returns true if lock acquired */
 bool
-lock_tables(MYSQL *connection)
+lock_tables_maybe(MYSQL *connection)
 {
+	if (tables_locked || opt_lock_ddl_per_table) {
+		return(true);
+	}
+
+	if (have_backup_locks) {
+		return lock_tables_for_backup(connection);
+	}
+
 	if (have_lock_wait_timeout) {
 		/* Set the maximum supported session value for
 		lock_wait_timeout to prevent unnecessary timeouts when the
 		global value is changed from the default */
 		xb_mysql_query(connection,
 			"SET SESSION lock_wait_timeout=31536000", false);
-	}
-
-	if (have_backup_locks) {
-		msg_ts("Executing LOCK TABLES FOR BACKUP...\n");
-		xb_mysql_query(connection, "LOCK TABLES FOR BACKUP", false);
-		return(true);
 	}
 
 	if (!opt_lock_wait_timeout && !opt_kill_long_queries_timeout) {
@@ -1048,6 +1083,8 @@ lock_tables(MYSQL *connection)
 	if (opt_kill_long_queries_timeout) {
 		stop_query_killer();
 	}
+
+	tables_locked = true;
 
 	return(true);
 }
@@ -1967,3 +2004,75 @@ backup_cleanup()
 		mysql_close(mysql_connection);
 	}
 }
+
+static ib_mutex_t mdl_lock_con_mutex;
+static MYSQL *mdl_con = NULL;
+
+void
+mdl_lock_init()
+{
+	mutex_create(LATCH_ID_XTRA_DATAFILES_ITER_MUTEX, &mdl_lock_con_mutex);
+
+	mdl_con = xb_mysql_connect();
+
+	if (mdl_con != NULL) {
+		xb_mysql_query(mdl_con, "BEGIN", false, true);
+	}
+}
+
+
+void
+mdl_lock_table(ulint space_id)
+{
+	MYSQL_RES *mysql_result = NULL;
+	MYSQL_ROW row;
+	char *query;
+
+	mutex_enter(&mdl_lock_con_mutex);
+
+	xb_a(asprintf(&query,
+		"SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES "
+		"WHERE SPACE = %lu", space_id));
+
+	xb_mysql_query(mdl_con, query, true, true);
+
+	mysql_result = xb_mysql_query(mdl_con, query, true);
+
+	while ((row = mysql_fetch_row(mysql_result))) {
+		char *table_name = strdup(row[0]);
+		char *separator = strchr(table_name, '/');
+		char *lock_query;
+
+		if (separator != NULL) {
+			*separator = '.';
+		}
+
+		msg_ts("Locking MDL for %s\n", table_name);
+
+		xb_a(asprintf(&lock_query,
+			"SELECT * FROM %s LIMIT 1",
+			table_name));
+
+		xb_mysql_query(mdl_con, lock_query, false, false);
+
+		free(lock_query);
+		free(table_name);
+	}
+
+	mysql_free_result(mysql_result);
+	free(query);
+
+	mutex_exit(&mdl_lock_con_mutex);
+}
+
+
+void
+mdl_unlock_all()
+{
+	msg_ts("Unlocking MDL for all tables");
+
+	xb_mysql_query(mdl_con, "COMMIT", false, true);
+
+	mutex_free(&mdl_lock_con_mutex);
+}
+

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -81,7 +81,10 @@ bool
 lock_binlog_maybe(MYSQL *connection);
 
 bool
-lock_tables(MYSQL *connection);
+lock_tables_for_backup(MYSQL *connection, int timeout = 31536000);
+
+bool
+lock_tables_maybe(MYSQL *connection);
 
 bool
 wait_for_safe_slave(MYSQL *connection);
@@ -92,5 +95,16 @@ write_galera_info(MYSQL *connection);
 bool
 write_slave_info(MYSQL *connection);
 
+void
+parse_show_engine_innodb_status(MYSQL *connection);
+
+void
+mdl_lock_init();
+
+void
+mdl_lock_table(ulint space_id);
+
+void
+mdl_unlock_all();
 
 #endif

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -1,0 +1,96 @@
+# Check lock-ddl, lock-ddl-timeout and lock-ddl-per-table
+
+require_server_version_higher_than 5.7.0
+
+start_server
+
+load_sakila
+
+function start_transaction() {
+	run_cmd_expect_failure $MYSQL $MYSQL_ARGS <<EOF
+BEGIN;
+SELECT * FROM sakila.payment LIMIT 1;
+SELECT SLEEP(10000);
+EOF
+}
+
+function alter_table() {
+	run_cmd_expect_failure $MYSQL $MYSQL_ARGS \
+		-e "ALTER TABLE sakila.payment ADD COLUMN col1 INT"
+}
+
+if ! has_backup_locks ;
+then
+
+	run_cmd_expect_failure $XB_BIN $XB_ARGS \
+		--backup --lock-ddl --target-dir=$topdir/backup1
+
+else
+
+	xtrabackup --backup --lock-ddl \
+		--lock-ddl-timeout=2 --target-dir=$topdir/backup1
+
+	start_transaction &
+	tr_job_id=$!
+
+	while ! mysql -e 'SHOW PROCESSLIST' | grep -q 'User sleep' ; do
+		sleep 1
+	done
+
+	alter_table &
+	ddl_job_id=$!
+
+	while ! mysql -e 'SHOW PROCESSLIST' | grep -q 'Waiting for table metadata lock' ; do
+		sleep 1
+	done
+
+	# SELECT blocks ALTER TABLE, ALTER TABLE blocks LOCK TABLES FOR BACKUP
+	run_cmd_expect_failure \
+		$XB_BIN $XB_ARGS --backup --lock-ddl --lock-ddl-timeout=2 \
+				 --target-dir=$topdir/backup2
+
+	mysql -Ne "SELECT CONCAT('KILL ', id, ';') FROM \
+	INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'SELECT SLEEP%' \
+	OR info LIKE 'ALTER TABLE%'" | mysql
+
+	wait $tr_job_id
+	wait $ddl_job_id
+
+	xtrabackup --backup --lock-ddl \
+		--lock-ddl-timeout=2 --target-dir=$topdir/backup3
+
+fi
+
+mysql -e "CREATE TABLE rcount (val INT)" test
+mysql -e "INSERT INTO rcount (val) VALUES (0)" test
+
+function heavy_index_rotation() {
+	trap "finish=true" SIGUSR1
+	finish="false"
+	while [ $finish != "true" ] ; do
+		mysql -e "CREATE INDEX idx_payment_date ON payment (payment_date)" sakila
+		mysql -e "DROP INDEX idx_payment_date ON payment" sakila
+		mysql -e "UPDATE rcount SET val = val + 1" test
+	done
+}
+
+heavy_index_rotation &
+job_id=$!
+
+while [ `mysql -Ne "SELECT val FROM rcount"` -lt "3" ] ; do
+	sleep 1
+done
+
+xtrabackup --backup --lock-ddl-per-table --target-dir=$topdir/backup5
+xtrabackup --prepare --target-dir=$topdir/backup5
+
+if has_backup_locks ;
+then
+	xtrabackup --backup --lock-ddl --target-dir=$topdir/backup6
+	xtrabackup --prepare --target-dir=$topdir/backup6
+fi
+
+kill -USR1 $job_id
+wait $job_id
+
+stop_server


### PR DESCRIPTION
Blueprint:
https://blueprints.launchpad.net/percona-xtrabackup/+spec/mdl-lock-tables

`--lock-ddl` to issue `LOCK TABLES FOR BACKUP` at the beginning of the
backup if it is supported by server. Backup aborts if `LOCK TABLES FOR
BACKUP` is not supported.

`--lock-ddl-timeout` to set timeout for `LOCK TABLES FOR BACKUP` to wait
for lock.

`--lock-ddl-per-table` during the datafiles copy process, xtrabackup
will place MDL lock (using the `SELECT * LIMIT 1` inside of transaction)
for each table it starting to copy. Locks are released at the end of the
backup by committing transaction.