### PR TITLE
PXB-1634: CREATE TABLE fails with DUPLICATE KEY error

### DIFF
--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -1941,13 +1941,13 @@ detect this and will eventually quit sooner. */
     return (s);
   }
 
-  int field_number(const char* field_name) const {
-    for(int i = 0; i < n_def; ++i) {
-      if(strcmp(field_name, get_col_name(i)) == 0) {
+  int field_number(const char *field_name) const {
+    for (int i = 0; i < n_def; ++i) {
+      if (strcmp(field_name, get_col_name(i)) == 0) {
         return i;
       }
     }
-    ut_ad(0);
+    ut_a(0);
   }
 
   /**Gets the nth column of a table.

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -853,7 +853,7 @@ page_checksum_fix(byte *page, const page_size_t &page_size)
 
 	BlockReporter reporter =
 		BlockReporter(false, page, page_size, false);
-	ut_ad(!reporter.is_corrupted());
+	ut_a(!reporter.is_corrupted());
 }
 
 /************************************************************************

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2193,6 +2193,12 @@ innodb_init(bool init_dd)
 
 	if (init_dd) {
 		dict_load_from_spaces_sdi();
+		dict_sys->dynamic_metadata =
+			dd_table_open_on_name(NULL, NULL,
+				"mysql/innodb_dynamic_metadata",
+				false, DICT_ERR_IGNORE_NONE);
+		dict_persist->table_buffer = UT_NEW_NOKEY(DDTableBuffer());
+		srv_dict_recover_on_restart();
 	}
 
 	srv_start_threads(false);


### PR DESCRIPTION
CREATE TABLE reported DUPLICATE KEY error after a database restore. The
error was easy to reproduce with release builds of xtrabackup, but not
with debug builds.

Starting with MySQL 8 InnoDB does not use SELECT MAX(ai_col) to
initialize auto increment value on server restart. Instead, it relies on
two sources:

- mysql.dynamic_table_metadata table contents are used after normal
  server shutdown
- MLOG_TABLE_DYNAMIC_META redo log records are used to update counters
  which haven't been flushed yet

It turned out that debug builds of xtrabackup backed up the data a bit
slower than release builds and InnoDB had time to flush auto increment
counters to dynamic_table_metadata table. During prepare, xtrabackup was
able to restore this table from usual INSERT and UPDATE log records.

In the case when InnoDB had no time to flush auto-increment data,
dynamic_table_metadata contained outdated counters after prepare, which
caused DUPLICATE KEY errors.

Fix is to make sure that xtrabackup is flushing auto increment counters
it has read from the redo log during prepare.