### PR TITLE
BUG 1590320: Flush binary logs for consistent GTID

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1590320.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1590320.sh
@@ -1,0 +1,41 @@
+########################################################################
+# Test for consistent mysql.gtid_executed on restore
+########################################################################
+
+. inc/common.sh
+
+require_server_version_higher_than 5.7.4
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+gtid_mode=on
+log_slave_updates=on
+enforce_gtid_consistency=on
+"
+start_server
+
+$MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE t(id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, c INT);
+INSERT INTO t(c) VALUES (1),(2),(3),(4),(5),(6),(7),(8);
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+master_gtid_executed=$(run_cmd $MYSQL $MYSQL_ARGS -Nse 'SELECT @@global.gtid_executed' mysql)
+stop_server
+
+rm -fr $mysql_datadir/*
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+slave_gtid_executed=$(run_cmd $MYSQL $MYSQL_ARGS -Nse 'SELECT @@global.gtid_executed' mysql)
+
+if [ $master_gtid_executed != $slave_gtid_executed ]
+then
+	vlog "GTIDs do not match! ($master_gtid_executed != $slave_gtid_executed)"
+	exit -1
+fi
+
+vlog "GTIDs are OK ($master_gtid_executed == $slave_gtid_executed)"


### PR DESCRIPTION
GTIDs are only flushed to the mysql.gtid_executed on binlog rotate or
on a clean shutdown.  During a backup, the contents of this table may be
lagging significantly behind @@global.gtid_executed.  This means that
without flushing binlogs that a restored instance's
@@global.gtid_executed is not guaranteed to contain the correct
coordinates and may require manual steps to fix.

With this change under MySQL 5.7.5+ with gtid replication enabled,
xtrabackup flushes binary logs to ensure up-to-date contents of the
mysql.gtid_executed table.