### PR TITLE
Add deprecation notice for innobackupex

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/innobackupex/innobackupex_script.rst
+++ b/storage/innobase/xtrabackup/doc/source/innobackupex/innobackupex_script.rst
@@ -1,10 +1,13 @@
 =========================
- The innobackupex Script
+ The innobackupex Program
 =========================
 
-The |innobackupex| tool is a *Perl* script that acts as a wrapper for the :doc:`xtrabackup <../xtrabackup_bin/xtrabackup_binary>` *C* program. It is a patched version of the ``innobackup`` *Perl* script that *Oracle* distributes with the *InnoDB Hot Backup* tool. It enables more functionality by integrating |xtrabackup| and other functions such as file copying and streaming, and adds some convenience. It lets you perform point-in-time backups of |InnoDB| / |XtraDB| tables together with the schema definitions, |MyISAM| tables, and other portions of the server.
+The |innobackupex| program is a symlink to the :doc:`xtrabackup <../xtrabackup_bin/xtrabackup_binary>` *C* program. It lets you perform point-in-time backups of |InnoDB| / |XtraDB| tables together with the schema definitions, |MyISAM| tables, and other portions of the server. In previous versions |innobackupex| was implemented as a *Perl* script.
 
 This manual section explains how to use |innobackupex| in detail.
+
+.. warning::
+   The |innobackupex| program is deprecated. Please switch to |xtrabackup|.
 
 The Backup Cycle - Full Backups
 ===============================

--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -753,6 +753,8 @@ You can download full text of the license on http://www.gnu.org/licenses/gpl-2.0
 
 	puts("innobackupex - Non-blocking backup tool for InnoDB, XtraDB and HailDB databases\n\
 \n\
+NOTICE: 'innobackupex' is deprecated, please switch to 'xtrabackup'\n\
+\n\
 SYNOPOSIS\n\
 \n\
 innobackupex [--compress] [--compress-threads=NUMBER-OF-THREADS] [--compress-chunk-size=CHUNK-SIZE]\n\


### PR DESCRIPTION
As a follow up for: https://bugs.launchpad.net/percona-xtrabackup/+bug/1706314

innobackupex is the compatibility layer of xtrabackup to be compatible with the way
the original perl script was called.

From the bug report:
"innobackupex is deprecated we don't add new options to this binary and don't fix bugs in it"

Not that most options are identical, so switching should be easy.

Also note the lie in the manpage: "The innobackupex tool is a Perl script"