### PR TITLE
PXB-1672: Allow MTS slave without GTID to be backed up with --safe-sl…

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1372679.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1372679.sh
@@ -21,14 +21,17 @@ setup_slave $slave_id $master_id
 
 switch_server $slave_id
 
-innobackupex --no-timestamp --slave-info $topdir/backup 2>&1 |
-    grep 'The --slave-info option requires GTID enabled for a multi-threaded slave' ||
+xtrabackup --backup --slave-info --target-dir=$topdir/backup 2>&1 |
+    grep 'The --slave-info option requires GTID enabled or --safe-slave-backup option used for a multi-threaded slave.' ||
     die "could not find the error message"
 
 if [[ ${PIPESTATUS[0]} == 0 ]]
 then
-    die "innobackupex did not fail as expected"
+    die "xtrabackup did not fail as expected"
 fi
+
+# --slave-info allowed with --safe-slave-backup and MTS
+xtrabackup --backup --slave-info --safe-slave-backup --target-dir=$topdir/backup0
 
 stop_server_with_id $master_id
 stop_server_with_id $slave_id
@@ -53,4 +56,4 @@ switch_server $slave_id
 
 sync_slave_with_master $slave_id $master_id
 
-innobackupex --no-timestamp --slave-info $topdir/backup
+xtrabackup --backup --slave-info --target-dir=$topdir/backup


### PR DESCRIPTION
…ave-backup

- Only fail when --slave-info is used with MTS without GTID and without
  --safe-slave-backup.
- Debug assertion added to write_slave_info to make sure that slave SQL
  thread is stopped if slave is multi-threaded.
- Error message changed to reflect code changes.
- Test case modified to check --slave-info works in conjunction with
  --safe-slave-backup.