### PR TITLE
PXB-1660: InnoDB: Log block N at lsn M has valid header, but checksum…

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -41,6 +41,12 @@ ibool buf_page_is_compacted(
 @param[out]	key		fetched tablespace iv */
 void xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
 
+/** Save tablespace key for later use.
+@param[in]  space_id    tablespace id
+@param[in]  key     tablespace key
+@param[in]  key     tablespace iv */
+void xb_insert_tablespace_key(ulint space_id, byte *key, byte *iv);
+
 /** Fetch tablespace key from "xtrabackup_keys" and set the encryption
 type for the tablespace.
 @param[in]	space		tablespace

--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -93,6 +93,18 @@ void xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv) {
   memcpy(iv, it->second.iv, ENCRYPTION_KEY_LEN);
 }
 
+/** Save tablespace key for later use.
+@param[in]	space_id	tablespace id
+@param[in]	key		tablespace key
+@param[in]	key		tablespace iv */
+void xb_insert_tablespace_key(ulint space_id, byte *key, byte *iv) {
+  tablespace_encryption_info info;
+
+  memcpy(info.key, key, ENCRYPTION_KEY_LEN);
+  memcpy(info.iv, iv, ENCRYPTION_KEY_LEN);
+  encryption_info[space_id] = info;
+}
+
 /** Fetch tablespace key from "xtrabackup_keys" and set the encryption
 type for the tablespace.
 @param[in]	space		tablespace


### PR DESCRIPTION
… field contains Q, should be P

xtrabackup was run as follows:

xtrabackup --prepare --transition-key --innodb-redo-log-encrypt

In this mode, xtrabackup created fresh redo log and encrypted it. It did
not save the key however. During subsequent restart of InnoDB engine,
the key was not found and this error message was displayed telling that
xtrabackup is not able to properly decrypt and validate redo log block.

Fix is to save encryption key between restarts of InnoDB.