### PR TITLE
Bug 1691093: xtrabackup increment crashes with --prepare --apply-log-only and --throttle

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7352,6 +7352,11 @@ int main(int argc, char **argv)
 		    "as --innodb-log-arch-dir and --to-archived-lsn can be used "
 		    "only with --prepare they will be reset\n");
 	}
+	if (xtrabackup_throttle && !xtrabackup_backup) {
+		xtrabackup_throttle = 0;
+		msg("xtrabackup: warning: --throttle has effect "
+		    "only with --backup");
+	}
 
 	/* cannot execute both for now */
 	{

--- a/storage/innobase/xtrabackup/test/t/bug1691093.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1691093.sh
@@ -1,0 +1,26 @@
+start_server
+
+vlog "Full backup"
+
+xtrabackup --backup \
+    --target-dir=$topdir/data/full
+
+vlog "Incremental backup"
+
+xtrabackup --backup \
+    --target-dir=$topdir/data/delta \
+    --incremental-basedir=$topdir/data/full
+
+vlog "Prepare full"
+
+xtrabackup --prepare --apply-log-only \
+    --throttle=40 \
+    --target-dir=$topdir/data/full
+
+vlog "Prepare incremental"
+xtrabackup --prepare --apply-log-only \
+    --throttle=40 \
+    --target-dir=$topdir/data/full --incremental-dir=$topdir/data/delta \
+    2>&1 | tee $topdir/pxb.log
+
+run_cmd grep 'xtrabackup: warning.*--throttle' $topdir/pxb.log


### PR DESCRIPTION
Ported from 2.3 to 2.4:

Disabling throttle if not performing a backup;
Added an extra warning message to inform user.

Bug: https://bugs.launchpad.net/percona-xtrabackup/+bug/1691093
PR to 2.3: https://github.com/percona/percona-xtrabackup/pull/389
Param-build: http://jenkins.percona.com/job/percona-xtrabackup-2.4-param/228/