### PR TITLE
BUG 1706584[pxb-2.4]: Added missing newline character for Unlocking MDL message

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -2140,7 +2140,7 @@ mdl_lock_table(ulint space_id)
 void
 mdl_unlock_all()
 {
-	msg_ts("Unlocking MDL for all tables");
+	msg_ts("Unlocking MDL for all tables\n");
 
 	xb_mysql_query(mdl_con, "COMMIT", false, true);
 


### PR DESCRIPTION
Fix for:
https://bugs.launchpad.net/percona-xtrabackup/+bug/1706584