### PR TITLE
Bug 1734916: Removed argument that caused test crash on Galera-enabled Jenkins slaves.

### DIFF
--- a/storage/innobase/xtrabackup/test/t/PXB-197.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-197.sh
@@ -39,7 +39,7 @@ run_cmd xtrabackup --backup --no-version-check --stream=xbstream --target-dir=$t
 
 check_pipestatus
 
-run_cmd innobackupex --backup --no-version-check --galera-info --stream=xbstream $topdir/backup2 \
+run_cmd innobackupex --backup --no-version-check --stream=xbstream $topdir/backup2 \
     | xbcrypt --encrypt-algo=$algo --encrypt-key=$key \
     | xbcrypt -d --encrypt-algo=$algo --encrypt-key=$key \
     | xbstream -x -C $topdir/tmp3


### PR DESCRIPTION
PR to 2.3: https://github.com/percona/percona-xtrabackup/pull/455

Test crashes since Galera is not properly set up for the test, but its status is requested.

Bug: https://bugs.launchpad.net/percona-xtrabackup/+bug/1734916
Jenkins param build: http://jenkins.percona.com/job/percona-xtrabackup-2.4-param-medium/47/