### PR TITLE
PXB-1526: Test kill_long_selects.sh failing with MySQL 5.7.21

### DIFF
--- a/storage/innobase/xtrabackup/test/t/kill_long_selects.sh
+++ b/storage/innobase/xtrabackup/test/t/kill_long_selects.sh
@@ -4,6 +4,10 @@
 
 . inc/common.sh
 
+MYSQLD_EXTRA_MY_CNF_OPTS="
+secure-file-priv=$TEST_VAR_ROOT
+"
+
 if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
 then
     skip_test "Incompatible with AddressSanitizer"
@@ -94,7 +98,7 @@ function wait_for_connection_count()
   done
 }
 
-start_server --innodb_file_per_table
+start_server
 
 has_backup_locks && skip_test "Requires a server without backup locks support"
 


### PR DESCRIPTION
At some point behaviour of MySQL 5.7 has changed and now it requires
--secure-file-priv to explicitly allow using the directiry as a target
for SELECT INTO OUTFILE