### PR TITLE
PXB-1639: Partition tests failures

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/ib_part.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_part.sh
@@ -83,7 +83,7 @@ function ib_part_restore()
 
 	# Restore database from backup
 	cp -rv $topdir/backup/* $mysql_datadir
-	mkdir $mysql_datadir/mysql
+	[ -d $mysql_datadir/mysql ] || mkdir $mysql_datadir/mysql
 	vlog "database restored from backup"
 
 }


### PR DESCRIPTION
Don't attempt to create mysql directory at destination when restoring
partial backup if directory already exists.