### PR TITLE
PXB-1647: Fix bug1470847 testcase

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1470847.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1470847.sh
@@ -14,25 +14,17 @@ run_cmd ${MYSQL} ${MYSQL_ARGS} -e \
 run_cmd ${MYSQL} ${MYSQL_ARGS} -e \
 	"INSERT INTO t VALUES (), (), (), (), (), (), (), ()" test
 
-# fill 3 of 4 redo log files
-while [ $(innodb_lsn) -lt 12600000 ] ; do
+# fill some redo log files
+while [ $(innodb_lsn) -lt 30800000 ] ; do
 	run_cmd ${MYSQL} ${MYSQL_ARGS} -e \
 		"INSERT INTO t SELECT NULL FROM t LIMIT 1000" test
 done
-
-# wait for InnoDB to flush all dirty pages
-innodb_wait_for_flush_all
-
-# wait for InnoDB to flush redo log
-while [ $(innodb_flushed_lsn) != $(innodb_lsn) ] ; do
-	sleep 1
-done
-
-sleep 1
 
 # pass wrong value for innodb-log-files-in-group
 run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --backup \
 			--target-dir=$topdir/backup \
 			--innodb-log-files-in-group=3
 
-grep -q "xtrabackup: error: last checkpoint LS" $OUTFILE
+sleep 1
+
+grep -q "xtrabackup: error: log block numbers mismatch" $OUTFILE


### PR DESCRIPTION
https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/25/

(read_buffer_size fails in the tests because I merged it after I created this topic branch)