### PR TITLE
PXB-1678: Incremental backup prepare with apply-log-only rolls back u…

### DIFF
--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -623,7 +623,7 @@ static void dict_stats_snapshot_free(
 static void dict_stats_update_transient_for_index(
     dict_index_t *index) /*!< in/out: index */
 {
-  if (srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO &&
+  if (!srv_apply_log_only && srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO &&
       (srv_force_recovery >= SRV_FORCE_NO_LOG_REDO || !index->is_clustered())) {
     /* If we have set a high innodb_force_recovery
     level, do not calculate statistics, as a badly
@@ -2698,7 +2698,8 @@ storage */
 
     dict_stats_empty_table(table);
     return (DB_TABLESPACE_DELETED);
-  } else if (srv_force_recovery >= SRV_FORCE_NO_IBUF_MERGE) {
+  } else if (!srv_apply_log_only &&
+             srv_force_recovery >= SRV_FORCE_NO_IBUF_MERGE) {
     /* If we have set a high innodb_force_recovery level, do
     not calculate statistics, as a badly corrupted index can
     cause a crash in it. */

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -4016,7 +4016,7 @@ void ibuf_merge_or_delete_for_page(buf_block_t *block, const page_id_t &page_id,
   ut_ad(block == NULL || page_id.equals_to(block->page.id));
   ut_ad(block == NULL || buf_block_get_io_fix_unlocked(block) == BUF_IO_READ);
 
-  if (srv_force_recovery >= SRV_FORCE_NO_IBUF_MERGE ||
+  if (srv_apply_log_only || srv_force_recovery >= SRV_FORCE_NO_IBUF_MERGE ||
       trx_sys_hdr_page(page_id) || fsp_is_system_temporary(page_id.space())) {
     return;
   }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2639,8 +2639,8 @@ void srv_start_threads(bool bootstrap) {
     return;
   }
 
-  if (!bootstrap && srv_force_recovery < SRV_FORCE_NO_TRX_UNDO &&
-      trx_sys_need_rollback()) {
+  if (!srv_apply_log_only && !bootstrap &&
+      srv_force_recovery < SRV_FORCE_NO_TRX_UNDO && trx_sys_need_rollback()) {
     /* Rollback all recovered transactions that are
     not in committed nor in XA PREPARE state. */
     trx_rollback_or_clean_is_active = true;

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -944,6 +944,10 @@ static void trx_resurrect(trx_rseg_t *rseg) {
 void trx_lists_init_at_db_start(void) {
   ut_a(srv_is_being_started);
 
+  if (srv_apply_log_only) {
+    return;
+  }
+
   /* Look through the rollback segments in the TRX_SYS for
   transaction undo logs. */
   for (auto rseg : trx_sys->rsegs) {


### PR DESCRIPTION
…ncommitted transactions

The fix is to explicitly skip rollback, IBUF merge and update of
persistent dict stats when prepare was started with --apply-log-only as
it was done in previous xtrabackup versions.

Special care is taken to free update_undo_list and insert_undo_list on
shutdown.