### PR TITLE
PXB-1627: Support obtaining binary log coordinates from performance_s…

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4410,7 +4410,7 @@ static int innobase_init_files(dict_init_mode_t dict_init_mode,
   directories.push_back(FIL_PATH_SEPARATOR);
   directories.append(MySQL_datadir_path.path());
 
-  err = srv_start(create, directories);
+  err = srv_start(create, directories, ULLONG_MAX);
 
   if (err != DB_SUCCESS) {
     DBUG_RETURN(innodb_init_abort());

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -179,11 +179,13 @@ bool recv_recovery_is_on() MY_ATTRIBUTE((warn_unused_result));
 
 /** Start recovering from a redo log checkpoint.
 @see recv_recovery_from_checkpoint_finish
-@param[in,out]	log		redo log
-@param[in]	flush_lsn	FIL_PAGE_FILE_FLUSH_LSN
+@param[in,out]  log   redo log
+@param[in]  flush_lsn FIL_PAGE_FILE_FLUSH_LSN
                                 of first system tablespace page
+@param[in]  to_lsn    LSN to store recovery at
 @return error code or DB_SUCCESS */
-dberr_t recv_recovery_from_checkpoint_start(log_t &log, lsn_t flush_lsn)
+dberr_t recv_recovery_from_checkpoint_start(log_t &log, lsn_t flush_lsn,
+                                            lsn_t to_lsn)
     MY_ATTRIBUTE((warn_unused_result));
 
 /** Complete the recovery from the latest checkpoint.

--- a/storage/innobase/include/srv0start.h
+++ b/storage/innobase/include/srv0start.h
@@ -91,11 +91,13 @@ dberr_t srv_undo_tablespaces_upgrade();
 dberr_t srv_undo_tablespaces_update(ulong target);
 
 /** Start InnoDB.
-@param[in]	create_new_db		Whether to create a new database
-@param[in]	scan_directories	Scan directories for .ibd files for
+@param[in]  create_new_db     Whether to create a new database
+@param[in]  scan_directories  Scan directories for .ibd files for
                                         recovery "dir1;dir2; ... dirN"
+@param[in]  to_lsn            LSN to stop recovery at
 @return DB_SUCCESS or error code */
-dberr_t srv_start(bool create_new_db, const std::string &scan_directories);
+dberr_t srv_start(bool create_new_db, const std::string &scan_directories,
+                  lsn_t to_lsn);
 
 /** On a restart, initialize the remaining InnoDB subsystems so that
 any tables (including data dictionary tables) can be accessed. */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1605,11 +1605,13 @@ static lsn_t srv_prepare_to_delete_redo_log_files(ulint n_files) {
 }
 
 /** Start InnoDB.
-@param[in]	create_new_db		Whether to create a new database
-@param[in]	scan_directories	Scan directories for .ibd files for
+@param[in]  create_new_db     Whether to create a new database
+@param[in]  scan_directories  Scan directories for .ibd files for
                                         recovery "dir1;dir2; ... dirN"
+@param[in]  to_lsn            LSN to stop recovery at
 @return DB_SUCCESS or error code */
-dberr_t srv_start(bool create_new_db, const std::string &scan_directories) {
+dberr_t srv_start(bool create_new_db, const std::string &scan_directories,
+                  lsn_t to_lsn) {
   lsn_t flushed_lsn;
 
   /* just for assertions */
@@ -2152,7 +2154,7 @@ files_checked:
     /* We always try to do a recovery, even if the database had
     been shut down normally: this is the normal startup path */
 
-    err = recv_recovery_from_checkpoint_start(*log_sys, flushed_lsn);
+    err = recv_recovery_from_checkpoint_start(*log_sys, flushed_lsn, to_lsn);
 
     recv_sys->dblwr.pages.clear();
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1140,8 +1140,11 @@ out:
 	return(ret);
 }
 
+/* Backup non-InnoDB data.
+@param  backup_lsn   backup LSN
+@return true if success. */
 bool
-backup_start()
+backup_start(lsn_t &backup_lsn)
 {
 	if (!opt_no_lock) {
 		if (opt_safe_slave_backup) {
@@ -1165,20 +1168,18 @@ backup_start()
 		return(false);
 	}
 
-	// There is no need to stop slave thread before coping non-Innodb data when
+	// There is no need to stop slave thread before copying non-Innodb data when
 	// --no-lock option is used because --no-lock option requires that no DDL or
 	// DML to non-transaction tables can occur.
-	if (opt_no_lock) {
-		if (opt_safe_slave_backup) {
-			if (!wait_for_safe_slave(mysql_connection)) {
-				return(false);
-			}
+	if (opt_no_lock && opt_safe_slave_backup) {
+		if (!wait_for_safe_slave(mysql_connection)) {
+			return(false);
 		}
 	}
 
-	if (opt_slave_info) {
-		lock_binlog_maybe(mysql_connection);
+	log_status_get(mysql_connection);
 
+	if (opt_slave_info) {
 		if (!write_slave_info(mysql_connection)) {
 			return(false);
 		}
@@ -1197,11 +1198,7 @@ backup_start()
 		write_current_binlog_file(mysql_connection);
 	}
 
-	if (opt_binlog_info == BINLOG_INFO_ON) {
-
-		lock_binlog_maybe(mysql_connection);
-		write_binlog_info(mysql_connection);
-	}
+	write_binlog_info(mysql_connection, backup_lsn);
 
 	if (have_flush_engine_logs) {
 		msg_ts("Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...\n");
@@ -1213,6 +1210,8 @@ backup_start()
 }
 
 
+/* Finsh the backup. Release all locks. Write down backup metadata.
+@return true if success. */
 bool
 backup_finish()
 {
@@ -1244,8 +1243,9 @@ backup_finish()
 	}
 
 	msg_ts("Backup created in directory '%s'\n", xtrabackup_target_dir);
-	if (mysql_binlog_position != NULL) {
-		msg("MySQL binlog position: %s\n", mysql_binlog_position);
+	if (!mysql_binlog_position.empty()) {
+		msg("MySQL binlog position: %s\n",
+			mysql_binlog_position.c_str());
 	}
 	if (!mysql_slave_position.empty() && opt_slave_info) {
 		msg("MySQL slave binlog position: %s\n",

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -31,10 +31,17 @@ copy_file(ds_ctxt_t *datasink,
 	  const char *dst_file_path,
 	  uint thread_n);
 
+/* Backup non-InnoDB data.
+@param  backup_lsn   backup LSN
+@return true if success. */
 bool
-backup_start();
+backup_start(lsn_t &backup_lsn);
+
+/* Finsh the backup. Release all locks. Write down backup metadata.
+@return true if success. */
 bool
 backup_finish();
+
 bool
 apply_log_finish();
 bool

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -28,7 +28,7 @@ extern time_t history_lock_time;
 
 extern bool sql_thread_started;
 extern std::string mysql_slave_position;
-extern char *mysql_binlog_position;
+extern std::string mysql_binlog_position;
 extern char *buffer_pool_filename;
 
 /** connection to mysql server */
@@ -71,8 +71,19 @@ unlock_all(MYSQL *connection);
 bool
 write_current_binlog_file(MYSQL *connection);
 
+/** Read binaty log position and InnoDB LSN from p_s.log_status.
+@param[in]   conn         mysql connection handle */
+void
+log_status_get(MYSQL *conn);
+
+/*********************************************************************//**
+Retrieves MySQL binlog position and
+saves it in a file. It also prints it to stdout.
+@param[in]   connection  MySQL connection handler
+@param[out]  lsn         InnoDB's current LN
+@return true if success. */
 bool
-write_binlog_info(MYSQL *connection);
+write_binlog_info(MYSQL *connection, lsn_t &lsn);
 
 char*
 get_xtrabackup_info(MYSQL *connection);
@@ -82,9 +93,6 @@ write_xtrabackup_info(MYSQL *connection);
 
 bool
 write_backup_config_file();
-
-bool
-lock_binlog_maybe(MYSQL *connection);
 
 bool
 lock_tables_for_backup(MYSQL *connection, int timeout = 31536000);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -159,6 +159,7 @@ long xtrabackup_throttle = 0; /* 0:unlimited */
 lint io_ticket;
 os_event_t wait_throttle = NULL;
 os_event_t log_copying_stop = NULL;
+lsn_t log_copying_stop_lsn = 0;
 
 char *xtrabackup_incremental = NULL;
 lsn_t incremental_lsn;
@@ -391,8 +392,6 @@ static const char *binlog_info_values[] = {"off", "lockless", "on", "auto",
 					   NullS};
 static TYPELIB binlog_info_typelib = {array_elements(binlog_info_values)-1, "",
 				      binlog_info_values, NULL};
-ulong opt_binlog_info;
-
 char *opt_incremental_history_name = NULL;
 char *opt_incremental_history_uuid = NULL;
 
@@ -467,9 +466,6 @@ extern mysql_mutex_t LOCK_sql_rand;
 
 static void
 check_all_privileges();
-
-/* Whether xtrabackup_binlog_info should be created on recovery */
-static bool recover_binlog_info;
 
 #define CLIENT_WARN_DEPRECATED(opt, new_opt) \
   msg("WARNING: " opt \
@@ -663,7 +659,6 @@ enum options_xtrabackup
   OPT_LOCK_WAIT_THRESHOLD,
   OPT_DEBUG_SLEEP_BEFORE_UNLOCK,
   OPT_SAFE_SLAVE_BACKUP_TIMEOUT,
-  OPT_BINLOG_INFO,
   OPT_XB_SECURE_AUTH,
   OPT_TRANSITION_KEY,
   OPT_GENERATE_TRANSITION_KEY,
@@ -1091,13 +1086,6 @@ struct my_option xb_client_options[] =
    (uchar*) &opt_safe_slave_backup_timeout,
    (uchar*) &opt_safe_slave_backup_timeout, 0, GET_UINT,
    REQUIRED_ARG, 300, 0, 0, 0, 0, 0},
-
-  {"binlog-info", OPT_BINLOG_INFO,
-   "This option controls how XtraBackup should retrieve server's binary log "
-   "coordinates corresponding to the backup. Possible values are OFF, ON, "
-   "LOCKLESS and AUTO. See the XtraBackup manual for more information",
-   &opt_binlog_info, &opt_binlog_info,
-   &binlog_info_typelib, GET_ENUM, OPT_ARG, BINLOG_INFO_AUTO, 0, 0, 0, 0, 0},
 
   {"check-privileges", OPT_XTRA_CHECK_PRIVILEGES, "Check database user "
     "privileges before performing any query.", &opt_check_privileges,
@@ -2176,7 +2164,13 @@ innodb_init(bool init_dd)
 	directories.push_back(FIL_PATH_SEPARATOR);
 	directories.append(MySQL_datadir_path.path());
 
-	err = srv_start(false, directories);
+	lsn_t to_lsn = ULLONG_MAX;
+	if (!init_dd && xtrabackup_prepare) {
+		to_lsn = (xtrabackup_incremental_dir == nullptr) ?
+				metadata_last_lsn : incremental_last_lsn;
+	}
+
+	err = srv_start(false, directories, to_lsn);
 
 	if (err != DB_SUCCESS) {
 		free(internal_innobase_data_file_path);
@@ -2239,7 +2233,6 @@ xtrabackup_read_metadata(char *filename)
 {
 	FILE	*fp;
 	bool	 r = TRUE;
-	int	 t;
 
 	fp = fopen(filename,"r");
 	if(!fp) {
@@ -2269,9 +2262,6 @@ xtrabackup_read_metadata(char *filename)
 		metadata_last_lsn = 0;
 	}
 
-	if (fscanf(fp, "recover_binlog_info = %d\n", &t) == 1) {
-		recover_binlog_info = (t == 1);
-	}
 end:
 	fclose(fp);
 
@@ -2290,13 +2280,11 @@ xtrabackup_print_metadata(char *buf, size_t buf_len)
 		 "backup_type = %s\n"
 		 "from_lsn = " UINT64PF "\n"
 		 "to_lsn = " UINT64PF "\n"
-		 "last_lsn = " UINT64PF "\n"
-		 "recover_binlog_info = %d\n",
+		 "last_lsn = " UINT64PF "\n",
 		 metadata_type,
 		 metadata_from_lsn,
 		 metadata_to_lsn,
-		 metadata_last_lsn,
-		 MY_TEST(opt_binlog_info == BINLOG_INFO_LOCKLESS));
+		 metadata_last_lsn);
 }
 
 /***********************************************************************
@@ -3221,23 +3209,19 @@ log_copying_thread()
 
 	log_copying_running = true;
 
-	while(log_copying) {
+	while (log_copying || log_copy_scanned_lsn < log_copying_stop_lsn) {
 		os_event_reset(log_copying_stop);
 		os_event_wait_time_low(log_copying_stop,
 				       xtrabackup_log_copy_interval * 1000ULL,
 				       0);
-		if (log_copying) {
-			if(xtrabackup_copy_logfile(*log_sys,
-				log_copy_scanned_lsn, false)) {
-
-				exit(EXIT_FAILURE);
-			}
+		if (xtrabackup_copy_logfile(*log_sys,
+			log_copy_scanned_lsn, false)) {
+			exit(EXIT_FAILURE);
 		}
 	}
 
 	/* last copying */
-	if(xtrabackup_copy_logfile(*log_sys, log_copy_scanned_lsn, TRUE)) {
-
+	if (xtrabackup_copy_logfile(*log_sys, log_copy_scanned_lsn, true)) {
 		exit(EXIT_FAILURE);
 	}
 
@@ -4357,16 +4341,14 @@ hence will not be backed up. */
 static void
 xb_tables_compatibility_check()
 {
-	const char* query = "SELECT\n"
-			    "  CONCAT(table_schema, '/', table_name), engine\n"
-			    "FROM information_schema.tables\n"
-			    "WHERE engine NOT IN (\n"
-			    "  'MyISAM', 'InnoDB', 'CSV', 'MRG_MYISAM'\n"
-			    ")\n"
-			    "AND table_schema NOT IN (\n"
-			    "  'performance_schema', 'information_schema',"
-			    "  'mysql'\n"
-			    ");";
+	const char* query = "SELECT"
+			    "  CONCAT(table_schema, '/', table_name), engine "
+			    "FROM information_schema.tables "
+			    "WHERE engine NOT IN ("
+			    "'MyISAM', 'InnoDB', 'CSV', 'MRG_MYISAM') "
+			    "AND table_schema NOT IN ("
+			    "  'performance_schema', 'information_schema', "
+			    "  'mysql');";
 
 	MYSQL_RES* result = xb_mysql_query(mysql_connection, query, true, true);
 	MYSQL_ROW row;
@@ -4447,6 +4429,7 @@ xtrabackup_backup_func(void)
 	uint			 count;
 	ib_mutex_t		 count_mutex;
 	data_thread_ctxt_t 	*data_threads;
+	lsn_t 			 backup_lsn = 0;
 
 	recv_is_making_a_backup = true;
 
@@ -4830,7 +4813,7 @@ reread_log_header:
 	}
 	}
 
-	if (!backup_start()) {
+	if (!backup_start(backup_lsn)) {
 		exit(EXIT_FAILURE);
 	}
 
@@ -4858,8 +4841,10 @@ reread_log_header:
 skip_last_cp:
 	/* stop log_copying_thread */
 	log_copying = FALSE;
+	log_copying_stop_lsn = backup_lsn;
 	os_event_set(log_copying_stop);
-	msg("xtrabackup: Stopping log copying thread.\n");
+	msg("xtrabackup: Stopping log copying thread at LSN " LSN_PF ".\n",
+	    backup_lsn);
 	while (log_copying_running) {
 		msg(".");
 		os_thread_sleep(200000); /*0.2 sec*/
@@ -4879,7 +4864,7 @@ skip_last_cp:
 		metadata_from_lsn = incremental_lsn;
 	}
 	metadata_to_lsn = latest_cp;
-	metadata_last_lsn = log_copy_scanned_lsn;
+	metadata_last_lsn = log_copying_stop_lsn;
 
 	if (!xtrabackup_stream_metadata(ds_meta)) {
 		msg("xtrabackup: Error: failed to stream metadata.\n");
@@ -7555,9 +7540,7 @@ next_node:
 	backup_safe_binlog_info was available on the server) to
 	xtrabackup_binlog_info. In the latter case xtrabackup_binlog_pos_innodb
 	becomes redundant and is created only for compatibility. */
-	if (!store_binlog_info("xtrabackup_binlog_pos_innodb") ||
-	    (recover_binlog_info &&
-	     !store_binlog_info(XTRABACKUP_BINLOG_INFO))) {
+	if (!store_binlog_info("xtrabackup_binlog_pos_innodb")) {
 
 		exit(EXIT_FAILURE);
 	}
@@ -7972,6 +7955,13 @@ check_all_privileges()
 	int check_result = PRIVILEGE_OK;
 	bool reload_checked = false;
 
+	/* SELECT FROM P_S.LOG_STATUS */
+	check_result |= check_privilege(granted_privileges,
+		"BACKUP_ADMIN", "*", "*");
+	check_result |= check_privilege(
+		granted_privileges,
+		"SELECT", "PERFORMANCE_SCHEMA", "LOG_STATUS");
+
 	/* SHOW DATABASES */
 	check_result |= check_privilege(granted_privileges,
 		"SHOW DATABASES", "*", "*");
@@ -8024,8 +8014,7 @@ check_all_privileges()
 	if (!opt_no_lock
 		/* LOCK TABLES FOR BACKUP */
 		/* UNLOCK TABLES */
-		&& ((have_backup_locks && !opt_no_lock) || opt_slave_info
-		|| opt_binlog_info == BINLOG_INFO_ON)) {
+		&& ((have_backup_locks && !opt_no_lock) || opt_slave_info)) {
 		check_result |= check_privilege(
 			granted_privileges,
 			"LOCK TABLES", "*", "*");
@@ -8268,6 +8257,7 @@ int main(int argc, char **argv)
 	handle_options(argc, argv, &client_argc, &client_defaults,
 		       &server_argc, &server_defaults);
 
+	print_version();
 	xb_libgcrypt_init();
 
 	if ((!xtrabackup_print_param) && (!xtrabackup_prepare) && (strcmp(mysql_data_home, "./") == 0)) {
@@ -8395,7 +8385,6 @@ int main(int argc, char **argv)
 		exit(EXIT_SUCCESS);
 	}
 
-	print_version();
 	if (xtrabackup_incremental) {
 		msg("incremental backup from " LSN_PF " is enabled.\n",
 		    incremental_lsn);

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -179,8 +179,6 @@ extern bool		opt_generate_new_master_key;
 enum binlog_info_enum { BINLOG_INFO_OFF, BINLOG_INFO_LOCKLESS, BINLOG_INFO_ON,
 			BINLOG_INFO_AUTO};
 
-extern ulong opt_binlog_info;
-
 void xtrabackup_io_throttling(void);
 bool xb_write_delta_metadata(const char *filename,
 			     const xb_delta_info_t *info);

--- a/storage/innobase/xtrabackup/test/t/binlog_info.sh
+++ b/storage/innobase/xtrabackup/test/t/binlog_info.sh
@@ -1,8 +1,6 @@
 ########################################################################
-# --binlog-info tests
+# binlog-info tests
 ########################################################################
-
-xtrabackup --help 2>&1 | grep 'binlog-info *auto'
 
 function test_binlog_info() {
 
@@ -38,42 +36,8 @@ EOF
     xb_binlog_info=$topdir/backup/xtrabackup_binlog_info
     xb_binlog_info_innodb=$topdir/backup/xtrabackup_binlog_pos_innodb
 
-    # --binlog-info=auto
-    xtrabackup --backup --binlog-info=auto --target-dir=$topdir/backup
-
-    if [ $bsbi_avail = 1 ] && [ $gtid = 0 ]
-    then
-        verify_binlog_info_lockless
-    else
-        verify_binlog_info_on
-    fi
-
-    rm -rf $topdir/backup
-
-    # --binlog-info=off
-    xtrabackup --backup --binlog-info=off --target-dir=$topdir/backup
-
-    verify_binlog_info_off
-
-    rm -rf $topdir/backup
-
-    # --binlog-info=on
-    xtrabackup --backup --binlog-info=on --target-dir=$topdir/backup
-
+    xtrabackup --backup --target-dir=$topdir/backup
     verify_binlog_info_on
-
-    rm -rf $topdir/backup
-
-    # --binlog-info=lockless
-
-    if [ $bsbi_avail = 0 ]
-    then
-       run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --binlog-info=lockless \
-                              --target-dir=$topdir/backup
-    else
-        xtrabackup --backup --binlog-info=lockless --target-dir=$topdir/backup
-        verify_binlog_info_lockless
-    fi
 
     rm -rf $topdir/backup
 
@@ -90,8 +54,6 @@ function normalize_path()
 
 function verify_binlog_info_on()
 {
-    grep "recover_binlog_info = 0" $topdir/backup/xtrabackup_checkpoints
-
     normalize_path $xb_binlog_info
 
     if [ $gtid = 1 ]
@@ -120,41 +82,6 @@ EOF
 $binlog_file_innodb	$binlog_pos_innodb
 EOF
     fi
-}
-
-function verify_binlog_info_lockless()
-{
-    test -f $xb_binlog_info &&
-        die "$xb_binlog_info was created on the backup stage with --binlog-info=auto and BSBI available"
-    grep "recover_binlog_info = 1" $topdir/backup/xtrabackup_checkpoints
-
-    xtrabackup --prepare --target-dir=$topdir/backup
-
-    normalize_path $xb_binlog_info
-    normalize_path $xb_binlog_info_innodb
-
-    diff $xb_binlog_info - <<EOF
-$binlog_file	$binlog_pos
-EOF
-    # Real coordinates in xtrabackup_binlog_pos_innodb
-    diff $xb_binlog_info_innodb - <<EOF
-$binlog_file	$binlog_pos
-EOF
-}
-
-function verify_binlog_info_off()
-{
-    grep "recover_binlog_info = 0" $topdir/backup/xtrabackup_checkpoints
-
-    test -f $xb_binlog_info &&
-        die "$xb_binlog_info was created on the backup stage with --binlog-info=off"
-
-    xtrabackup --prepare --target-dir=$topdir/backup
-
-    test -f $xb_binlog_info &&
-        die "$xb_binlog_info was created on the prepare stage with --binlog-info=off"
-
-    true
 }
 
 test_binlog_info

--- a/storage/innobase/xtrabackup/test/t/bug1277403.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1277403.sh
@@ -10,6 +10,8 @@ start_server
 
 has_backup_locks && skip_test "Requires server without backup locks support"
 
+mysql -e 'CREATE TABLE t1 (a INT) engine=MyISAM' test
+
 $MYSQL $MYSQL_ARGS -Ns -e \
        "SHOW GLOBAL STATUS LIKE 'Com_unlock_tables%'; \
        SHOW GLOBAL STATUS LIKE 'Com_flush%'" \

--- a/storage/innobase/xtrabackup/test/t/bug1343722.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1343722.sh
@@ -8,6 +8,16 @@ socket=$MYSQLD_SOCKET
 
 start_server_with_id 2
 
+# HACK: make InnoDB to write some log records so that server 2 LSN is ahead of
+# the server 1 LSN and xtrabackup is able to reach the LSN obtained from
+# server 1 while copying redo log from server 2.
+# Otherwise backup will hang forever.
+mysql -e 'CREATE TABLE t (a INT)' test
+mysql -e 'INSERT INTO t (a) VALUES (1), (2), (3)' test
+mysql -e 'INSERT INTO t (a) SELECT a FROM t' test
+mysql -e 'INSERT INTO t (a) SELECT a FROM t' test
+mysql -e 'INSERT INTO t (a) SELECT a FROM t' test
+
 # Try to backup server 2, but use server 1's connection socket
 xtrabackup --backup --socket=$socket --target-dir=$topdir/backup 2>&1 |
     grep 'has different values'

--- a/storage/innobase/xtrabackup/test/t/bug1630841.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1630841.sh
@@ -43,9 +43,10 @@ then
 
 vlog "Creating user 'pxb'"
 
-${MYSQL} ${MYSQL_ARGS} -e "CREATE USER pxb@'localhost' IDENTIFIED BY 'password1' REQUIRE SSL"
-${MYSQL} ${MYSQL_ARGS} -e "GRANT PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO pxb@'localhost'"
-${MYSQL} ${MYSQL_ARGS} -e "FLUSH PRIVILEGES"
+mysql -e "CREATE USER pxb@'localhost' IDENTIFIED BY 'password1' REQUIRE SSL"
+mysql -e "GRANT BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO pxb@'localhost'"
+mysql -e "GRANT SELECT ON performance_schema.log_status TO pxb@'localhost'"
+mysql -e "FLUSH PRIVILEGES"
 
 vlog 'connecting with MYSQL cli'
 run_cmd ${MYSQL} \
@@ -94,9 +95,10 @@ sha256_password_public_key_path=${PWD}/inc/ssl-certs/rsa_public_key.pem
 
 start_server
 
-${MYSQL} ${MYSQL_ARGS} -e "CREATE USER pbx@'localhost' IDENTIFIED BY 'password1'"
-${MYSQL} ${MYSQL_ARGS} -e "GRANT PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO pbx@'localhost'"
-${MYSQL} ${MYSQL_ARGS} -e "FLUSH PRIVILEGES"
+mysql -e "CREATE USER pbx@'localhost' IDENTIFIED BY 'password1'"
+mysql -e "GRANT BACKUP_ADMIN, PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO pbx@'localhost'"
+mysql -e "GRANT SELECT ON performance_schema.log_status TO pbx@'localhost'"
+mysql -e "FLUSH PRIVILEGES"
 
 vlog 'connecting with MYSQL cli'
 run_cmd ${MYSQL} \

--- a/storage/innobase/xtrabackup/test/t/bug733651.sh
+++ b/storage/innobase/xtrabackup/test/t/bug733651.sh
@@ -13,18 +13,6 @@ then
     options="$options innodb_page_size"
 fi
 
-# innodb_fast_checksum is supported in XtraDB 5.1/5.5
-if is_xtradb && is_server_version_lower_than 5.6.0
-then
-    options="$options innodb_fast_checksum"
-fi
-
-# innodb_log_block_size is only supported in XtraDB
-if is_xtradb
-then
-    options="$options innodb_log_block_size"
-fi
-
 start_server
 
 xtrabackup --backup --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
@@ -16,6 +16,12 @@ setup_slave $slave_id $master_id
 switch_server $master_id
 load_dbase_schema incremental_sample
 
+if has_backup_locks ; then
+    backup_locks="yes"
+else
+    backup_locks="no"
+fi
+
 # Adding initial rows
 multi_row_insert incremental_sample.test \({1..100},100\)
 
@@ -25,10 +31,60 @@ vlog "Check that --slave-info with --no-lock and no --safe-slave-backup fails"
 run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --slave-info --no-lock \
   --target-dir=$topdir/backup
 
+$MYSQL $MYSQL_ARGS -Ns -e \
+       "SHOW GLOBAL STATUS LIKE 'Com_lock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_unlock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
+       > $topdir/status1
+
+if [ $backup_locks = "yes" ] ; then
+	diff -u - $topdir/status1 <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_lock_tables_for_backup	0
+Com_unlock_instance	0
+Com_unlock_tables	0
+Com_flush	1
+EOF
+else
+diff -u $topdir/status1 - <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_unlock_instance	0
+Com_unlock_tables	0
+Com_flush	1
+EOF
+fi
+
 vlog "Full backup of the slave server"
 xtrabackup --backup --target-dir=$topdir/backup \
-    --no-timestamp --slave-info --binlog-info=on \
+    --no-timestamp --slave-info \
     2>&1 | tee $topdir/pxb.log
+
+$MYSQL $MYSQL_ARGS -Ns -e \
+       "SHOW GLOBAL STATUS LIKE 'Com_lock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_unlock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
+       > $topdir/status1
+
+if [ $backup_locks = "yes" ] ; then
+	diff -u - $topdir/status1 <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_lock_tables_for_backup	0
+Com_unlock_instance	0
+Com_unlock_tables	1
+Com_flush	2
+EOF
+else
+diff -u $topdir/status1 - <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_unlock_instance	0
+Com_unlock_tables	1
+Com_flush	4
+EOF
+fi
 
 run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
     $topdir/backup/xtrabackup_binlog_info
@@ -36,7 +92,6 @@ run_cmd egrep -q '^mysql-bin.[0-9]+[[:space:]]+[0-9]+$' \
 run_cmd egrep "MySQL binlog position: $pxb_log_binlog_info_pattern" $topdir/pxb.log
 
 run_cmd egrep "MySQL slave binlog position: $pxb_log_slave_info_pattern" $topdir/pxb.log
-#    egrep 'master host '\''\w+'\'', filename mysql-bin.\d+'\'', position '\''\d+'\'', channel name: '\''\w*'\'''
 
 run_cmd egrep -q "$binlog_slave_info_pattern" \
     $topdir/backup/xtrabackup_slave_info
@@ -44,51 +99,69 @@ run_cmd egrep -q "$binlog_slave_info_pattern" \
 mkdir $topdir/xbstream_backup
 
 vlog "Full backup of the slave server to a xbstream stream"
-xtrabackup --backup --no-timestamp --slave-info --binlog-info=on --stream=xbstream \
+xtrabackup --backup --no-timestamp --slave-info --stream=xbstream \
     | xbstream -xv -C $topdir/xbstream_backup
 
 vlog "Verifying that xtrabackup_slave_info is not corrupted"
 run_cmd egrep -q "$binlog_slave_info_pattern" \
     $topdir/xbstream_backup/xtrabackup_slave_info
 
+# GTID + auto position
 
-if is_server_version_higher_than 5.6.9
-then
-    rm -rf $topdir/backup
+rm -rf $topdir/backup
 
-    MYSQLD_EXTRA_MY_CNF_OPTS="
-    gtid_mode=on
-    enforce_gtid_consistency=on
-    "
-    if is_server_version_lower_than 5.7.0
-    then
-       MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS}
-       log-slave-updates=on"
-    fi
+MYSQLD_EXTRA_MY_CNF_OPTS="
+gtid_mode=on
+enforce_gtid_consistency=on
+"
 
-    start_server_with_id $slave2_id
-    setup_slave GTID $slave2_id $master_id
+start_server_with_id $slave2_id
+setup_slave GTID $slave2_id $master_id
 
-    vlog "Full backup of the GTID with AUTO_POSITION slave server"
-    xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
+vlog "Full backup of the GTID with AUTO_POSITION slave server"
+xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
 
-    run_cmd egrep -q '^SET GLOBAL gtid_purged=.*;$' \
-        $topdir/backup/xtrabackup_slave_info
-    run_cmd egrep -q '^CHANGE MASTER TO MASTER_AUTO_POSITION=1;$' \
-        $topdir/backup/xtrabackup_slave_info
+$MYSQL $MYSQL_ARGS -Ns -e \
+       "SHOW GLOBAL STATUS LIKE 'Com_lock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_unlock%'; \
+       SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
+       > $topdir/status1
 
-    rm -rf $topdir/backup
-
-    # Restarting master in GTID mode, but not setting AUTO_POSITION on slave
-    # so it uses binlog.
-    stop_server_with_id $master_id
-    start_server_with_id $master_id
-    start_server_with_id $slave3_id
-    setup_slave $slave3_id $master_id
-
-    vlog "Full backup of the GTID slave server"
-    xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
-
-    run_cmd egrep -q "$binlog_slave_info_pattern" \
-        $topdir/backup/xtrabackup_slave_info
+if [ $backup_locks = "yes" ] ; then
+	diff -u - $topdir/status1 <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_lock_tables_for_backup	0
+Com_unlock_instance	0
+Com_unlock_tables	1
+Com_flush	2
+EOF
+else
+	diff -u - $topdir/status1 <<EOF
+Com_lock_instance	0
+Com_lock_tables	0
+Com_unlock_instance	0
+Com_unlock_tables	1
+Com_flush	2
+EOF
 fi
+
+run_cmd egrep -q '^SET GLOBAL gtid_purged=.*;$' \
+    $topdir/backup/xtrabackup_slave_info
+run_cmd egrep -q '^CHANGE MASTER TO MASTER_AUTO_POSITION=1;$' \
+    $topdir/backup/xtrabackup_slave_info
+
+rm -rf $topdir/backup
+
+# Restarting master in GTID mode, but not setting AUTO_POSITION on slave
+# so it uses binlog.
+stop_server_with_id $master_id
+start_server_with_id $master_id
+start_server_with_id $slave3_id
+setup_slave $slave3_id $master_id
+
+vlog "Full backup of the GTID slave server"
+xtrabackup --backup --no-timestamp --slave-info --target-dir=$topdir/backup
+
+run_cmd egrep -q "$binlog_slave_info_pattern" \
+    $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/kill_long_selects.sh
+++ b/storage/innobase/xtrabackup/test/t/kill_long_selects.sh
@@ -107,6 +107,8 @@ has_backup_locks && skip_test "Requires a server without backup locks support"
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 CREATE TABLE t1(a INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
+CREATE TABLE t2(a INT) ENGINE=MyISAM;
+INSERT INTO t2 VALUES (1);
 EOF
 
 mkdir $topdir/full

--- a/storage/innobase/xtrabackup/test/t/pxb-1569.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1569.sh
@@ -5,9 +5,11 @@
 start_server
 
 mysql -e "CREATE USER 'bkpuser'@'localhost' IDENTIFIED BY '111'"
-mysql -e "GRANT RELOAD, LOCK TABLES, PROCESS, REPLICATION CLIENT ON *.* TO 'bkpuser'@'localhost';"
-mysql -e "GRANT ALL ON PERCONA_SCHEMA.* TO 'bkpuser'@'localhost';"
+mysql -e "GRANT BACKUP_ADMIN, RELOAD, LOCK TABLES, PROCESS, REPLICATION CLIENT ON *.* TO 'bkpuser'@'localhost'"
+mysql -e "GRANT SELECT ON performance_schema.log_status TO 'bkpuser'@'localhost'"
+mysql -e "GRANT ALL ON PERCONA_SCHEMA.* TO 'bkpuser'@'localhost'"
 mysql -e "SET GLOBAL init_connect='set autocommit=0'"
+mysql -e "FLUSH PRIVILEGES"
 
 xtrabackup -ubkpuser -p111 --backup --history=abcx --target-dir=$topdir/backup
 


### PR DESCRIPTION
…chema.log_status

Implementation details:

At the beginning of the backup PXB detecting is there any MyISAM
tables to backup and whether the server is a GTID slave with auto
positioning.

Privileges needed to query `p_s.log_status` table are checked if
privilege check was requested.

Log copying thread has changed to stop at specific LSN. Log recovery
modified to take a final LSN to recover up to.

`--binlog-info` option has been removed, binary log info always
stored during the backup. Code related to LOCK BACKUP FOR BINLOG
removed because this feature won't be ported to PS 8.

Final stage of the backup now looks like following:

1.  Issue FTWRL is needed. Conditions for FTWRL are:
    -   MyISAM tables
    -   `-slave-info` is specified and server is not a GTID slave with
        auto positioning
2.  Copy MyISAM tables
3.  Query `p_s.log_status`, save LSN and binary log position
4.  Query SHOW SLAVE STATUS if `-slave-info` is specified
5.  Stop log copying thread at the LSN obtained from `log_status`
6.  Unlock tables if they were locked at step 1

Tests changed:

`binlog_info.sh`: test that binlog info is always created during the
backup stage

`bug1277403.sh`: create MyISAM table to force FTWRL

`bug1343722.sh`: produce the workload on the server we backing up

`bug1630841.sh`: privileges adjusted

`ib_slave_info.sh`: check whether FTWRL was used

`kill_long_selects.sh`: create MyISAM table to force FTWRL

`pxb-1569.sh`: privileges adjusted