### PR TITLE
PXB-1467: XtraBackup stuck in prepare stage waiting for pending reads

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -5376,6 +5376,7 @@ buf_page_init_for_read(
 		mutex_exit(&buf_pool->zip_mutex);
 	}
 
+	ut_ad(mutex_own(&buf_pool->mutex));
 	buf_pool->n_pend_reads++;
 func_exit:
 	buf_pool_mutex_exit(buf_pool);
@@ -5682,6 +5683,7 @@ buf_mark_space_corrupt(
 	}
 
 	ut_ad(buf_pool->n_pend_reads > 0);
+	ut_ad(mutex_own(&buf_pool->mutex));
 	buf_pool->n_pend_reads--;
 
 	buf_pool_mutex_exit(buf_pool);
@@ -5877,6 +5879,13 @@ corrupt:
 			recv_recover_page(TRUE, (buf_block_t*) bpage);
 		}
 
+		buf_pool_mutex_enter(buf_pool);
+		ut_ad(buf_pool->n_pend_reads > 0);
+		ut_ad(mutex_own(&buf_pool->mutex));
+		buf_pool->n_pend_reads--;
+		buf_pool->stat.n_pages_read++;
+		buf_pool_mutex_exit(buf_pool);
+
 		/* If space is being truncated then avoid ibuf operation.
 		During re-init we have already freed ibuf entries. */
 		if (uncompressed
@@ -5919,10 +5928,6 @@ corrupt:
 		/* NOTE that the call to ibuf may have moved the ownership of
 		the x-latch to this OS thread: do not let this confuse you in
 		debugging! */
-
-		ut_ad(buf_pool->n_pend_reads > 0);
-		buf_pool->n_pend_reads--;
-		buf_pool->stat.n_pages_read++;
 
 		if (uncompressed) {
 			rw_lock_x_unlock_gen(&((buf_block_t*) bpage)->lock,

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -84,6 +84,7 @@ buf_read_page_handle_error(
 	buf_LRU_free_one_page(bpage);
 
 	ut_ad(buf_pool->n_pend_reads > 0);
+	ut_ad(mutex_own(&buf_pool->mutex));
 	buf_pool->n_pend_reads--;
 
 	buf_pool_mutex_exit(buf_pool);

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -138,7 +138,6 @@ volatile lsn_t backup_redo_log_flushed_lsn = 0;
 bool	recv_is_making_a_backup	= false;
 /** TRUE when recovering from a backed up redo log file */
 bool	recv_is_from_backup	= false;
-# define buf_pool_get_curr_size() (5 * 1024 * 1024)
 #endif /* !UNIV_HOTBACKUP */
 /** The following counter is used to decide when to print info on
 log scan */


### PR DESCRIPTION
By code review following was discovered:

1. xtrabackup set maximum number of pending reads 4 times lower than it
   supposed to due to regression
2. there was a deadlock in `recv_apply_hashed_log_recs' and
   `buf_page_io_complete'.

Here is an example deadlock scenario:

Thread 1 in `recv_apply_hashed_log_recs' is waiting when
`buf_pool->n_pend_reads' become not too high to make a progress. It is
`apply_batch_on=TRUE' and will change it to be `FALSE' once apply batch
completed. Note that `buf_pool->n_pend_reads' is already high.

Now, one of the pending reads completes and `buf_page_io_complete'
invoked. It should decrement `buf_pool->n_pend_reads' and let current
apply batch to make progress.

But before decrementing `buf_pool->n_pend_reads', `buf_page_io_complete'
invoked `ibuf_merge_or_delete_for_page' which in turn triggered one more
`recv_apply_hashed_log_recs'. This new `recv_apply_hashed_log_recs'
cannot make progress because `apply_batch_on' is `TRUE', it is waiting
for thread 1. We are in the deadlock now.

Lets imagine that all IO handlers (`buf_page_io_complete') stuck in the
`recv_apply_hashed_log_recs', here is what we see in this case.

Proposed fix is to decrement `buf_pool->n_pend_reads' before invoking
`ibuf_merge_or_delete_for_page'.