### PR TITLE
kill-long-query-type default value is worng

### DIFF
--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -452,7 +452,7 @@ static struct my_option ibx_long_options[] =
 	 "unblock the global lock. Default is \"all\".",
 	 (uchar*) &opt_ibx_kill_long_query_type,
 	 (uchar*) &opt_ibx_kill_long_query_type, &query_type_typelib,
-	 GET_ENUM, REQUIRED_ARG, QUERY_TYPE_SELECT, 0, 0, 0, 0, 0},
+	 GET_ENUM, REQUIRED_ARG, QUERY_TYPE_ALL, 0, 0, 0, 0, 0},
 
 	{"history", OPT_HISTORY,
 	 "This option enables the tracking of backup history in the "

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -959,7 +959,7 @@ struct my_option xb_client_options[] =
    "unblock the global lock. Default is \"all\".",
    (uchar*) &opt_kill_long_query_type,
    (uchar*) &opt_kill_long_query_type, &query_type_typelib,
-   GET_ENUM, REQUIRED_ARG, QUERY_TYPE_SELECT, 0, 0, 0, 0, 0},
+   GET_ENUM, REQUIRED_ARG, QUERY_TYPE_ALL, 0, 0, 0, 0, 0},
 
   {"history", OPT_HISTORY,
    "This option enables the tracking of backup history in the "


### PR DESCRIPTION
The kill-long-query-type option default value  described is all，but actually is QUERY_TYPE_SELECT，so fix it to QUERY_TYPE_ALL.