### PR TITLE
PXB-197: 5.6 MTR PXB failure in galera_sst_xtrabackup-v2-options on all nodes

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_decrypt.c
+++ b/storage/innobase/xtrabackup/src/ds_decrypt.c
@@ -355,26 +355,31 @@ decrypt_write(ds_file_t *file, const void *buf, size_t len)
 	nthreads = crypt_ctxt->nthreads;
 
 	if (crypt_file->buf_len > 0) {
+		const size_t remainder = crypt_file->buf_len;
+		size_t new_data_size = 0;
 		thd = threads;
 
 		pthread_mutex_lock(&thd->ctrl_mutex);
-
 		do {
-			if (parse_result == XB_CRYPT_READ_INCOMPLETE) {
-				crypt_file->buf_size = crypt_file->buf_size * 2;
+			if (parse_result == XB_CRYPT_READ_INCOMPLETE
+			    || crypt_file->buf_size == remainder) {
+				crypt_file->buf_size *= 2;
 				crypt_file->buf = (uchar *) my_realloc(
 						crypt_file->buf,
 						crypt_file->buf_size,
 						MYF(MY_FAE|MY_ALLOW_ZERO_PTR));
 			}
 
-			memcpy(crypt_file->buf + crypt_file->buf_len,
-			       buf, MY_MIN(crypt_file->buf_size -
-					   crypt_file->buf_len, len));
+			new_data_size = MY_MIN(crypt_file->buf_size -
+					       remainder, len);
+			xb_ad(new_data_size > 0u);
+			memcpy(crypt_file->buf + remainder, buf,
+			       new_data_size);
 
 			parse_result = parse_xbcrypt_chunk(
 				thd, crypt_file->buf,
-				crypt_file->buf_size, &bytes_processed);
+				remainder + new_data_size,
+				&bytes_processed);
 
 			if (parse_result == XB_CRYPT_READ_ERROR) {
 				pthread_mutex_unlock(&thd->ctrl_mutex);
@@ -382,10 +387,19 @@ decrypt_write(ds_file_t *file, const void *buf, size_t len)
 			}
 
 		} while (parse_result == XB_CRYPT_READ_INCOMPLETE &&
-			 crypt_file->buf_size < len);
+			 crypt_file->buf_size < remainder + len);
+		crypt_file->buf_len += new_data_size;
+
+		/* Give caller a chance to supply remaining data in subsequent
+		invocations, closing a file will report an error if there is
+		still some buffered data left unprocessed. */
+		if (parse_result == XB_CRYPT_READ_INCOMPLETE) {
+			pthread_mutex_unlock(&thd->ctrl_mutex);
+			return 0;
+		}
 
 		if (parse_result != XB_CRYPT_READ_CHUNK) {
-			msg("decrypt: incomplete data.\n");
+			msg("decrypt: failed to decrypt.\n");
 			pthread_mutex_unlock(&thd->ctrl_mutex);
 			return 1;
 		}
@@ -395,8 +409,9 @@ decrypt_write(ds_file_t *file, const void *buf, size_t len)
 		pthread_cond_signal(&thd->data_cond);
 		pthread_mutex_unlock(&thd->data_mutex);
 
-		len -= bytes_processed - crypt_file->buf_len;
-		buf += bytes_processed - crypt_file->buf_len;
+		xb_ad(bytes_processed > remainder);
+		len -= bytes_processed - remainder;
+		buf += bytes_processed - remainder;
 
 		/* reap */
 
@@ -530,7 +545,15 @@ decrypt_close(ds_file_t *file)
 	crypt_file = (ds_decrypt_file_t *) file->ptr;
 	dest_file = crypt_file->dest_file;
 
+	if (crypt_file->buf_len != 0) {
+		msg("decrypt: incomplete data, "
+		    "%zu bytes are still not decrypted.\n",
+		    crypt_file->buf_len);
+		rc = 2;
+	}
+
 	if (ds_close(dest_file)) {
+		msg("decrypt: failed to close dest file.\n");
 		rc = 1;
 	}
 

--- a/storage/innobase/xtrabackup/src/xbcrypt.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt.c
@@ -51,6 +51,7 @@ static void 		*opt_encrypt_key = NULL;
 static ulonglong	opt_encrypt_chunk_size = 0;
 static my_bool		opt_verbose = FALSE;
 static uint 		opt_encrypt_threads = 1;
+static uint		opt_read_buffer_size = 0;
 
 static uint 		encrypt_key_len = 0;
 
@@ -95,6 +96,13 @@ static struct my_option my_long_options[] =
 	 "The default value is 1",
 	 &opt_encrypt_threads, &opt_encrypt_threads, 0,
 	 GET_UINT, OPT_ARG, 1, 1, UINT_MAX, 0, 0, 0},
