### PR TITLE
PXB-1569: --history does not work when autocommit is disabled

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -162,6 +162,9 @@ xb_mysql_connect()
 	xb_mysql_query(connection, "SET SESSION wait_timeout=2147483",
 		       false, true);
 
+	xb_mysql_query(connection, "SET SESSION autocommit=1",
+		       false, true);
+
 	return(connection);
 }
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1569.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1569.sh
@@ -1,0 +1,16 @@
+#
+# PXB-1569: --history does not work when autocommit is disabled
+#
+
+start_server
+
+mysql -e "CREATE USER 'bkpuser'@'localhost' IDENTIFIED BY '111'"
+mysql -e "GRANT RELOAD, LOCK TABLES, PROCESS, REPLICATION CLIENT ON *.* TO 'bkpuser'@'localhost';"
+mysql -e "GRANT ALL ON PERCONA_SCHEMA.* TO 'bkpuser'@'localhost';"
+mysql -e "SET GLOBAL init_connect='set autocommit=0'"
+
+xtrabackup -ubkpuser -p111 --backup --history=abcx --target-dir=$topdir/backup
+
+N=`mysql -N -e "SELECT COUNT(*) FROM PERCONA_SCHEMA.xtrabackup_history"`
+
+test $N -eq 1 || die "Wrong rows number in xtrabackup_history: $N"


### PR DESCRIPTION
Fix is to enable session autocommit when connected.