### PR TITLE
PXB-1609: Make version_check optional via build flag

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, 2017 Percona LLC and/or its affiliates.
+# Copyright (c) 2013, 2018 Percona LLC and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,6 +17,8 @@ INCLUDE(gcrypt)
 INCLUDE(curl)
 INCLUDE(libev)
 
+OPTION(WITH_VERSION_CHECK "Build with version check" ON)
+
 ADD_SUBDIRECTORY(libarchive)
 ADD_SUBDIRECTORY(crc)
 ADD_SUBDIRECTORY(jsmn)
@@ -25,12 +27,18 @@ FIND_GCRYPT()
 FIND_CURL()
 FIND_EV()
 
+IF(WITH_VERSION_CHECK)
 # xxd is needed to embed version_check script
 FIND_PROGRAM(XXD_PATH xxd)
 
 IF(NOT XXD_PATH)
   MESSAGE(FATAL_ERROR "xxd not found. Try to install vim-common.")
 ENDIF(NOT XXD_PATH)
+
+SET(HAVE_VERSION_CHECK 1)
+ELSE()
+SET(HAVE_VERSION_CHECK 0)
+ENDIF(WITH_VERSION_CHECK)
 
 INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/include
@@ -52,15 +60,10 @@ ADD_DEFINITIONS(${SSL_DEFINES})
 # xtrabackup binary
 ########################################################################
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/xtrabackup_version.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/xtrabackup_version.h )
+               ${CMAKE_CURRENT_BINARY_DIR}/xtrabackup_version.h)
 
-ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
-                   COMMAND ${XXD_PATH} --include version_check.pl
-                   ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
-                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-ADD_CUSTOM_TARGET(GenVersionCheck
-                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h)
+CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/xtrabackup_config.h)
 
 SET_SOURCE_FILES_PROPERTIES(
   xtrabackup.cc
@@ -104,7 +107,17 @@ TARGET_LINK_LIBRARIES(xtrabackup
   crc
   )
 
+IF(WITH_VERSION_CHECK)
+ADD_CUSTOM_COMMAND(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
+                   COMMAND ${XXD_PATH} --include version_check.pl
+                   ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h
+                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+ADD_CUSTOM_TARGET(GenVersionCheck
+                  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/version_check_pl.h)
+
 ADD_DEPENDENCIES(xtrabackup GenVersionCheck)
+ENDIF(WITH_VERSION_CHECK)
 
 ########################################################################
 # innobackupex symlink

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -48,13 +48,17 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <set>
 #include <string>
 #include <mysqld.h>
-#include <version_check_pl.h>
 #include <sstream>
 #include "fil_cur.h"
 #include "xtrabackup.h"
 #include "common.h"
 #include "backup_copy.h"
 #include "backup_mysql.h"
+#include "xtrabackup_version.h"
+#include "xtrabackup_config.h"
+#ifdef HAVE_VERSION_CHECK
+#include <version_check_pl.h>
+#endif
 
 
 /* list of files to sync for --rsync mode */
@@ -2059,6 +2063,7 @@ decrypt_decompress()
 	return(ret);
 }
 
+#ifdef HAVE_VERSION_CHECK
 void
 version_check()
 {
@@ -2079,6 +2084,7 @@ version_check()
 		snprintf(port, sizeof(port), "%u", opt_port);
 		setenv("option_mysql_port", port, 1);
 	}
+	setenv("XTRABACKUP_VERSION", XTRABACKUP_VERSION, 1);
 
 	FILE *pipe = popen("perl", "w");
 	if (pipe == NULL) {
@@ -2089,3 +2095,4 @@ version_check()
 
 	pclose(pipe);
 }
+#endif

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -41,8 +41,10 @@ bool
 copy_back();
 bool
 decrypt_decompress();
+#ifdef HAVE_VERSION_CHECK
 void
 version_check();
+#endif
 bool
 is_path_separator(char);
 bool

--- a/storage/innobase/xtrabackup/src/config.h.cmake
+++ b/storage/innobase/xtrabackup/src/config.h.cmake
@@ -1,0 +1,26 @@
+/******************************************************
+Copyright (c) 2018 Percona LLC and/or its affiliates.
+
+Version numbers definitions.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef XTRABACKUP_CONFIG_H
+#define XTRABACKUP_CONFIG_H
+
+#cmakedefine HAVE_VERSION_CHECK 1
+
+#endif

--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -66,6 +66,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "backup_copy.h"
 #include "xbcrypt_common.h"
 #include "ds_encrypt.h"
+#include "xtrabackup_config.h"
 
 using std::min;
 using std::max;
@@ -202,7 +203,9 @@ enum innobackupex_options
 	OPT_INCLUDE,
 	OPT_FORCE_NON_EMPTY_DIRS,
 	OPT_NO_TIMESTAMP,
+#ifdef HAVE_VERSION_CHECK
 	OPT_NO_VERSION_CHECK,
+#endif
 	OPT_NO_BACKUP_LOCKS,
 	OPT_DATABASES,
 	OPT_DECRYPT,
@@ -357,11 +360,13 @@ static struct my_option ibx_long_options[] =
 	 (uchar *) &opt_ibx_notimestamp,
 	 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
+#ifdef HAVE_VERSION_CHECK
 	{"no-version-check", OPT_NO_VERSION_CHECK, "This option disables the "
 	 "version check which is enabled by the --version-check option.",
 	 (uchar *) &opt_ibx_noversioncheck,
 	 (uchar *) &opt_ibx_noversioncheck,
 	 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+#endif
 
 	{"no-backup-locks", OPT_NO_BACKUP_LOCKS, "This option controls if "
 	 "backup locks should be used instead of FLUSH TABLES WITH READ LOCK "
@@ -1010,7 +1015,9 @@ ibx_init()
 	opt_safe_slave_backup = opt_ibx_safe_slave_backup;
 	opt_rsync = opt_ibx_rsync;
 	opt_force_non_empty_dirs = opt_ibx_force_non_empty_dirs;
+#ifdef HAVE_VERSION_CHECK
 	opt_noversioncheck = opt_ibx_noversioncheck;
+#endif
 	opt_no_backup_locks = opt_ibx_no_backup_locks;
 	opt_decompress = opt_ibx_decompress;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -95,6 +95,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "ds_encrypt.h"
 #include "xbcrypt_common.h"
 #include "crc_glue.h"
+#include "xtrabackup_config.h"
 
 /* TODO: replace with appropriate macros used in InnoDB 5.6 */
 #define PAGE_ZIP_MIN_SIZE_SHIFT	10
@@ -349,7 +350,9 @@ my_bool opt_no_lock = FALSE;
 my_bool opt_safe_slave_backup = FALSE;
 my_bool opt_rsync = FALSE;
 my_bool opt_force_non_empty_dirs = FALSE;
+#ifdef HAVE_VERSION_CHECK
 my_bool opt_noversioncheck = FALSE;
+#endif
 my_bool opt_no_backup_locks = FALSE;
 my_bool opt_decompress = FALSE;
 my_bool opt_remove_original = FALSE;
@@ -593,7 +596,9 @@ enum options_xtrabackup
   OPT_SAFE_SLAVE_BACKUP,
   OPT_RSYNC,
   OPT_FORCE_NON_EMPTY_DIRS,
+#ifdef HAVE_VERSION_CHECK
   OPT_NO_VERSION_CHECK,
+#endif
   OPT_NO_BACKUP_LOCKS,
   OPT_DECOMPRESS,
   OPT_INCREMENTAL_HISTORY_NAME,
@@ -858,11 +863,13 @@ struct my_option xb_client_options[] =
    (uchar *) &opt_force_non_empty_dirs,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
+#ifdef HAVE_VERSION_CHECK
   {"no-version-check", OPT_NO_VERSION_CHECK, "This option disables the "
    "version check which is enabled by the --version-check option.",
    (uchar *) &opt_noversioncheck,
    (uchar *) &opt_noversioncheck,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+#endif
 
   {"no-backup-locks", OPT_NO_BACKUP_LOCKS, "This option controls if "
    "backup locks should be used instead of FLUSH TABLES WITH READ LOCK "
@@ -7040,9 +7047,11 @@ xb_init()
 
 	if (xtrabackup_backup) {
 
+#ifdef HAVE_VERSION_CHECK
 		if (!opt_noversioncheck) {
 			version_check();
 		}
+#endif
 
 		if ((mysql_connection = xb_mysql_connect()) == NULL) {
 			return(false);

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "datasink.h"
 #include "xbstream.h"
 #include "changed_page_bitmap.h"
+#include "xtrabackup_config.h"
 
 #ifdef __WIN__
 #define XB_FILE_UNDEFINED NULL
@@ -129,7 +130,9 @@ extern my_bool		opt_no_lock;
 extern my_bool		opt_safe_slave_backup;
 extern my_bool		opt_rsync;
 extern my_bool		opt_force_non_empty_dirs;
+#ifdef HAVE_VERSION_CHECK
 extern my_bool		opt_noversioncheck;
+#endif
 extern my_bool		opt_no_backup_locks;
 extern my_bool		opt_decompress;
 extern my_bool		opt_remove_original;

--- a/storage/innobase/xtrabackup/test/t/version_check.sh
+++ b/storage/innobase/xtrabackup/test/t/version_check.sh
@@ -5,6 +5,9 @@
 # just test that the percona-version-check file is created
 ################################################################################
 
+( $XB_BIN --help 2>/dev/null | grep -q -- --no-version-check ) || \
+    skip_test "Requres version check"
+
 start_server
 
 # Override the directory where percona-version-check is created to make the test


### PR DESCRIPTION
cmake option added -DWITH_VERSION_CHECK=ON/OFF, ON by default.

XTRABACKUP_VERSION environment variable is set before calling
version_check.