+
+	{"read-buffer-size", 'r',
+	 "Read buffer size. The defaut value is 10Mb.",
+	 &opt_read_buffer_size, &opt_read_buffer_size, 0, GET_UINT, OPT_ARG,
+	 10*1024*1024, 1, UINT_MAX,
+	 0, 0, 0
+	},
 
 	{"verbose", 'v', "Display verbose status output.",
 	 &opt_verbose, &opt_verbose,
@@ -288,12 +296,22 @@ process(File filein, ds_file_t* fileout, const char* action)
 	ulonglong		ttlchunkswritten = 0;
 	ulonglong		ttlbyteswritten = 0;
 
-	chunkbuf = (uchar *) my_malloc(opt_encrypt_chunk_size, MYF(MY_FAE));
-	while ((bytesread = my_read(filein, chunkbuf, opt_encrypt_chunk_size,
-				    MYF(MY_WME))) > 0) {
+	chunkbuf = (uchar *) my_malloc(opt_read_buffer_size, MYF(MY_FAE));
+	while (TRUE) {
+		bytesread = my_read(filein, chunkbuf, opt_read_buffer_size, MYF(MY_WME));
+		if (bytesread == 0) {
+			break;
+		}
+
+		if (bytesread == MY_FILE_ERROR) {
+			msg("%s failed to %s: can't read input.\n",
+			    my_progname, action);
+			goto err;
+		}
 
 		if (ds_write(fileout, chunkbuf, bytesread)) {
-			msg("%s failed to %s ", my_progname, action);
+			msg("%s failed to %s: can't write to output.\n",
+			    my_progname, action);
 			goto err;
 		}
 

--- a/storage/innobase/xtrabackup/test/t/PXB-197.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-197.sh
@@ -1,0 +1,47 @@
+###############################################################################
+# PXB-197: 5.6 MTR PXB failure in galera_sst_xtrabackup-v2-options on all nodes
+###############################################################################
+
+# Reproducible even on 'empty' server, so don't load any schema and data.
+start_server
+
+function check_pipestatus()
+{
+    pipestatus=${PIPESTATUS[@]}
+    local command_index=0
+    for i in ${pipestatus[@]}
+    do
+        ((command_index++))
+        if [ $i -ne 0 ]
+        then
+            die "piped command #${command_index} died with error $i"
+        fi
+    done
+}
+
+key=12345678901234567890123456789012
+algo=AES256
+
+mkdir -p $topdir/tmp $topdir/tmp2 $topdir/tmp3
+set -o pipefail
+
+run_cmd xtrabackup --backup --no-version-check --stream=xbstream --target-dir=$topdir/backup \
+    | xbcrypt --encrypt-algo=$algo --encrypt-key=$key \
+    | xbcrypt -d --encrypt-algo=$algo --encrypt-key=$key \
+    | xbstream -x -C $topdir/tmp
+
+check_pipestatus
+
+run_cmd xtrabackup --backup --no-version-check --stream=xbstream --target-dir=$topdir/backup \
+    | xbcrypt --encrypt-algo=$algo --encrypt-key=$key --read-buffer-size=10K \
+    | xbcrypt -d --encrypt-algo=$algo --encrypt-key=$key --read-buffer-size=10K \
+    | xbstream -x -C $topdir/tmp2
+
+check_pipestatus
+
+run_cmd innobackupex --backup --no-version-check --galera-info --stream=xbstream $topdir/backup2 \
+    | xbcrypt --encrypt-algo=$algo --encrypt-key=$key \
+    | xbcrypt -d --encrypt-algo=$algo --encrypt-key=$key \
+    | xbstream -x -C $topdir/tmp3
+
+check_pipestatus

--- a/storage/innobase/xtrabackup/test/t/xbcrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcrypt.sh
@@ -29,6 +29,12 @@ run_cmd xbcrypt -d -i ${test_file}.xbcrypt \
 vlog "Comparing..."
 run_cmd cmp inc/decrypt_v1_test_file.txt ${test_file}.txt
 
+vlog "Piping..."
+run_cmd xbcrypt -i inc/decrypt_v1_test_file.txt \
+    -a ${encrypt_algo} -k ${encrypt_key} \
+    | xbcrypt -d -a ${encrypt_algo} -k ${encrypt_key} \
+    > ${test_file}_pipes.txt
+run_cmd cmp inc/decrypt_v1_test_file.txt ${test_file}_pipes.txt
 
 vlog "Parallel encryption-decryption"
 run_cmd xbcrypt -i inc/decrypt_v1_test_file.txt \


### PR DESCRIPTION
Ported from 2.3

Fixed various bugs in ds_decrypt.c, all related to caller of decrypt_write
providing data in smaller portions than expected.
Added test for PXB-197 issue;
Updated xbcrypt.sh test.

Original PR: https://github.com/percona/percona-xtrabackup/pull/425
Jira issue: https://jira.percona.com/browse/PXB-197
Jenkins param-build: http://jenkins.percona.com/job/percona-xtrabackup-2.4-param-medium/28/