### PR TITLE
PXB-1540: XB removes and recreate keyring file of 0 size

### DIFF
--- a/plugin/keyring/buffered_file_io.cc
+++ b/plugin/keyring/buffered_file_io.cc
@@ -105,8 +105,6 @@ my_bool Buffered_file_io::check_if_keyring_file_can_be_opened_or_created()
   my_off_t file_size= file_io.tell(file, MYF(MY_WME));
   if ((file_size == ((my_off_t) - 1)) || file_io.close(file, MYF(MY_WME)) < 0)
     return TRUE;
-  if (file_size == 0 && file_io.remove(this->keyring_filename.c_str(), MYF(MY_WME))) //remove empty file
-    return TRUE;
   return FALSE;
 }
 

--- a/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
@@ -28,6 +28,9 @@ function test_do()
 
 	run_cmd $MYSQL $MYSQL_ARGS test -e "SELECT @@server_uuid"
 
+	# PXB-1540: XB removes and recreate keyring file of 0 size
+	xtrabackup --backup --target-dir=$topdir/backup0
+
 	run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 CREATE TABLE t1 (c1 VARCHAR(100)) ${encryption_clause} ${compression_clause};
 INSERT INTO t1 (c1) VALUES ('ONE'), ('TWO'), ('THREE');


### PR DESCRIPTION
This bug was introduced with the keyring_file plugin update in the
xtrabackup source tree. Keyring plugin removes empty keyring file. It
doesn't corrupt existing non-empty keyring file. The issue is that
server detects file modification time change and refuses to create
encrypted tables afterward.