### PR TITLE
PXB-1669: Preparation of incremental backup displays database corrupted

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
@@ -125,3 +125,8 @@ then
 fi
 
 vlog "Checksums are OK"
+
+if egrep -q "We scanned the log up to [0-9]+. A checkpoint was at [0-9]+" $OUTFILE
+then
+    die "PXB-1699 is present"
+fi


### PR DESCRIPTION
The part of the PXB-1627 patch was to stop redo log recovery at the LSN
stored in the xtrabackup_checkpoints file. The issue is that when
xtrabackup is called on already prepared backup, it has nothing in redo
logs to apply, instead it creates new empty redo logs. This moves LSN a
bit further and at the end the last checkpoint LSN becomes greater than
the last applied LSN. It triggers the error message.

The fix is to recognise the case when log is already applied and avoid
setting the hard limit on the LSN.

Another issue this patch is addressing is that in some cases redo log
recovery would not stop at intended position and it could lead to
assertion failures.