### PR TITLE
PXB-1539: lock-ddl-per-table report error for table name with special…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -178,6 +178,9 @@ xb_mysql_connect()
 	xb_mysql_query(connection, "SET SESSION autocommit=1",
 		       false, true);
 
+	xb_mysql_query(connection, "SET NAMES utf8",
+		       false, true);
+
 	return(connection);
 }
 
@@ -2126,13 +2129,10 @@ mdl_lock_table(ulint space_id)
 	mysql_result = xb_mysql_query(mdl_con, query, true);
 
 	while ((row = mysql_fetch_row(mysql_result))) {
-		char *table_name = strdup(row[0]);
-		char *separator = strchr(table_name, '/');
 		char *lock_query;
+		char table_name[MAX_FULL_NAME_LEN + 1];
 
-		if (separator != NULL) {
-			*separator = '.';
-		}
+		innobase_format_name(table_name, sizeof(table_name), row[0]);
 
 		msg_ts("Locking MDL for %s\n", table_name);
 
@@ -2143,7 +2143,6 @@ mdl_lock_table(ulint space_id)
 		xb_mysql_query(mdl_con, lock_query, false, false);
 
 		free(lock_query);
-		free(table_name);
 	}
 
 	mysql_free_result(mysql_result);

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -6,6 +6,8 @@ start_server
 
 load_sakila
 
+mysql -e 'CREATE TABLE t_hello_你好(id INT, PRIMARY KEY(id)) ENGINE=InnoDB' test
+
 function start_transaction() {
 	run_cmd_expect_failure $MYSQL $MYSQL_ARGS <<EOF
 BEGIN;
@@ -89,6 +91,9 @@ then
 	xtrabackup --backup --lock-ddl --target-dir=$topdir/backup6
 	xtrabackup --prepare --target-dir=$topdir/backup6
 fi
+
+# PXB-1539: lock-ddl-per-table reports error for table name with special characters
+run_cmd_expect_failure grep 'failed to execute query SELECT \* FROM test.t_hello' $OUTFILE
 
 kill -USR1 $job_id
 wait $job_id


### PR DESCRIPTION
… characters

Fix is to convert file name into MySQL encoding and escape it if needed.