### PR TITLE
Bug 1717158: Safe-slave-backups stucks with long query

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1043,6 +1043,27 @@ get_open_temp_tables(MYSQL *connection)
 	return(result);
 }
 
+static
+char*
+get_slave_coordinates(MYSQL *connection)
+{
+	char *relay_log_file = NULL;
+	char *exec_log_pos = NULL;
+	char *result = NULL;
+
+	mysql_variable slave_coordinates[] = {
+		{"Relay_Master_Log_File", &relay_log_file},
+		{"Exec_Master_Log_Pos", &exec_log_pos},
+		{NULL, NULL}
+	};
+
+	read_mysql_variables(connection, "SHOW SLAVE STATUS",
+		slave_coordinates, false);
+	ut_a(asprintf(&result, "%s\\%s", relay_log_file, exec_log_pos));
+	free_mysql_variables(slave_coordinates);
+	return result;
+}
+
 /*********************************************************************//**
 Wait until it's safe to backup a slave.  Returns immediately if
 the host isn't a slave.  Currently there's only one check:
@@ -1052,8 +1073,13 @@ wait_for_safe_slave(MYSQL *connection)
 {
 	char *read_master_log_pos = NULL;
 	char *slave_sql_running = NULL;
-	int n_attempts = 1;
+	char *curr_slave_coordinates = NULL;
+	char *prev_slave_coordinates = NULL;
+
 	const int sleep_time = 3;
+	const ssize_t routine_start_time = (ssize_t)my_time(MY_WME);
+	const ssize_t timeout = opt_safe_slave_backup_timeout;
+
 	int open_temp_tables = 0;
 	bool result = true;
 
@@ -1074,47 +1100,80 @@ wait_for_safe_slave(MYSQL *connection)
 	}
 
 	if (strcmp(slave_sql_running, "Yes") == 0) {
+		/* Stopping slave may take significant amount of time,
+		take that into account as part of total timeout.
+		*/
 		sql_thread_started = true;
 		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
 	}
 
-	if (opt_safe_slave_backup_timeout > 0) {
-		n_attempts = opt_safe_slave_backup_timeout / sleep_time;
-	}
-
+retry:
 	open_temp_tables = get_open_temp_tables(connection);
 	msg_ts("Slave open temp tables: %d\n", open_temp_tables);
+	curr_slave_coordinates = get_slave_coordinates(connection);
 
-	while (open_temp_tables && n_attempts--) {
+	while (open_temp_tables &&
+	       routine_start_time + timeout > (ssize_t)my_time(MY_WME)) {
 		msg_ts("Starting slave SQL thread, waiting %d seconds, then "
-		       "checking Slave_open_temp_tables again (%d attempts "
-		       "remaining)...\n", sleep_time, n_attempts);
+		       "checking Slave_open_temp_tables again (%d seconds of "
+		       "sleep time remaining)...\n",
+		       sleep_time,
+		       (int)(routine_start_time + timeout - (ssize_t)my_time(MY_WME)));
+		free(prev_slave_coordinates);
+		prev_slave_coordinates = curr_slave_coordinates;
+		curr_slave_coordinates = NULL;
 
 		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
 		os_thread_sleep(sleep_time * 1000000);
-		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
+
+		curr_slave_coordinates = get_slave_coordinates(connection);
+		msg_ts("Slave pos:\n\tprev: %s\n\tcurr: %s\n",
+		       prev_slave_coordinates, curr_slave_coordinates);
+		if (prev_slave_coordinates && curr_slave_coordinates &&
+		    strcmp(prev_slave_coordinates, curr_slave_coordinates) == 0) {
+			msg_ts("Slave pos hasn't moved during wait period, "
+			       "not stopping the SQL thread.\n");
+		}
+		else {
+			msg_ts("Stopping SQL thread.\n");
+			xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
+		}
 
 		open_temp_tables = get_open_temp_tables(connection);
 		msg_ts("Slave open temp tables: %d\n", open_temp_tables);
 	}
 
