### PR TITLE
PXB-792: Make --lock-ddl and --lock-ddl-per-table mutually exclusive

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -8014,6 +8014,11 @@ xb_init()
 	int n_mixed_options;
 
 	/* sanity checks */
+    if (opt_lock_ddl && opt_lock_ddl_per_table) {
+        msg("Error: %s and %s are mutually exclusive\n",
+            "--lock-ddl", "--lock-ddl-per-table");
+        return(false);
+    }
 
 	if (opt_slave_info
 		&& opt_no_lock

--- a/storage/innobase/xtrabackup/test/t/bug1706582.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1706582.sh
@@ -1,0 +1,12 @@
+########################################################################
+# Bug #1706582: Make --lock-ddl and --lock-ddl-per-table mutually exclusive
+########################################################################
+
+start_server
+
+vlog "Full backup"
+
+run_cmd_expect_failure xtrabackup --backup --lock-ddl --lock-ddl-per-table \
+    --target-dir=$topdir/data/full  2>&1 | \
+        grep "Error: --lock-ddl and --lock-ddl-per-table are mutually exclusive"
+


### PR DESCRIPTION
Fix for:
https://jira.percona.com/browse/PXB-792