### PR TITLE
2.4 xb 1548

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -542,7 +542,7 @@ datafile_read(datafile_cur_t *cursor)
 
 	xtrabackup_io_throttling();
 
-	to_read = min(cursor->statinfo.st_size - cursor->buf_offset, 
+	to_read = min(cursor->statinfo.st_size - cursor->buf_offset,
 		      cursor->buf_size);
 
 	if (to_read == 0) {
@@ -1560,7 +1560,8 @@ backup_finish()
 	/* Copy buffer pool dump or LRU dump */
 	if (!opt_rsync) {
 		if(opt_dump_innodb_buffer_pool)
-			dump_innodb_buffer_pool(mysql_connection);
+			check_dump_innodb_buffer_pool(mysql_connection);
+
 
 		if (buffer_pool_filename && file_exists(buffer_pool_filename)) {
 			const char *dst_name;

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -542,7 +542,7 @@ datafile_read(datafile_cur_t *cursor)
 
 	xtrabackup_io_throttling();
 
-	to_read = min(cursor->statinfo.st_size - cursor->buf_offset,
+	to_read = min(cursor->statinfo.st_size - cursor->buf_offset, 
 		      cursor->buf_size);
 
 	if (to_read == 0) {

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1559,6 +1559,9 @@ backup_finish()
 
 	/* Copy buffer pool dump or LRU dump */
 	if (!opt_rsync) {
+		if(opt_dump_innodb_buffer_pool)
+			dump_innodb_buffer_pool(mysql_connection);
+
 		if (buffer_pool_filename && file_exists(buffer_pool_filename)) {
 			const char *dst_name;
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1392,6 +1392,12 @@ backup_files(const char *from, bool prep_mode)
 		int err;
 
 		if (buffer_pool_filename && file_exists(buffer_pool_filename)) {
+			/*	Check if dump of buffer pool has completed
+				and potentially wait for it to complete
+				is only executed before FTWRL - prep_mode */
+			if (prep_mode && opt_dump_innodb_buffer_pool) {
+				check_dump_innodb_buffer_pool(mysql_connection);
+			}
 			fprintf(rsync_tmpfile, "%s\n", buffer_pool_filename);
 			rsync_list.insert(buffer_pool_filename);
 		}
@@ -1559,7 +1565,7 @@ backup_finish()
 
 	/* Copy buffer pool dump or LRU dump */
 	if (!opt_rsync) {
-		if(opt_dump_innodb_buffer_pool && has_innodb_buffer_pool_dump()) {
+		if (opt_dump_innodb_buffer_pool) {
 			check_dump_innodb_buffer_pool(mysql_connection);
 		}
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1559,8 +1559,9 @@ backup_finish()
 
 	/* Copy buffer pool dump or LRU dump */
 	if (!opt_rsync) {
-		if(opt_dump_innodb_buffer_pool)
+		if(opt_dump_innodb_buffer_pool) {
 			check_dump_innodb_buffer_pool(mysql_connection);
+		}
 
 
 		if (buffer_pool_filename && file_exists(buffer_pool_filename)) {

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1559,7 +1559,7 @@ backup_finish()
 
 	/* Copy buffer pool dump or LRU dump */
 	if (!opt_rsync) {
-		if(opt_dump_innodb_buffer_pool) {
+		if(opt_dump_innodb_buffer_pool && has_innodb_buffer_pool_dump()) {
 			check_dump_innodb_buffer_pool(mysql_connection);
 		}
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -2185,7 +2185,7 @@ dump_innodb_buffer_pool(MYSQL *connection)
 	char *change_bp_dump_pct_query;
 
 	/* Verify if we need to change innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0 && 	has_innodb_buffer_pool_dump_pct())
+	if(opt_dump_innodb_buffer_pool_pct != 0 && has_innodb_buffer_pool_dump_pct())
 	{
 		mysql_variable variables[] = {
 			{"innodb_buffer_pool_dump_pct", &innodb_buffer_pool_dump_pct},
@@ -2246,7 +2246,7 @@ check_dump_innodb_buffer_pool(MYSQL *connection)
 	free_mysql_variables(status);
 
 	/* restore original innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0 && 	has_innodb_buffer_pool_dump_pct())
+	if(opt_dump_innodb_buffer_pool_pct != 0 && has_innodb_buffer_pool_dump_pct())
 	{
 		xb_a(asprintf(&change_bp_dump_pct_query,
 				"SET GLOBAL innodb_buffer_pool_dump_pct = %u",

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -102,6 +102,11 @@ static bool binlog_locked;
 during backup */
 static bool tables_locked;
 
+/* buffer pool dump */
+ssize_t innodb_buffer_pool_dump_start_time;
+static int original_innodb_buffer_pool_dump_pct;
+
+
 extern "C" {
 MYSQL * STDCALL
 cli_mysql_real_connect(MYSQL *mysql,const char *host, const char *user,
@@ -2160,19 +2165,27 @@ mdl_unlock_all()
 	mutex_free(&mdl_lock_con_mutex);
 }
 
-void dump_innodb_buffer_pool(MYSQL *connection)
+bool
+has_innodb_buffer_pool_dump_pct()
 {
-	const ssize_t routine_start_time = (ssize_t)my_time(MY_WME);
-	const ssize_t timeout = opt_dump_innodb_buffer_pool_timeout;
+	if( (server_flavor == FLAVOR_PERCONA_SERVER || server_flavor == FLAVOR_MYSQL) && mysql_server_version >= 50702)
+		return true;
+	if(server_flavor == FLAVOR_MARIADB && mysql_server_version >= 10110)
+		return true;
 
-	char *innodb_buffer_pool_dump_status;
+	return false;
+}
+
+void
+dump_innodb_buffer_pool(MYSQL *connection)
+{
+	innodb_buffer_pool_dump_start_time = (ssize_t)my_time(MY_WME);
+
 	char *innodb_buffer_pool_dump_pct;
 	char *change_bp_dump_pct_query;
 
-	int original_innodb_buffer_pool_dump_pct;
-
 	/* Verify if we need to change innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0)
+	if(opt_dump_innodb_buffer_pool_pct != 0 && 	has_innodb_buffer_pool_dump_pct())
 	{
 		mysql_variable variables[] = {
 			{"innodb_buffer_pool_dump_pct", &innodb_buffer_pool_dump_pct},
@@ -2190,20 +2203,33 @@ void dump_innodb_buffer_pool(MYSQL *connection)
 		xb_mysql_query(mysql_connection, change_bp_dump_pct_query, false);
 	}
 
-
 	msg_ts("Executing SET GLOBAL innodb_buffer_pool_dump_now=ON...\n");
 	xb_mysql_query(mysql_connection,
 		"SET GLOBAL innodb_buffer_pool_dump_now=ON;", false);
+}
+
+void
+check_dump_innodb_buffer_pool(MYSQL *connection)
+{
+	const ssize_t timeout = opt_dump_innodb_buffer_pool_timeout;
+
+	char *innodb_buffer_pool_dump_status;
+	char *change_bp_dump_pct_query;
+
 
 	mysql_variable status[] = {
 			{"Innodb_buffer_pool_dump_status", &innodb_buffer_pool_dump_status},
 			{NULL, NULL}
 	};
 
+	read_mysql_variables(connection,
+		"SHOW STATUS LIKE 'Innodb_buffer_pool_dump_status'", status, true);
+
 	/* check if dump has been completed */
+	msg_ts("Checking if InnoDB buffer pool dump has completed\n");
 	while (!strstr(innodb_buffer_pool_dump_status, "dump completed at"))
 	{
-		if(routine_start_time + timeout < (ssize_t)my_time(MY_WME))
+		if(innodb_buffer_pool_dump_start_time + timeout < (ssize_t)my_time(MY_WME))
 		{
 			msg_ts("InnoDB Buffer Pool Dump was not completed after %d seconds...  "
 			"Adjust --dump-innodb-buffer-pool-timeout if you need higher wait time before copying %s.\n",
@@ -2220,7 +2246,7 @@ void dump_innodb_buffer_pool(MYSQL *connection)
 	free_mysql_variables(status);
 
 	/* restore original innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0)
+	if(opt_dump_innodb_buffer_pool_pct != 0 && 	has_innodb_buffer_pool_dump_pct())
 	{
 		xb_a(asprintf(&change_bp_dump_pct_query,
 				"SET GLOBAL innodb_buffer_pool_dump_pct = %u",

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -105,6 +105,8 @@ static bool tables_locked;
 /* buffer pool dump */
 ssize_t innodb_buffer_pool_dump_start_time;
 static int original_innodb_buffer_pool_dump_pct;
+static bool innodb_buffer_pool_dump;
+static bool innodb_buffer_pool_dump_pct;
 
 
 extern "C" {
@@ -2168,12 +2170,12 @@ mdl_unlock_all()
 bool
 has_innodb_buffer_pool_dump()
 {
-	if((server_flavor == FLAVOR_PERCONA_SERVER || 
+	if ((server_flavor == FLAVOR_PERCONA_SERVER ||
 		server_flavor == FLAVOR_MYSQL) && mysql_server_version >= 50603) {
 		return true;
 	}
 		
-	if(server_flavor == FLAVOR_MARIADB && mysql_server_version >= 10000) {
+	if (server_flavor == FLAVOR_MARIADB && mysql_server_version >= 10000) {
 		return true;
 	}
 
@@ -2183,12 +2185,12 @@ has_innodb_buffer_pool_dump()
 bool
 has_innodb_buffer_pool_dump_pct()
 {
-	if((server_flavor == FLAVOR_PERCONA_SERVER || 
+	if ((server_flavor == FLAVOR_PERCONA_SERVER ||
 		server_flavor == FLAVOR_MYSQL) && mysql_server_version >= 50702) {
 		return true;
 	}
 		
-	if(server_flavor == FLAVOR_MARIADB && mysql_server_version >= 10110) {
+	if (server_flavor == FLAVOR_MARIADB && mysql_server_version >= 10110) {
 		return true;
 	}
 
@@ -2198,80 +2200,100 @@ has_innodb_buffer_pool_dump_pct()
 void
 dump_innodb_buffer_pool(MYSQL *connection)
 {
-	innodb_buffer_pool_dump_start_time = (ssize_t)my_time(MY_WME);
+	innodb_buffer_pool_dump =
+	has_innodb_buffer_pool_dump();
+	innodb_buffer_pool_dump_pct =
+	has_innodb_buffer_pool_dump_pct();
+	if (innodb_buffer_pool_dump)
+	{
+		innodb_buffer_pool_dump_start_time = (ssize_t)my_time(MY_WME);
 
-	char *innodb_buffer_pool_dump_pct;
-	char *change_bp_dump_pct_query;
+		char *innodb_buffer_pool_dump_pct;
+		char *change_bp_dump_pct_query;
 
-	/* Verify if we need to change innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0 && 
-		has_innodb_buffer_pool_dump_pct()) {
-		mysql_variable variables[] = {
-			{"innodb_buffer_pool_dump_pct", &innodb_buffer_pool_dump_pct},
-			{NULL, NULL}
-		};
-		read_mysql_variables(connection,
-			"SHOW GLOBAL VARIABLES LIKE 'innodb_buffer_pool_dump_pct'", 
-			variables, true);
+		/* Verify if we need to change innodb_buffer_pool_dump_pct */
+		if (opt_dump_innodb_buffer_pool_pct != 0 &&
+			innodb_buffer_pool_dump_pct) {
+				mysql_variable variables[] = {
+					{"innodb_buffer_pool_dump_pct",
+					&innodb_buffer_pool_dump_pct},
+					{NULL, NULL}
+				};
+				read_mysql_variables(connection,
+					"SHOW GLOBAL VARIABLES "
+					"LIKE 'innodb_buffer_pool_dump_pct'",
+					variables, true);
 
-		original_innodb_buffer_pool_dump_pct = 
-		atoi(innodb_buffer_pool_dump_pct);
+					original_innodb_buffer_pool_dump_pct = 
+					atoi(innodb_buffer_pool_dump_pct);
 
-		free_mysql_variables(variables);
-		xb_a(asprintf(&change_bp_dump_pct_query,
-				"SET GLOBAL innodb_buffer_pool_dump_pct = %u",
-				opt_dump_innodb_buffer_pool_pct));
-		xb_mysql_query(mysql_connection, change_bp_dump_pct_query, false);
-	}
+					free_mysql_variables(variables);
+					xb_a(asprintf(&change_bp_dump_pct_query,
+						"SET GLOBAL innodb_buffer_pool_dump_pct = %u",
+						opt_dump_innodb_buffer_pool_pct));
+					xb_mysql_query(mysql_connection,
+						change_bp_dump_pct_query, false);
+		}
 
-	msg_ts("Executing SET GLOBAL innodb_buffer_pool_dump_now=ON...\n");
-	xb_mysql_query(mysql_connection,
-		"SET GLOBAL innodb_buffer_pool_dump_now=ON;", false);
+		msg_ts("Executing SET GLOBAL innodb_buffer_pool_dump_now=ON...\n");
+		xb_mysql_query(mysql_connection,
+			"SET GLOBAL innodb_buffer_pool_dump_now=ON;", false);
+		}
 }
 
 void
 check_dump_innodb_buffer_pool(MYSQL *connection)
 {
-	const ssize_t timeout = opt_dump_innodb_buffer_pool_timeout;
+	if (innodb_buffer_pool_dump)
+	{
+		const ssize_t timeout = opt_dump_innodb_buffer_pool_timeout;
 
-	char *innodb_buffer_pool_dump_status;
-	char *change_bp_dump_pct_query;
+		char *innodb_buffer_pool_dump_status;
+		char *change_bp_dump_pct_query;
 
 
-	mysql_variable status[] = {
-			{"Innodb_buffer_pool_dump_status", &innodb_buffer_pool_dump_status},
-			{NULL, NULL}
-	};
-
-	read_mysql_variables(connection,
-		"SHOW STATUS LIKE 'Innodb_buffer_pool_dump_status'", status, true);
-
-	/* check if dump has been completed */
-	msg_ts("Checking if InnoDB buffer pool dump has completed\n");
-	while (!strstr(innodb_buffer_pool_dump_status, "dump completed at")) {
-		if(innodb_buffer_pool_dump_start_time + 
-			timeout < (ssize_t)my_time(MY_WME)){
-			msg_ts("InnoDB Buffer Pool Dump was not completed "
-				"after %d seconds... Adjust --dump-innodb-buffer-pool-timeout "
-				"if you need higher wait time before copying %s.\n",
-				opt_dump_innodb_buffer_pool_timeout, buffer_pool_filename);
-			break;
-		}
+		mysql_variable status[] = {
+				{"Innodb_buffer_pool_dump_status",
+				&innodb_buffer_pool_dump_status},
+				{NULL, NULL}
+		};
 
 		read_mysql_variables(connection,
-			"SHOW STATUS LIKE 'Innodb_buffer_pool_dump_status'", status, true);
+			"SHOW STATUS LIKE "
+			"'Innodb_buffer_pool_dump_status'",
+			status, true);
 
-		os_thread_sleep(1000000);
-	}
+		/* check if dump has been completed */
+		msg_ts("Checking if InnoDB buffer pool dump has completed\n");
+		while (!strstr(innodb_buffer_pool_dump_status, 
+						"dump completed at")) {
+			if(innodb_buffer_pool_dump_start_time + 
+					timeout < (ssize_t)my_time(MY_WME)){
+				msg_ts("InnoDB Buffer Pool Dump was not completed "
+						"after %d seconds... "
+						"Adjust --dump-innodb-buffer-pool-timeout "
+						"if you need higher wait time before copying %s.\n",
+					opt_dump_innodb_buffer_pool_timeout, 
+					buffer_pool_filename);
+				break;
+			}
 
-	free_mysql_variables(status);
+			read_mysql_variables(connection,
+				"SHOW STATUS LIKE 'Innodb_buffer_pool_dump_status'", status, true);
 
-	/* restore original innodb_buffer_pool_dump_pct */
-	if(opt_dump_innodb_buffer_pool_pct != 0 && 
-		has_innodb_buffer_pool_dump_pct()) {
-		xb_a(asprintf(&change_bp_dump_pct_query,
-				"SET GLOBAL innodb_buffer_pool_dump_pct = %u",
-				original_innodb_buffer_pool_dump_pct));
-		xb_mysql_query(mysql_connection, change_bp_dump_pct_query, false);
+			os_thread_sleep(1000000);
+		}
+
+		free_mysql_variables(status);
+
+		/* restore original innodb_buffer_pool_dump_pct */
+		if(opt_dump_innodb_buffer_pool_pct != 0 && 
+				innodb_buffer_pool_dump_pct) {
+			xb_a(asprintf(&change_bp_dump_pct_query,
+							"SET GLOBAL innodb_buffer_pool_dump_pct = %u",
+							original_innodb_buffer_pool_dump_pct));
+			xb_mysql_query(mysql_connection, 
+							change_bp_dump_pct_query, false);
+		}
 	}
 }

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -113,4 +113,7 @@ mdl_lock_table(ulint space_id);
 void
 mdl_unlock_all();
 
+void
+dump_innodb_buffer_pool(MYSQL *connection);
+
 #endif

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -113,7 +113,13 @@ mdl_lock_table(ulint space_id);
 void
 mdl_unlock_all();
 
+bool
+has_innodb_buffer_pool_dump_pct(void);
+
 void
 dump_innodb_buffer_pool(MYSQL *connection);
+
+void
+check_dump_innodb_buffer_pool(MYSQL *connection);
 
 #endif

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -114,7 +114,10 @@ void
 mdl_unlock_all();
 
 bool
-has_innodb_buffer_pool_dump_pct(void);
+has_innodb_buffer_pool_dump();
+
+bool
+has_innodb_buffer_pool_dump_pct();
 
 void
 dump_innodb_buffer_pool(MYSQL *connection);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -423,6 +423,9 @@ uint opt_lock_wait_timeout = 0;
 uint opt_lock_wait_threshold = 0;
 uint opt_debug_sleep_before_unlock = 0;
 uint opt_safe_slave_backup_timeout = 0;
+uint opt_dump_innodb_buffer_pool_timeout = 10;
+uint opt_dump_innodb_buffer_pool_pct = 0;
+my_bool opt_dump_innodb_buffer_pool = FALSE;
 
 my_bool opt_lock_ddl = FALSE;
 my_bool opt_lock_ddl_per_table = FALSE;
@@ -654,6 +657,9 @@ enum options_xtrabackup
   OPT_LOCK_DDL,
   OPT_LOCK_DDL_TIMEOUT,
   OPT_LOCK_DDL_PER_TABLE,
+  OPT_DUMP_INNODB_BUFFER,
+  OPT_DUMP_INNODB_BUFFER_TIMEOUT,
+  OPT_DUMP_INNODB_BUFFER_PCT,
   OPT_SAFE_SLAVE_BACKUP,
   OPT_RSYNC,
   OPT_FORCE_NON_EMPTY_DIRS,
@@ -915,6 +921,25 @@ struct my_option xb_client_options[] =
    "before xtrabackup starts to copy it and until the backup is completed.",
    (uchar*) &opt_lock_ddl_per_table, (uchar*) &opt_lock_ddl_per_table, 0,
    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+  {"dump-innodb-buffer-pool", OPT_DUMP_INNODB_BUFFER, "Instruct MySQL server to"
+   "dump innodb buffer pool by issuing a SET GLOBAL innodb_buffer_pool_dump_now=ON ",
+   (uchar*) &opt_dump_innodb_buffer_pool, (uchar*) &opt_dump_innodb_buffer_pool, 0,
+   GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+  {"dump-innodb-buffer-pool-timeout", OPT_DUMP_INNODB_BUFFER_TIMEOUT,
+   "This option specifies the number of seconds xtrabackup waits "
+   "for innodb buffer pool dump to complete",
+   (uchar*) &opt_dump_innodb_buffer_pool_timeout,
+   (uchar*) &opt_dump_innodb_buffer_pool_timeout, 0, GET_UINT,
+   REQUIRED_ARG, 10, 0, 0, 0, 0, 0},
+
+  {"dump-innodb-buffer-pool-pct", OPT_DUMP_INNODB_BUFFER_PCT,
+   "This option specifies the percentage of buffer pool "
+   "to be dumped ",
+   (uchar*) &opt_dump_innodb_buffer_pool_pct,
+   (uchar*) &opt_dump_innodb_buffer_pool_pct, 0, GET_UINT,
+   REQUIRED_ARG, 0, 0, 100, 0, 1, 0},
 
   {"safe-slave-backup", OPT_SAFE_SLAVE_BACKUP, "Stop slave SQL thread "
    "and wait to start backup until Slave_open_temp_tables in "

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4737,6 +4737,11 @@ xtrabackup_backup_func(void)
 		exit(EXIT_FAILURE);
 	}
 
+	if (!opt_rsync) {
+		if(opt_dump_innodb_buffer_pool)
+	    	dump_innodb_buffer_pool(mysql_connection);
+	}
+
         {
         fil_system_t*   f_system = fil_system;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4737,10 +4737,9 @@ xtrabackup_backup_func(void)
 		exit(EXIT_FAILURE);
 	}
 
-	if (!opt_rsync) {
-		if(opt_dump_innodb_buffer_pool && has_innodb_buffer_pool_dump()) {
-	    	dump_innodb_buffer_pool(mysql_connection);
-		}
+
+	if (opt_dump_innodb_buffer_pool) {
+	   	dump_innodb_buffer_pool(mysql_connection);
 	}
 
         {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4738,8 +4738,9 @@ xtrabackup_backup_func(void)
 	}
 
 	if (!opt_rsync) {
-		if(opt_dump_innodb_buffer_pool)
+		if(opt_dump_innodb_buffer_pool && has_innodb_buffer_pool_dump()) {
 	    	dump_innodb_buffer_pool(mysql_connection);
+		}
 	}
 
         {

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -180,6 +180,10 @@ extern char		*opt_xtra_plugin_dir;
 extern char		*opt_transition_key;
 extern my_bool		opt_generate_new_master_key;
 
+extern uint		opt_dump_innodb_buffer_pool_timeout;
+extern uint		opt_dump_innodb_buffer_pool_pct;
+extern my_bool		opt_dump_innodb_buffer_pool;
+
 #if defined(HAVE_OPENSSL)
 extern uint opt_ssl_mode;
 extern my_bool opt_use_ssl_arg;

--- a/storage/innobase/xtrabackup/test/t/PXB-1548_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-1548_basic.sh
@@ -1,0 +1,21 @@
+########################################################################
+# Basic dump innodb buffer test
+########################################################################
+
+. inc/common.sh
+
+require_server_version_higher_than 5.6.0
+
+start_server
+
+load_sakila
+
+mkdir $topdir/backup
+
+xtrabackup --backup --dump-innodb-buffer-pool --target-dir=$topdir/backup
+
+$MYSQL $MYSQL_ARGS -e \
+       "SHOW GLOBAL STATUS LIKE 'Innodb_buffer_pool_dump_status';" > $topdir/status1
+
+grep -q "dump completed at" $topdir/status1 \
+ || die "Could not find \"dump completed at\" message"

--- a/storage/innobase/xtrabackup/test/t/PXB-1548_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-1548_basic.sh
@@ -5,7 +5,12 @@
 . inc/common.sh
 
 require_server_version_higher_than 5.6.0
-
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_buffer_pool_filename=ib_buffer_pool
+"
+if [[ -f  $mysql_datadir/ib_buffer_pool ]]; then
+    rm -f $mysql_datadir/ib_buffer_pool
+fi
 start_server
 
 load_sakila
@@ -14,8 +19,18 @@ mkdir $topdir/backup
 
 xtrabackup --backup --dump-innodb-buffer-pool --target-dir=$topdir/backup
 
-$MYSQL $MYSQL_ARGS -e \
-       "SHOW GLOBAL STATUS LIKE 'Innodb_buffer_pool_dump_status';" > $topdir/status1
+if [[ ! -f  $mysql_datadir/ib_buffer_pool ]]; then
+    die "dump file doesnt exist"
+fi
 
-grep -q "dump completed at" $topdir/status1 \
- || die "Could not find \"dump completed at\" message"
+$MYSQL $MYSQL_ARGS -e \
+       "SHOW GLOBAL STATUS LIKE 'Innodb_buffer_pool_dump_status';" > $topdir/message
+
+grep -q "dump completed at" $topdir/message \
+|| die "Could not find \"dump completed at\" message"
+
+cat $mysql_datadir/ib_buffer_pool | wc -l > $topdir/status1
+cat $topdir/backup/ib_buffer_pool | wc -l > $topdir/status2
+
+diff -q $topdir/status1 $topdir/status2 \
+|| die "Not all pages were dumped"

--- a/storage/innobase/xtrabackup/test/t/PXB-1548_dump_pct.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-1548_dump_pct.sh
@@ -1,0 +1,28 @@
+########################################################################
+# Basic dump innodb buffer test
+########################################################################
+
+. inc/common.sh
+
+require_server_version_higher_than 5.7.02
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_buffer_pool_filename=ib_buffer_pool
+"
+
+start_server
+
+load_sakila
+
+mkdir $topdir/backup
+
+xtrabackup --backup --dump-innodb-buffer-pool --dump-innodb-buffer-pool-pct=100 --target-dir=$topdir/backup
+
+$MYSQL $MYSQL_ARGS -e \
+       "SHOW ENGINE INNODB STATUS\G" | grep "Database pages" \
+       | head -1 | awk '{print $3}' > $topdir/status1
+       
+cat $mysql_datadir/ib_buffer_pool | wc -l > $topdir/status2
+
+diff -q $topdir/status1 $topdir/status2 \
+|| die "Not all pages were dumped"

--- a/storage/innobase/xtrabackup/test/t/PXB-1548_rsync_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-1548_rsync_basic.sh
@@ -4,26 +4,36 @@
 
 . inc/common.sh
 
-require_server_version_higher_than 5.7.02
+require_server_version_higher_than 5.6.0
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_buffer_pool_filename=ib_buffer_pool
 "
+
 if [[ -f  $mysql_datadir/ib_buffer_pool ]]; then
     rm -f $mysql_datadir/ib_buffer_pool
 fi
+
 start_server
 
 load_sakila
 
 mkdir $topdir/backup
 
-xtrabackup --backup --dump-innodb-buffer-pool --dump-innodb-buffer-pool-pct=100 --target-dir=$topdir/backup
+xtrabackup --backup --dump-innodb-buffer-pool --rsync --target-dir=$topdir/backup
+
+
+if [[ ! -f  $mysql_datadir/ib_buffer_pool ]]; then
+    die "dump file doesnt exist"
+fi
 
 $MYSQL $MYSQL_ARGS -e \
-       "SHOW ENGINE INNODB STATUS\G" | grep "Database pages" \
-       | head -1 | awk '{print $3}' > $topdir/status1
-       
+       "SHOW GLOBAL STATUS LIKE 'Innodb_buffer_pool_dump_status';" > $topdir/message
+
+grep -q "dump completed at" $topdir/message \
+|| die "Could not find \"dump completed at\" message"
+
+cat $mysql_datadir/ib_buffer_pool | wc -l > $topdir/status1
 cat $topdir/backup/ib_buffer_pool | wc -l > $topdir/status2
 
 diff -q $topdir/status1 $topdir/status2 \

--- a/storage/innobase/xtrabackup/test/t/PXB-1548_rsync_dump_pct.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-1548_rsync_dump_pct.sh
@@ -18,7 +18,7 @@ load_sakila
 
 mkdir $topdir/backup
 
-xtrabackup --backup --dump-innodb-buffer-pool --dump-innodb-buffer-pool-pct=100 --target-dir=$topdir/backup
+xtrabackup --backup --dump-innodb-buffer-pool --dump-innodb-buffer-pool-pct=100 --rsync --target-dir=$topdir/backup
 
 $MYSQL $MYSQL_ARGS -e \
        "SHOW ENGINE INNODB STATUS\G" | grep "Database pages" \


### PR DESCRIPTION
This implements #PXB-1548.

Buffer pool dump happens at the beginning of backup if `--dump-innodb-buffer-pool` is set. 
Prior to copying `ib_buffer_pool` it checks if current `SHOW STATUS LIKE 'Innodb_buffer_pool_dump_status'` contains the string `dump completed at`. If dump is still in progress, the tool keeps checking untill `--dump-innodb-buffer-pool-timeout=N` seconds has elapsed since we originally started the dump.

User can choose to change the default `innodb_buffer_pool_dump_pct`. If `--dump-innodb-buffer-pool-pct` is set, it stores the current MySQL `innodb_buffer_pool_dump_pct` value, then it changes it to the desired percentage. After the check in the end of backup, orginal values is restored back.

3 new parameters have been added:
`--dump-innodb-buffer-pool` - When set, this will trigger dump of buffer pool prior to copying ib_buffer_pool
`--dump-innodb-buffer-pool-timeout=N` - This controlls for how long (in seconds) to wait for dump of buffer pool before moving on. (default: 10)
`--dump-innodb-buffer-pool-pct=N` - This controlls the percentage of buffer pool to dump. If set, xtrabackup will save current MySQL value, change to the desired value, once dump is completed or it aborts due to time out, it will change it back to original value.