### PR TITLE
Bug 1705383: xtrabackup 2.4.7 prepare hangs at log_reserve_and_open

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -262,7 +262,7 @@ long innobase_file_io_threads = 4;
 long innobase_read_io_threads = 4;
 long innobase_write_io_threads = 4;
 long innobase_force_recovery = 0;
-long innobase_log_buffer_size = 1024*1024L;
+long innobase_log_buffer_size = 16*1024*1024L;
 long innobase_log_files_in_group = 2;
 long innobase_open_files = 300L;
 
@@ -1225,7 +1225,7 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
   {"innodb_log_buffer_size", OPT_INNODB_LOG_BUFFER_SIZE,
    "The size of the buffer which InnoDB uses to write log to the log files on disk.",
    (G_PTR*) &innobase_log_buffer_size, (G_PTR*) &innobase_log_buffer_size, 0,
-   GET_LONG, REQUIRED_ARG, 1024*1024L, 256*1024L, LONG_MAX, 0, 1024, 0},
+   GET_LONG, REQUIRED_ARG, 16*1024*1024L, 256*1024L, LONG_MAX, 0, 1024, 0},
   {"innodb_log_file_size", OPT_INNODB_LOG_FILE_SIZE,
    "Size of each log file in a log group.",
    (G_PTR*) &innobase_log_file_size, (G_PTR*) &innobase_log_file_size, 0,
@@ -1404,7 +1404,7 @@ static void usage(void)
 {
   puts("Open source backup tool for InnoDB and XtraDB\n\
 \n\
-Copyright (C) 2009-2015 Percona LLC and/or its affiliates.\n\
+Copyright (C) 2009-2017 Percona LLC and/or its affiliates.\n\
 Portions Copyright (C) 2000, 2011, MySQL AB & Innobase Oy. All Rights Reserved.\n\
 \n\
 This program is free software; you can redistribute it and/or\n\

--- a/storage/innobase/xtrabackup/test/t/xb_print_param.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_print_param.sh
@@ -44,3 +44,8 @@ innodb_checksum_algorithm=strict_crc32
 innodb_log_checksum_algorithm=none
 innodb_buffer_pool_filename=/some/buffer/pool/file
 EOF
+
+diff -u <($XB_BIN --no-defautls 2>/dev/null | grep -E log.buffer.size) - <<EOF
+  --innodb-log-buffer-size=# 
+innodb-log-buffer-size            16777216
+EOF


### PR DESCRIPTION
As analysis shown there was not enough room in log buffer to accomodate
checkpoint information at the end of the crash recovery process. Further
on log buffer size would automatically grow, but not in this specific
place.

Fixed by aligning initial log buffer size with MySQL 5.7 default.