### PR TITLE
Make chunk size produced by innobackupex/xtrabackup adjustable

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -514,7 +514,8 @@ datafile_open(const char *file, datafile_cur_t *cursor, uint thread_n)
 
 	posix_fadvise(cursor->file, 0, 0, POSIX_FADV_SEQUENTIAL);
 
-	cursor->buf_size = 10 * 1024 * 1024;
+	ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
+	cursor->buf_size = opt_read_buffer_size;
 	cursor->buf = static_cast<byte *>(ut_malloc(cursor->buf_size));
 
 	return(true);

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -240,8 +240,9 @@ xb_fil_cur_open(
 	cursor->page_size_shift = page_size_shift;
 	cursor->zip_size = zip_size;
 
+	ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
 	/* Allocate read buffer */
-	cursor->buf_size = XB_FIL_CUR_PAGES * page_size;
+	cursor->buf_size = opt_read_buffer_size;
 	cursor->orig_buf = static_cast<byte *>
 		(ut_malloc(cursor->buf_size + UNIV_PAGE_SIZE));
 	cursor->buf = static_cast<byte *>

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -391,6 +391,7 @@ uint opt_safe_slave_backup_timeout = 0;
 
 const char *opt_history = NULL;
 my_bool opt_decrypt = FALSE;
+uint opt_read_buffer_size = 0;
 
 #if defined(HAVE_OPENSSL)
 my_bool opt_ssl_verify_server_cert = FALSE;
@@ -617,6 +618,7 @@ enum options_xtrabackup
   OPT_XTRA_TABLES_EXCLUDE,
   OPT_XTRA_DATABASES_EXCLUDE,
   OPT_XTRA_CHECK_PRIVILEGES,
+  OPT_XTRA_READ_BUFFER_SIZE,
 };
 
 struct my_option xb_client_options[] =
@@ -1022,6 +1024,15 @@ struct my_option xb_client_options[] =
   {"check-privileges", OPT_XTRA_CHECK_PRIVILEGES, "Check database user "
     "privileges before performing any query.", &opt_check_privileges,
    &opt_check_privileges, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+  {"read_buffer_size",
+   OPT_XTRA_READ_BUFFER_SIZE,
+   "Set datafile read buffer size, given value is scaled up to page size."
+   " Default is 10Mb.",
+   &opt_read_buffer_size,
+   &opt_read_buffer_size,
+   0, GET_UINT, OPT_ARG, UNIV_PAGE_SIZE_MAX*640,
+   UNIV_PAGE_SIZE_MAX, UINT_MAX, 0, UNIV_PAGE_SIZE_MAX, 0},
 
 #include "sslopt-longopts.h"
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -167,6 +167,8 @@ extern uint		opt_safe_slave_backup_timeout;
 extern const char	*opt_history;
 extern my_bool		opt_decrypt;
 
+extern uint		opt_read_buffer_size;
+
 #if defined(HAVE_OPENSSL)
 extern my_bool opt_use_ssl;
 extern my_bool opt_ssl_verify_server_cert;

--- a/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
+++ b/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
@@ -1,0 +1,39 @@
+start_server
+
+load_dbase_schema incremental_sample
+multi_row_insert incremental_sample.test \({1..100},100\)
+
+vlog "Creating a MyISAM-powered clone of the incremental_sample.test"
+mysql -e "show create table incremental_sample.test;" \
+    | tail -n +2 \
+    | sed -r 's/test\s+CREATE TABLE `test`/CREATE TABLE `test_MyISAM`/' \
+    | sed 's/ENGINE=InnoDB/ENGINE=MyISAM/' \
+    > $topdir/is_test_myISAM.sql
+
+mysql incremental_sample <<EOF
+$(cat $topdir/is_test_myISAM.sql);
+insert into test_MyISAM select * from test;
+EOF
+
+record_db_state incremental_sample
+
+vlog "Default buffer size"
+xtrabackup --backup --target-dir=$topdir/backup \
+	--read_buffer_size=0 \
+	2>&1 | tee $topdir/xb.log
+rm -rf $topdir/backup
+
+vlog "100Mb buffer"
+xtrabackup --backup --target-dir=$topdir/backup \
+	--read_buffer_size=100Mb \
+	2>&1 | tee $topdir/xb.log
+
+stop_server
+rm -rf $mysql_datadir/*
+
+vlog "Restoring..."
+xtrabackup --prepare --target-dir=$topdir/backup
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+
+verify_db_state incremental_sample


### PR DESCRIPTION
Added option '--datafile_buffer_size_multiplicator' that allows to
increase size of the datafile read buffer.

Original PR: https://github.com/percona/percona-xtrabackup/pull/402

Blueprint: https://blueprints.launchpad.net/percona-xtrabackup/+spec/adjustable-chunk-size
Jenkins param build: http://jenkins.percona.com/job/percona-xtrabackup-2.4-param-medium/30/