### PR TITLE
PXB-1643: Memory issues reported by ASAN in PXB 8

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -9603,12 +9603,12 @@ byte *fil_tablespace_redo_delete(byte *ptr, const byte *end,
     fil_space_t *space = fil_space_get(page_id.space());
 
     if (space != nullptr) {
+      xb_tablespace_map_delete(space->name);
+
       dberr_t err =
           fil_delete_tablespace(page_id.space(), BUF_REMOVE_FLUSH_NO_WRITE);
 
       ut_a(err == DB_SUCCESS);
-
-      xb_tablespace_map_delete(space->name);
     }
 
   }

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -123,9 +123,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define DICT_TF_FORMAT_ZIP	1
 #define DICT_TF_FORMAT_SHIFT		5
 
-static void
-init_mysql_environment();
-
 static MEM_ROOT argv_alloc{PSI_NOT_INSTRUMENTED, 512};
 
 int sys_var_init();
@@ -2113,8 +2110,6 @@ dberr_t dict_load_tables_from_space_id(space_id_t space_id, THD *thd,
 			goto error;
 		}
 	}
-
-	return (DB_SUCCESS);
 
 error:
 	ut_free(compressed_sdi);
@@ -5005,6 +5000,8 @@ skip_last_cp:
 
 	xb_data_files_close();
 
+	recv_sys_free();
+
 	recv_sys_close();
 
 	clone_free();
@@ -5455,7 +5452,7 @@ xtrabackup_stats_func(int argc, char **argv)
 
 		mtr_commit(&mtr);
 		dd_table_close(sys_tables, thd, &mdl, true);
-		mem_heap_empty(heap);
+		mem_heap_free(heap);
 
 		mutex_exit(&(dict_sys->mutex));
 
@@ -5474,6 +5471,8 @@ xtrabackup_stats_func(int argc, char **argv)
 		exit(EXIT_FAILURE);
 
 	xb_keyring_shutdown();
+
+	cleanup_mysql_environment();
 }
 
 /* ================= prepare ================= */


### PR DESCRIPTION
This patch fixes following:

-   memory leak in `dict_load_tables_from_space_id`
-   memory leak in `init_mysql_environment` called from `xtrabackup_stats_func`
-   heap use after free in `fil_tablespace_redo_delete`
-   heap wasn't freed in `xtrabackup_stats_func`