### PR TITLE
PXB-1626: Support encrypted redo and undo logs

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -5628,6 +5628,16 @@ fil_load_status Fil_shard::ibd_open_for_recovery(space_id_t space_id,
     }
   }
 
+  if (FSP_FLAGS_GET_ENCRYPTION(space->flags) && !srv_backup_mode &&
+      use_dumped_tablespace_keys) {
+    err = xb_set_encryption(space);
+    if (err != DB_SUCCESS) {
+      ib::error() << "Cannot find encryption key for tablespace '%s'."
+                  << space->name;
+      return (FIL_LOAD_INVALID);
+    }
+  }
+
   return (FIL_LOAD_OK);
 }
 

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -36,18 +36,19 @@ buf_page_is_compacted(
 /*==================*/
 	const byte*	page);	/*!< in: a database page */
 
-/******************************************************************************
-Rebuild all secondary indexes in all tables in separate spaces. Called from
-innobase_start_or_create_for_mysql(). */
-void
-xb_compact_rebuild_indexes(void);
-
 /** Fetch tablespace key from "xtrabackup_keys".
 @param[in]	space_id	tablespace id
 @param[out]	key		fetched tablespace key
 @param[out]	key		fetched tablespace iv */
 void
 xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
+
+/** Fetch tablespace key from "xtrabackup_keys" and set the encryption
+type for the tablespace.
+@param[in]	space		tablespace
+@return DB_SUCCESS or error code */
+dberr_t
+xb_set_encryption(fil_space_t *space);
 
 /** Add file to tablespace map.
 @param[in]	file_name	file name

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -114,6 +114,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "usr0sess.h"
 #include "ut0crc32.h"
 #include "ut0new.h"
+#include "xb0xb.h"
 
 /** fil_space_t::flags for hard-coded tablespaces */
 extern ulint predefined_flags;
@@ -379,11 +380,13 @@ static dberr_t create_log_files(char *logfilename, size_t dirnamelen, lsn_t lsn,
   /* Once the redo log is set to be encrypted,
   initialize encryption information. */
   if (srv_redo_log_encrypt) {
+#if !defined(XTRABACKUP)
     if (!Encryption::check_keyring()) {
       ib::error(ER_IB_MSG_1065);
 
       return (DB_ERROR);
     }
+#endif
 
     log_space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
     err = fil_set_encryption(log_space->id, Encryption::AES, NULL, NULL);
@@ -666,15 +669,23 @@ static dberr_t srv_undo_tablespace_read_encryption(pfs_os_file_t fh,
     return (DB_SUCCESS);
   }
 
-  byte key[ENCRYPTION_KEY_LEN];
-  byte iv[ENCRYPTION_KEY_LEN];
-  if (fsp_header_get_encryption_key(space->flags, key, iv, first_page)) {
-    space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
-    err = fil_set_encryption(space->id, Encryption::AES, key, iv);
-    ut_ad(err == DB_SUCCESS);
+  if (!use_dumped_tablespace_keys || srv_backup_mode) {
+    byte key[ENCRYPTION_KEY_LEN];
+    byte iv[ENCRYPTION_KEY_LEN];
+    if (fsp_header_get_encryption_key(space->flags, key, iv, first_page)) {
+      space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
+      err = fil_set_encryption(space->id, Encryption::AES, key, iv);
+      ut_ad(err == DB_SUCCESS);
+    } else {
+      ut_free(first_page_buf);
+      return (DB_FAIL);
+    }
   } else {
-    ut_free(first_page_buf);
-    return (DB_FAIL);
+    err = xb_set_encryption(space);
+    if (err != DB_SUCCESS) {
+      ut_free(first_page_buf);
+      return (DB_FAIL);
+    }
   }
 
   ut_free(first_page_buf);

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -976,7 +976,8 @@ copy_or_move_file(const char *src_file_path,
 			  dst_dir, thread_n));
 
 	if (opt_generate_new_master_key &&
-	    file_purpose == FILE_PURPOSE_DATAFILE) {
+	    (file_purpose == FILE_PURPOSE_DATAFILE ||
+	     file_purpose == FILE_PURPOSE_UNDO_LOG)) {
 		reencrypt_datafile_header(dst_dir, dst_file_path, thread_n);
 	}
 

--- a/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
@@ -1,0 +1,60 @@
+#
+# Basic test of InnoDB encryption support
+#
+
+require_server_version_higher_than 8.0.10
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_redo_log_encrypt=ON
+innodb_undo_log_encrypt=ON
+"
+
+. inc/keyring_file.sh
+
+start_server
+
+load_sakila
+
+mysql -e 'CREATE TABLE t (a INT) engine=InnoDB' test
+
+function start_workload()
+{
+	mysql -e 'INSERT INTO t (a) VALUES (1), (2), (3), (4)' test
+	( while true ; do
+		echo 'INSERT INTO t (a) SELECT a FROM t;'
+		sleep 1
+	done ) | mysql test
+}
+
+function test_do() {
+	xtra_backup_args=$1
+	xtra_prepare_args=$2
+	xtra_restore_args=$3
+
+	start_workload &
+	job=$!
+
+	xtrabackup --backup --target-dir=$topdir/backup ${xtra_backup_args}
+	xtrabackup --prepare --target-dir=$topdir/backup ${xtra_prepare_args}
+
+	record_db_state sakila
+
+	kill -SIGKILL $job
+
+	stop_server
+
+	rm -rf $mysql_datadir
+
+	xtrabackup --copy-back --target-dir=$topdir/backup ${xtra_restore_args}
+
+	start_server
+
+	verify_db_state sakila
+	mysql -e 'SELECT SUM(a) FROM t' test
+
+	rm -rf $topdir/backup
+}
+
+
+test_do "" "--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}" ""
+test_do "--transition-key=123_" "--transition-key=123_" "--transition-key=123_ --generate-new-key"


### PR DESCRIPTION
This patch adds support for encrypted redo and undo logs.

Since redo and undo logs are just a special case of InnoDB
tablespaces, changes needed to support them are minimal:

-   xtrabackup now recognises `--innodb_redo_log_encrypt` and
    `innodb_undo_log_encrypt` server variables. Values of these
    variables are saved to `backup-my.cnf` and used for prepare.
-   instead of using a keyring plugin for the case when
    `--transition-key` is specified, xtrabackup will look for
    encryption key in the `xtrabackup_keys` file.
-   since encrypted redo log is decrypted by `recv_read_log_seg`,
    xtrabackup will encrypt it before writing to `xtrabackup_logfile`.