### PR TITLE
Bug 1533722: xtrabackup crashed during apply 5.5 backup set with utf8_general50_ci collation

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1612,7 +1612,15 @@ innobase_get_cset_width(
 			}
 		} else {
 
-			ut_a(cset == 0);
+			if (cset != 0) {
+				/* Since we don't do anything fancy with the
+				data itself, it is safe to ignore missing
+				collation. (special case for collation that
+				isn't supported in vanilla MySQL) */
+				ib_logf(IB_LOG_LEVEL_WARN,
+					"Unknown collation #%lu.",
+					cset);
+			}
 		}
 
 		*mbminlen = *mbmaxlen = 0;

--- a/storage/innobase/xtrabackup/test/t/bug1533722.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1533722.sh
@@ -1,0 +1,38 @@
+if ! is_xtradb || ! is_server_version_higher_than 5.5.23 || ! is_server_version_lower_than 5.6.0
+then
+    skip_test "Requires PS 5.5.23 or higher, but less than 5.6"
+fi
+
+function long_transaction()
+{
+    mysql foo <<EOF
+start transaction;
+insert into sbtest values (999999999, 'longrunning transaction');
+select sleep(1000);
+EOF
+}
+
+start_server
+
+mysql <<EOF
+create database foo;
+CREATE TABLE foo.sbtest (
+  i int PRIMARY KEY,
+  c char(50) CHARACTER SET utf8 COLLATE utf8_general50_ci NOT NULL DEFAULT ''
+) ENGINE=InnoDB;
+EOF
+
+multi_row_insert foo.sbtest \({1..100},\'"text"\'\)
+record_db_state foo
+long_transaction &
+sleep 1
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+xtrabackup --move-back --target-dir=$topdir/backup
+start_server
+
+verify_db_state foo


### PR DESCRIPTION
Ignoring unknown collations, since we are not currently
doing anything interesting with the data itself.
Added a test case to verify the fix.

Bug: https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1533722
Param-build: http://jenkins.percona.com/job/percona-xtrabackup-2.3-param-light/30/