### PR TITLE
PXB-1679: Crash after truncating table or partition when the backup i…

### DIFF
--- a/storage/innobase/xtrabackup/src/read_filt.h
+++ b/storage/innobase/xtrabackup/src/read_filt.h
@@ -54,6 +54,8 @@ struct xb_read_filt_t {
 			       ib_uint64_t* read_batch_start,
 			       ib_uint64_t* read_batch_len);
 	void (*deinit)(xb_read_filt_ctxt_t* ctxt);
+	void (*update)(xb_read_filt_ctxt_t* ctxt, ib_uint64_t len,
+		       const xb_fil_cur_t* cursor);
 };
 
 extern xb_read_filt_t rf_pass_through;

--- a/storage/innobase/xtrabackup/test/t/pxb-1679.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1679.sh
@@ -1,0 +1,54 @@
+#
+# PXB-1679: Crash after truncating partition when the backup is taken
+#
+
+start_server
+
+mysql test <<EOF
+CREATE TABLE test01 (id int auto_increment primary key, a TEXT, b TEXT) PARTITION BY HASH(id) PARTITIONS 4;
+INSERT INTO test01 (a, b) VALUES (REPEAT('a', 1000), REPEAT('b', 1000));
+INSERT INTO test01 (a, b) VALUES (REPEAT('x', 1000), REPEAT('y', 1000));
+INSERT INTO test01 (a, b) VALUES (REPEAT('q', 1000), REPEAT('p', 1000));
+INSERT INTO test01 (a, b) VALUES (REPEAT('l', 1000), REPEAT('c', 1000));
+INSERT INTO test01 (a, b) VALUES (REPEAT('m', 1000), REPEAT('p', 1000));
+INSERT INTO test01 (a, b) VALUES (REPEAT('1', 1000), REPEAT('2', 1000));
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+INSERT INTO test01 (a,b) SELECT a,b FROM test01;
+
+CREATE TABLE test02 (id int auto_increment primary key, a TEXT, b TEXT);
+INSERT INTO test02 SELECT * FROM test01;
+EOF
+
+xtrabackup --backup 2>&1 --target-dir=$topdir/backup | tee /dev/stderr | \
+    while read line ; do
+        echo $line
+        if [ $( echo $line | grep -c './test/test01#P#p3.ibd') -eq 1 ]; then
+            mysql -e "ALTER TABLE test01 TRUNCATE PARTITION p3" test
+        fi
+        if [ $( echo $line | grep -c './test/test02.ibd') -eq 1 ]; then
+            mysql -e "TRUNCATE TABLE test02" test
+        fi
+    done;
+
+if ! [ ${PIPESTATUS[0]} -eq 0 ] ; then
+    die "backup failed"
+fi
+
+record_db_state test
+
+shutdown_server
+
+xtrabackup --prepare --target-dir=$topdir/backup
+rm -rf $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+verify_db_state test


### PR DESCRIPTION
…s taken

Behaviour change between MySQL 5.6 and 5.7 is that TRUNCATE TABLE no
longer translates into DROP TABLE and CREATE TABLE. File is actually
truncated in 5.7.

In order to handle this, following has been done:

- os_file_read replaced with os_file_read_no_error_handling to give more
  control over error handling to caller in the fil_cur
- read_filter interface changed in order to handle partial reads
- partial read is no longer a fatal error when EOF is reached
  unexpectedly