### PR TITLE
Bug 1707918: using innobackupx with --slave-info output file xtraback…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -845,7 +845,6 @@ error:
 	return false;
 }
 
-static
 bool
 backup_file_print(const char *filename, const char *message, int len)
 {
@@ -901,28 +900,6 @@ backup_file_printf(const char *filename, const char *fmt, ...)
 	}
 
 	result = backup_file_print(filename, buf, buf_len);
-
-	free(buf);
-	return(result);
-}
-
-bool
-backup_ds_printf(ds_file_t *dstfile, const char *fmt, ...)
-{
-	bool result  = false;
-	char *buf    = 0;
-	int  buf_len = 0;
-	va_list ap;
-
-	va_start(ap, fmt);
-	buf_len = vasprintf(&buf, fmt, ap);
-	va_end(ap);
-
-	if (buf_len == -1) {
-		return false;
-	}
-
-	result = backup_ds_print(dstfile, buf, buf_len);
 
 	free(buf);
 	return(result);

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -12,11 +12,10 @@
 #define XTRABACKUP_INFO "xtrabackup_info"
 
 bool
-backup_file_printf(const char *filename, const char *fmt, ...)
-		__attribute__((format(printf, 2, 0)));
+backup_file_print(const char *filename, const char *message, int len);
 
 bool
-backup_ds_printf(ds_file_t *dstfile, const char *fmt, ...)
+backup_file_printf(const char *filename, const char *fmt, ...)
 		__attribute__((format(printf, 2, 0)));
 
 /************************************************************************


### PR DESCRIPTION
…up_slave_info does not contain slave information in 2.4.8

Fixed xtrabackup_slave_info creation so the archive header is set properly now.
Added a test.