### PR TITLE
PXB-1648: Backup fails with error "Encryption information in datafile…

### DIFF
--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -653,13 +653,10 @@ Datafile::validate_first_page(lsn_t*	flush_lsn,
 						   m_encryption_key,
 						   m_encryption_iv,
 						   m_first_page)) {
-			ib::error()
+			ib::info()
 				<< "Encryption information in"
 				<< " datafile: " << m_filepath
-				<< " can't be decrypted"
-				<< " , please confirm the keyfile"
-				<< " is match and keyring plugin"
-				<< " is loaded.";
+				<< " can't be decrypted.";
 
 			m_is_valid = false;
 			free_first_page();
@@ -667,7 +664,7 @@ Datafile::validate_first_page(lsn_t*	flush_lsn,
 			ut_free(m_encryption_iv);
 			m_encryption_key = NULL;
 			m_encryption_iv = NULL;
-			return(DB_CORRUPTION);
+			return(DB_PAGE_IS_BLANK);
 		}
 
 		if (recv_recovery_is_on()


### PR DESCRIPTION
…: <NAME.ibd> can't be decrypted"

Statements like

    ALTER TABLE ENCRYPTION='y';
    ALTER TABLE COMPRESSION='lz4';
    ALTER TABLE ADD INDEX ...;

are done by creating new table and copying all the contents from the
source table to this new one.

Table created in two steps:

-   table file is created, first page initialized and table flags are
    written (including encryption flag) using `os_file_write` which
    writes directly into the file, skipping redo log.
-   `fil_set_encryption` is called to store encryption information into
    the tablespace header. This call does not write into the file
    directly, instead information is updated in buffer pool and written
    to the redo log.

Error happens when xtrabackup is trying to open the tablespace which
has been created, but it's encryption information has not been flushed
to the file yet.

Fix is to skip such tablespaces. Entire tablespace will be restored
from redo logs during prepare.