### PR TITLE
Make chunk size produced by innobackupex/xtrabackup adjustable

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -514,7 +514,8 @@ datafile_open(const char *file, datafile_cur_t *cursor, uint thread_n)
 
 	posix_fadvise(cursor->file, 0, 0, POSIX_FADV_SEQUENTIAL);
 
-	cursor->buf_size = 10 * 1024 * 1024;
+	ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
+	cursor->buf_size = opt_read_buffer_size;
 	cursor->buf = static_cast<byte *>(ut_malloc(cursor->buf_size));
 
 	return(true);

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -240,8 +240,9 @@ xb_fil_cur_open(
 	cursor->page_size_shift = page_size_shift;
 	cursor->zip_size = zip_size;
 
+	ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
 	/* Allocate read buffer */
-	cursor->buf_size = XB_FIL_CUR_PAGES * page_size;
+	cursor->buf_size = opt_read_buffer_size;
 	cursor->orig_buf = static_cast<byte *>
 		(ut_malloc(cursor->buf_size + UNIV_PAGE_SIZE));
 	cursor->buf = static_cast<byte *>

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -391,6 +391,7 @@ uint opt_safe_slave_backup_timeout = 0;
 
 const char *opt_history = NULL;
 my_bool opt_decrypt = FALSE;
+uint opt_read_buffer_size = 0;
 
 #if defined(HAVE_OPENSSL)
 my_bool opt_ssl_verify_server_cert = FALSE;
@@ -617,6 +618,7 @@ enum options_xtrabackup
   OPT_XTRA_TABLES_EXCLUDE,
   OPT_XTRA_DATABASES_EXCLUDE,
   OPT_XTRA_CHECK_PRIVILEGES,
+  OPT_XTRA_READ_BUFFER_SIZE,
 };
 
 struct my_option xb_client_options[] =
@@ -1022,6 +1024,15 @@ struct my_option xb_client_options[] =
   {"check-privileges", OPT_XTRA_CHECK_PRIVILEGES, "Check database user "
     "privileges before performing any query.", &opt_check_privileges,
    &opt_check_privileges, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+  {"read_buffer_size",
+   OPT_XTRA_READ_BUFFER_SIZE,
+   "Set datafile read buffer size, given value is scaled up to page size."
+   " Default is 10Mb.",
+   &opt_read_buffer_size,
+   &opt_read_buffer_size,
+   0, GET_UINT, OPT_ARG, 10*1024*1024,
+   UNIV_PAGE_SIZE_MAX, UINT_MAX, 0, UNIV_PAGE_SIZE_MAX, 0},
 
 #include "sslopt-longopts.h"
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -167,6 +167,8 @@ extern uint		opt_safe_slave_backup_timeout;
 extern const char	*opt_history;
 extern my_bool		opt_decrypt;
 
+extern uint		opt_read_buffer_size;
+
 #if defined(HAVE_OPENSSL)
 extern my_bool opt_use_ssl;
 extern my_bool opt_ssl_verify_server_cert;

--- a/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
+++ b/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
@@ -1,0 +1,106 @@
+start_server
+
+########################################################################
+# Restore backup from given directory and . If given
+# multiple directories, first one is threated as base, rest as incremental.
+# Synopsis:
+#   restore_from <backup_dir> [<incremental_backup_dir> ...]
+#########################################################################
+function restore_from()
+{
+    local backup_path=$1
+    shift 1
+    stop_server
+    rm -rf $mysql_datadir/*
+    extra=
+
+
+    if [ "$#" -ne 0 ]
+    then
+        vlog "Preparing $backup_path as base of incremental backup"
+        extra="--apply-log-only "
+    else
+        vlog "Preparing $backup_path"
+    fi
+    run_cmd xtrabackup --prepare $extra --target-dir=$backup_path
+
+    while [ "$#" -ne 0 ]
+    do
+        incremental_dir=$1
+        shift 1
+        if [ "$#" -eq 0 ]
+        then
+            vlog "Last incremental $incremental_dir"
+            extra=
+        else
+            extra='--apply-log-only'
+        fi
+        vlog "Preparing $incremental_dir as incremental"
+        run_cmd xtrabackup --prepare $extra\
+           --target-dir=$backup_path --incremental-dir=$incremental_dir
+    done
+
+    run_cmd xtrabackup --copy-back --target-dir=$backup_path
+    start_server
+}
+
+function test_backup_with_custom_read_buffer()
+{
+    local buffer_size=$1
+    local backup_dest=$topdir/backup_${buffer_size}
+    local backup_dest_base=$topdir/backup_${buffer_size}_base
+    local backup_dest_inc=$topdir/backup_${buffer_size}_inc
+
+    vlog "$buffer_size buffer size"
+    vlog "Regular backup."
+    xtrabackup --backup --target-dir=$backup_dest \
+        --read_buffer_size=$buffer_size
+
+    mkdir $backup_dest_base
+    cp -r $backup_dest/* $backup_dest_base
+
+    vlog "Restoring."
+    restore_from $backup_dest
+
+    vlog "Verifying."
+    verify_db_state incremental_sample
+
+    vlog "Inserting more data into table"
+    multi_row_insert incremental_sample.test \({1000..1500},200\)
+    record_db_state incremental_sample
+
+    vlog "Incremental backup."
+    xtrabackup --backup \
+        --incremental-basedir=$backup_dest_base \
+        --target-dir=$backup_dest_inc
+
+    vlog "Restoring incremental."
+    restore_from $backup_dest $backup_dest_inc
+
+    vlog "Verifying incremental."
+    verify_db_state incremental_sample
+}
+
+load_dbase_schema incremental_sample
+multi_row_insert incremental_sample.test \({1..1000},100\)
+
+vlog "Creating a MyISAM-powered clone of the incremental_sample.test"
+mysql -e "show create table incremental_sample.test;" \
+    | tail -n +2 \
+    | sed -r 's/test\s+CREATE TABLE `test`/CREATE TABLE `test_MyISAM`/' \
+    | sed 's/ENGINE=InnoDB/ENGINE=MyISAM/' \
+    > $topdir/test_myISAM.sql
+
+mysql incremental_sample <<EOF
+$(cat $topdir/test_myISAM.sql);
+insert into test_MyISAM select * from test;
+EOF
+
+record_db_state incremental_sample
+
+test_backup_with_custom_read_buffer 1Kb
+
+vlog "Reverting table to original state"
+mysql -e "delete from incremental_sample.test where a >= 1000"
+
+test_backup_with_custom_read_buffer 50Mb


### PR DESCRIPTION
https://blueprints.launchpad.net/percona-xtrabackup/+spec/adjustable-chunk-size

Added option '--datafile_buffer_size_multiplicator' that allows to
increase size of the datafile read buffer.