-	/* Restart the slave if it was running at start */
 	if (open_temp_tables == 0) {
-		msg_ts("Slave is safe to backup\n");
+		/* We are in a race here, slave might open other temp tables
+		inbetween last check and stop. So we have to re-check
+		and potentially retry after stopping SQL thread. */
+		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
+		open_temp_tables = get_open_temp_tables(connection);
+		if (open_temp_tables != 0) {
+			goto retry;
+		}
+
+		msg_ts("Slave is safe to backup.\n");
 		goto cleanup;
 	}
 
 	result = false;
 
-	if (sql_thread_started) {
-		msg_ts("Restarting slave SQL thread.\n");
-		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
-	}
-
 	msg_ts("Slave_open_temp_tables did not become zero after "
 	       "%d seconds\n", opt_safe_slave_backup_timeout);
 
+	msg_ts("Restoring SQL thread state to %s\n",
+	       sql_thread_started ? "STARTED" : "STOPPED");
+	if (sql_thread_started) {
+		xb_mysql_query(connection, "START SLAVE SQL_THREAD", false);
+	}
+	else {
+		xb_mysql_query(connection, "STOP SLAVE SQL_THREAD", false);
+	}
+
 cleanup:
+	free(prev_slave_coordinates);
+	free(curr_slave_coordinates);
 	free_mysql_variables(status);
 
 	return(result);

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -485,6 +485,7 @@ function setup_slave()
     shift
 
     switch_server $slave_id_arg
+    mysql -e "STOP SLAVE"
     while [ "$#" -ne 0 ]
     do
         local master_id_arg=$1

--- a/storage/innobase/xtrabackup/test/t/bug1717158.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1717158.sh
@@ -1,0 +1,66 @@
+############################################################################
+# Bug 1717158: Safe-slave-backups stucks with long query
+############################################################################
+
+# Not stopping slave SQL thread until long-running query is over.
+
+master_id=1
+slave_id=2
+
+mkdir -p $topdir/backup
+
+function long_running_task()
+{
+    local name=$1
+    local duration=$2
+    switch_server $master_id
+    mysql <<EOF
+CREATE TEMPORARY TABLE $name (a INT) ENGINE=InnoDB;
+INSERT INTO $name VALUES(1);
+UPDATE $name SET a=a+1 WHERE 0 = sleep($duration);
+DROP TABLE $name;
+EOF
+    vlog "Long running task is DONE"
+}
+
+function run_test()
+{
+    local slave_mode=
+    if [ $# -gt 0 -a "${1:-}" = "GTID" ]
+    then
+        slave_mode="$1"
+        shift 1
+    fi
+
+    start_server_with_id $master_id "$@"
+    start_server_with_id $slave_id "$@"
+
+    setup_slave $slave_mode $slave_id $master_id
+
+    # Long running query completes during wait period.
+    switch_server $master_id
+    long_running_task test.tmp 5&
+    long_running_task_id=$!
+
+    switch_server $slave_id
+    xtrabackup --backup \
+        --safe-slave-backup \
+        --safe-slave-backup-timeout=15 \
+        --target-dir=$topdir/backup
+
+    stop_server_with_id $master_id
+    stop_server_with_id $slave_id
+}
+
+run_test
+rm -rf $topdir/backup/*
+
+if is_server_version_higher_than 5.6.0
+then
+    vlog "Testing GTID mode with auto-position"
+    run_test GTID \
+        --gtid-mode=ON \
+        --enforce-gtid-consistency=ON \
+        --log-bin \
+        --log-slave-updates
+fi


### PR DESCRIPTION
Not stopping slave SQL thread until long-running query is over.

Bug: https://bugs.launchpad.net/percona-xtrabackup/2.3/+bug/1717158
Param-builds: 
* http://jenkins.percona.com/job/percona-xtrabackup-2.3-param-light/33/
* http://jenkins.percona.com/job/percona-xtrabackup-2.3-param-medium/24/