### PR TITLE
Bug PXB-1497: Xtrabackup not returning Error when there is failure

### DIFF
--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -554,6 +554,7 @@ Datafile::validate_first_page(lsn_t*	flush_lsn,
 	char*		prev_name;
 	char*		prev_filepath;
 	const char*	error_txt = NULL;
+	dberr_t		err_code = DB_CORRUPTION;	/* default error code */
 
 	m_is_valid = true;
 
@@ -586,6 +587,7 @@ Datafile::validate_first_page(lsn_t*	flush_lsn,
 
 		if (nonzero_bytes == 0) {
 			error_txt = "Header page consists of zero bytes";
+			err_code = DB_PAGE_IS_BLANK;
 		}
 	}
 
@@ -634,7 +636,7 @@ Datafile::validate_first_page(lsn_t*	flush_lsn,
 
 		free_first_page();
 
-		return(DB_CORRUPTION);
+		return(err_code);
 
 	}
 

--- a/storage/innobase/include/db0err.h
+++ b/storage/innobase/include/db0err.h
@@ -137,6 +137,8 @@ enum dberr_t {
 
 	DB_TABLESPACE_TRUNCATED,	/*!< tablespace was truncated */
 
+	DB_PAGE_IS_BLANK,		/*!< page is blank */
+
 	DB_IO_ERROR = 100,		/*!< Generic IO error */
 
 	DB_IO_DECOMPRESS_FAIL,		/*!< Failure to decompress a page

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -734,6 +734,8 @@ ut_strerr(
 		return("Tablespace deleted or being deleted");
 	case DB_TABLESPACE_TRUNCATED:
 		return("Tablespace was truncated");
+	case DB_PAGE_IS_BLANK:
+		return("Page is blank");
 	case DB_TABLESPACE_NOT_FOUND:
 		return("Tablespace not found");
 	case DB_LOCK_TABLE_FULL:

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3557,9 +3557,9 @@ xb_load_single_table_tablespace(
 			fil_space_close(space->name);
 		}
 	} else {
-		/* allow corrupted first page for xtrabackup, it coulde be just
-		zero-filled page, which we restoer from redo log later */
-		if (xtrabackup_backup && err != DB_CORRUPTION) {
+		/* allow corrupted first page for xtrabackup, it could be just
+		zero-filled page, which we'll restore from redo log later */
+		if (xtrabackup_backup && err != DB_PAGE_IS_BLANK) {
 			exit(EXIT_FAILURE);
 		}
 	}


### PR DESCRIPTION
XtraBackup skipping a tablespace when it's first page is corrupted, it
was done because newly created tablespace can have invalid first page
(not flushed yet to disk).

Instead of blindly skipping tablespace when it's first page is
corrupted, check whether it is blank and skip the tablespace only in
this case.