### PR TITLE
2.4 xb bug1736210

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_decrypt.c
+++ b/storage/innobase/xtrabackup/src/ds_decrypt.c
@@ -55,8 +55,6 @@ typedef struct {
 	uint			nthreads;
 	int			encrypt_algo;
 	size_t			chunk_size;
-	char			*encrypt_key;
-	char			*encrypt_key_file;
 } ds_decrypt_ctxt_t;
 
 typedef struct {
@@ -607,7 +605,9 @@ create_worker_threads(uint n)
 			goto err;
 		}
 
-		xb_crypt_cipher_open(&thd->cipher_handle);
+		if (xb_crypt_cipher_open(&thd->cipher_handle)) {
+			goto err;
+		}
 
 		pthread_mutex_lock(&thd->ctrl_mutex);
 

--- a/storage/innobase/xtrabackup/src/ds_stdout.c
+++ b/storage/innobase/xtrabackup/src/ds_stdout.c
@@ -109,7 +109,7 @@ stdout_close(ds_file_t *file)
 {
 	my_free(file);
 
-	return 1;
+	return 0;
 }
 
 static

--- a/storage/innobase/xtrabackup/test/t/xb_compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_compress_encrypt.sh
@@ -9,7 +9,21 @@ encrypt_key="percona_xtrabackup_is_awesome___"
 
 xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
 
-data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=${encrypt_key} --target-dir=./"
+data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key=$encrypt_key --target-dir=./"
+data_decompress_cmd="xtrabackup --decompress --target-dir=./"
+
+. inc/xb_local.sh
+
+stop_server
+rm -rf $mysql_datadir
+rm -rf ${topdir}/backup
+
+KEY_FILE_NAME=${topdir}/key-file
+echo -n $encrypt_key > $KEY_FILE_NAME
+
+xtrabackup_options="--compress --compress-threads=4 --compress-chunk-size=8K --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
+
+data_decrypt_cmd="xtrabackup --decrypt=${encrypt_algo} --encrypt-key-file=$KEY_FILE_NAME --target-dir=./"
 data_decompress_cmd="xtrabackup --decompress --target-dir=./"
 
 . inc/xb_local.sh


### PR DESCRIPTION
Number of issues fixed:

- `ds_stdout` always returned error in `stdout_close`
- `xbcrypt` did not return error code when `ds_close` failed
- `xbcrypt` needlessly tried to parse `encrypt-key-file` and
  `encrypt-key` option, it should have been passing them to `ds_decrypt`
- we had no single test using `encrypt-key-file` option
- `ds_decrypt` did not handle libgrypt cipher open errors correctly

jenkins build is in progress