### PR TITLE
Bug 1704636: xtrabackup 2.4.7 crashes while backing up MariaDB 10.2.x

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -753,8 +753,10 @@ have_queries_to_wait_for(MYSQL *connection, uint threshold)
 	all_queries = (opt_lock_wait_query_type == QUERY_TYPE_ALL);
 	while ((row = mysql_fetch_row(result)) != NULL) {
 		const char	*info		= row[7];
-		int		duration	= atoi(row[5]);
 		char		*id		= row[0];
+		int		duration;
+
+		duration = (row[5] != NULL) ? atoi(row[5]) : 0;
 
 		if (info != NULL
 		    && duration >= (int)threshold


### PR DESCRIPTION
with ftwrl-* options

Unlike MySQL or Percona Server, MariaDB can return NULL as Time in SHOW
PROCESSLIST. Fix is to treat NULL as 0.