### PR TITLE
Bug 1734848: [pxb 2.4] Added newline character to --throttle warning message

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -8666,7 +8666,7 @@ int main(int argc, char **argv)
 	if (xtrabackup_throttle && !xtrabackup_backup) {
 		xtrabackup_throttle = 0;
 		msg("xtrabackup: warning: --throttle has effect "
-		    "only with --backup");
+		    "only with --backup\n");
 	}
 
 	if (xtrabackup_backup && xtrabackup_compact) {


### PR DESCRIPTION
Fix for:
https://bugs.launchpad.net/percona-xtrabackup/+bug/1734848