### PR TITLE
PXB-1651: Buffer pool dump creates a (null) file during prepare stage

### DIFF
--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -711,5 +711,7 @@ void buf_dump_thread() {
   my_thread_end();
 
   std::atomic_thread_fence(std::memory_order_seq_cst);
+#ifndef XTRABACKUP
   srv_threads.m_buf_dump_thread_active = false;
+#endif
 }

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -146,7 +146,9 @@ struct Srv_threads {
   bool m_error_monitor_thread_active;
 
   /** true if buffer pool dump/load thread is created */
+#ifndef XTRABACKUP
   bool m_buf_dump_thread_active;
+#endif
 
   /** true if buffer pool resize thread is created */
   bool m_buf_resize_thread_active;

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1737,8 +1737,10 @@ const char *srv_any_background_threads_are_active() {
     thread_active = "srv_lock_timeout thread";
   } else if (srv_threads.m_monitor_thread_active) {
     thread_active = "srv_monitor_thread";
+#ifndef XTRABACKUP
   } else if (srv_threads.m_buf_dump_thread_active) {
     thread_active = "buf_dump_thread";
+#endif
   } else if (srv_threads.m_buf_resize_thread_active) {
     thread_active = "buf_resize_thread";
   }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2658,9 +2658,11 @@ void srv_start_threads(bool bootstrap) {
     ibuf_update_max_tablespace_id();
   }
 
+#ifndef XTRABACKUP
   /* Create the buffer pool dump/load thread */
   srv_threads.m_buf_dump_thread_active = true;
   os_thread_create(buf_dump_thread_key, buf_dump_thread);
+#endif
 
   dict_stats_thread_init();
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -490,7 +490,7 @@ datafile_copy_backup(const char *filepath, uint thread_n)
 {
 	const char *ext_list[] = {"frm", "isl", "MYD", "MYI", "MAD", "MAI",
 		"MRG", "TRG", "TRN", "ARM", "ARZ", "CSM", "CSV", "opt", "par",
-		NULL};
+		"sdi", NULL};
 
 	/* Get the name and the path for the tablespace. node->name always
 	contains the path (which may be absolute for remote tablespaces in

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -1,0 +1,44 @@
+#
+# Compare files in the datadir and the backup dir
+#
+
+start_server
+
+load_sakila
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+# files that present in the backup directory, but not present in the datadir
+diff -u <( ( ( cd $topdir/backup; find . )
+             ( cd $mysql_datadir; find . )
+             ( cd $mysql_datadir; find . ) ) | sort | uniq -u ) - <<EOF
+./backup-my.cnf
+./test/db.opt
+./xtrabackup_binlog_info
+./xtrabackup_binlog_pos_innodb
+./xtrabackup_checkpoints
+./xtrabackup_info
+./xtrabackup_logfile
+./xtrabackup_master_key_id
+./xtrabackup_tablespaces
+EOF
+
+# files that present in the datadir, but not present in the backup
+diff -u <( ( ( cd $topdir/backup; find . )
+             ( cd $topdir/backup; find . )
+             ( cd $mysql_datadir; find . ) ) | sort | uniq -u ) - <<EOF
+./auto.cnf
+./ca-key.pem
+./ca.pem
+./client-cert.pem
+./client-key.pem
+./mysql-bin.000001
+./mysql-bin.000002
+./mysql-bin.index
+./mysqld1.err
+./private_key.pem
+./public_key.pem
+./server-cert.pem
+./server-key.pem
+EOF

--- a/storage/innobase/xtrabackup/test/t/bug1418438.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1418438.sh
@@ -11,4 +11,5 @@ xtrabackup --compress --backup --include=test.test --target-dir=$topdir/backup
 diff -u <(LANG=C ls $topdir/backup/test) - <<EOF
 test.MYD.qp
 test.MYI.qp
+test_332.sdi.qp
 EOF


### PR DESCRIPTION
- disable buffer pool dump thread on prepare to avoid creating the '(null)' file
- copy *.sdi files into the backup