### PR TITLE
Disable insert buffer during recovery

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1575,7 +1575,7 @@ log_preflush_pool_modified_pages(
 		and we could not make a new checkpoint on the basis of the
 		info on the buffer pool only. */
 
-		recv_apply_hashed_log_recs(FALSE);
+		recv_apply_hashed_log_recs(TRUE);
 	}
 
 	if (new_oldest == LSN_MAX
@@ -1929,7 +1929,7 @@ log_checkpoint(
 	ut_ad(!srv_read_only_mode);
 
 	if (recv_recovery_is_on()) {
-		recv_apply_hashed_log_recs(FALSE);
+		recv_apply_hashed_log_recs(TRUE);
 	}
 
 #ifndef _WIN32

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1575,7 +1575,7 @@ log_preflush_pool_modified_pages(
 		and we could not make a new checkpoint on the basis of the
 		info on the buffer pool only. */
 
-		recv_apply_hashed_log_recs(TRUE);
+		recv_apply_hashed_log_recs(FALSE);
 	}
 
 	if (new_oldest == LSN_MAX
@@ -1929,7 +1929,7 @@ log_checkpoint(
 	ut_ad(!srv_read_only_mode);
 
 	if (recv_recovery_is_on()) {
-		recv_apply_hashed_log_recs(TRUE);
+		recv_apply_hashed_log_recs(FALSE);
 	}
 
 #ifndef _WIN32

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2284,7 +2284,7 @@ files_checked:
 			respective file pages, for the last batch of
 			recv_group_scan_log_recs(). */
 
-			recv_apply_hashed_log_recs(TRUE);
+			recv_apply_hashed_log_recs(FALSE);
 			DBUG_PRINT("ib_log", ("apply completed"));
 
 			if (recv_needed_recovery) {

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2284,7 +2284,9 @@ files_checked:
 			respective file pages, for the last batch of
 			recv_group_scan_log_recs(). */
 
+			log_mutex_enter();
 			recv_apply_hashed_log_recs(FALSE);
+			log_mutex_exit();
 			DBUG_PRINT("ib_log", ("apply completed"));
 
 			if (recv_needed_recovery) {


### PR DESCRIPTION
Insert buffer merge operations causing deadlock during recovery between
recovery thread and read IO threads.

The reason is write to redo log during recovery by insert buffer
merge operation, while free space in the log below the margin.

Recovery thread is holding recv_sys->apply_batch_on and waiting for async IOs to
complete and IO threads are waiting for recv_sys->apply_batch_on to ensure
recovery hash applied before freeing space in the log.

Relevant thread stacks:

    4 nanosleep(libpthread.so.0), os_thread_sleep(os0thread.cc:254), *recv_apply_hashed_log_recs*(log0recv.cc:2756),log_checkpoint(log0log.cc:1938),log_margin_checkpoint_age(log0log.cc:341),mtr_t::Command::prepare_write(mtr0mtr.cc:869),mtr_t::Command::execute(mtr0mtr.cc:949),mtr_t::commit(mtr0mtr.cc:576),ibuf_mtr_commit(ibuf0ibuf.ic:60),ibuf_merge_or_delete_for_page(ibuf0ibuf.ic:60),buf_page_io_complete(buf0buf.cc:5894),fil_aio_wait(fil0fil.cc:6128),io_handler_thread(srv0start.cc:309),start_thread(libpthread.so.0),clone(libc.so.6)
    1 nanosleep(libpthread.so.0),os_thread_sleep(os0thread.cc:254),buf_read_recv_pages(buf0rea.cc:850),recv_read_in_area(log0recv.cc:2722),*recv_apply_hashed_log_recs*(log0recv.cc:2722),innobase_start_or_create_for_mysql(srv0start.cc:2217),innodb_init(xtrabackup.cc:2004),xtrabackup_prepare_func(xtrabackup.cc:7585),main(xtrabackup.cc:8704)

The fix is to completely disable insert buffer operations while recovering logs.