### PR TITLE
PXB-1674: xbcloud, xbcrypt and xbstream should have the same version …

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2014 Percona LLC and/or its affiliates.
+Copyright (c) 2014-2018 Percona LLC and/or its affiliates.
 
 The xbstream utility: serialize/deserialize files in the XBSTREAM format.
 
@@ -39,6 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <map>
 #include <string>
 #include "xbstream.h"
+#include "xtrabackup_version.h"
 
 using std::map;
 using std::max;
@@ -47,7 +48,7 @@ using std::string;
 
 static MEM_ROOT argv_alloc{PSI_NOT_INSTRUMENTED, 512};
 
-#define XBCLOUD_VERSION "1.0"
+#define XBCLOUD_VERSION XTRABACKUP_VERSION
 
 #define SWIFT_MAX_URL_SIZE 8192
 #define SWIFT_MAX_HDR_SIZE 8192
@@ -307,7 +308,7 @@ static void print_version() {
 
 static void usage() {
   print_version();
-  puts("Copyright (C) 2015 Percona LLC and/or its affiliates.");
+  puts("Copyright (C) 2015-2018 Percona LLC and/or its affiliates.");
   puts(
       "This software comes with ABSOLUTELY NO WARRANTY. "
       "This is free software,\nand you are welcome to modify and "

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2013 Percona LLC and/or its affiliates.
+Copyright (c) 2013-2018 Percona LLC and/or its affiliates.
 
 The xbcrypt utility: decrypt files in the XBCRYPT format.
 
@@ -30,8 +30,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "ds_decrypt.h"
 #include "ds_encrypt.h"
 #include "xbcrypt_common.h"
+#include "xtrabackup_version.h"
 
-#define XBCRYPT_VERSION "1.1"
+#define XBCRYPT_VERSION XTRABACKUP_VERSION
 
 typedef enum { RUN_MODE_NONE, RUN_MODE_ENCRYPT, RUN_MODE_DECRYPT } run_mode_t;
 
@@ -314,7 +315,7 @@ static void print_version(void) {
 
 static void usage(void) {
   print_version();
-  puts("Copyright (C) 2011 Percona Inc.");
+  puts("Copyright (C) 2011-2018 Percona Inc.");
   puts(
       "This software comes with ABSOLUTELY NO WARRANTY. "
       "This is free software,\nand you are welcome to modify and "

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2013 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2018 Percona LLC and/or its affiliates.
 
 The xbstream utility: serialize/deserialize files in the XBSTREAM format.
 
@@ -33,8 +33,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "ds_decrypt.h"
 #include "xbcrypt_common.h"
 #include "xbstream.h"
+#include "xtrabackup_version.h"
 
-#define XBSTREAM_VERSION "1.0"
+#define XBSTREAM_VERSION XTRABACKUP_VERSION
 #define XBSTREAM_BUFFER_SIZE (10 * 1024 * 1024UL)
 
 typedef enum { RUN_MODE_NONE, RUN_MODE_CREATE, RUN_MODE_EXTRACT } run_mode_t;
@@ -128,8 +129,6 @@ int main(int argc, char **argv) {
     goto err;
   }
 
-  xb_libgcrypt_init();
-
   crc_init();
 
   if (opt_mode == RUN_MODE_NONE) {
@@ -140,6 +139,10 @@ int main(int argc, char **argv) {
   /* Change the current directory if -C is specified */
   if (opt_directory && my_setwd(opt_directory, MYF(MY_WME))) {
     goto err;
+  }
+
+  if (opt_encrypt_algo || opt_encrypt_key) {
+    xb_libgcrypt_init();
   }
 
   if (opt_mode == RUN_MODE_CREATE && mode_create(argc, argv)) {
@@ -180,7 +183,7 @@ static void print_version(void) {
 
 static void usage(void) {
   print_version();
-  puts("Copyright (C) 2011-2013 Percona LLC and/or its affiliates.");
+  puts("Copyright (C) 2011-2018 Percona LLC and/or its affiliates.");
   puts(
       "This software comes with ABSOLUTELY NO WARRANTY. "
       "This is free software,\nand you are welcome to modify and "

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7663,16 +7663,14 @@ void handle_options(int argc, char **argv, int *argc_client,
 
     if (optend - argv[i] == 15 &&
         !strncmp(argv[i], "--defaults-file", optend - argv[i])) {
-      msg("xtrabackup: Error: --defaults-file "
-          "must be specified first on the command "
-          "line\n");
+      msg("xtrabackup: Error: --defaults-file must be specified first "
+          "on the command line\n");
       exit(EXIT_FAILURE);
     }
     if (optend - argv[i] == 21 &&
         !strncmp(argv[i], "--defaults-extra-file", optend - argv[i])) {
-      msg("xtrabackup: Error: --defaults-extra-file "
-          "must be specified first on the command "
-          "line\n");
+      msg("xtrabackup: Error: --defaults-extra-file must be specified first "
+          "on the command line\n");
       exit(EXIT_FAILURE);
     }
   }
@@ -7682,9 +7680,12 @@ void handle_options(int argc, char **argv, int *argc_client,
                                  xb_get_one_option)))
     exit(ho_error);
 
-  msg("xtrabackup: recognized server arguments: %s\n", param_str.str().c_str());
-  param_str.str("");
-  param_str.clear();
+  if (!param_str.str().empty()) {
+    msg("xtrabackup: recognized server arguments: %s\n",
+        param_str.str().c_str());
+    param_str.str("");
+    param_str.clear();
+  }
 
   if (load_defaults(conf_file, xb_client_default_groups, argc_client,
                     argv_client, &argv_alloc)) {
@@ -7696,8 +7697,11 @@ void handle_options(int argc, char **argv, int *argc_client,
                                  xb_get_one_option)))
     exit(ho_error);
 
-  msg("xtrabackup: recognized client arguments: %s\n", param_str.str().c_str());
-  param_str.clear();
+  if (!param_str.str().empty()) {
+    msg("xtrabackup: recognized client arguments: %s\n",
+        param_str.str().c_str());
+    param_str.clear();
+  }
 
   /* Reject command line arguments that don't look like options, i.e. are
   not of the form '-X' (single-character options) or '--option' (long
@@ -7763,7 +7767,10 @@ int main(int argc, char **argv) {
                  &server_defaults);
 
   print_version();
-  xb_libgcrypt_init();
+
+  if (xtrabackup_encrypt) {
+    xb_libgcrypt_init();
+  }
 
   if ((!xtrabackup_print_param) && (!xtrabackup_prepare) &&
       (strcmp(mysql_data_home, "./") == 0)) {
@@ -7843,9 +7850,7 @@ int main(int argc, char **argv) {
             XTRABACKUP_METADATA_FILENAME);
 
     if (!xtrabackup_read_metadata(filename)) {
-      msg("xtrabackup: error: failed to read metadata from "
-          "%s\n",
-          filename);
+      msg("xtrabackup: error: failed to read metadata from %s\n", filename);
       exit(EXIT_FAILURE);
     }
 
@@ -7858,9 +7863,7 @@ int main(int argc, char **argv) {
             XTRABACKUP_METADATA_FILENAME);
 
     if (!xtrabackup_read_metadata(filename)) {
-      msg("xtrabackup: error: failed to read metadata from "
-          "%s\n",
-          filename);
+      msg("xtrabackup: error: failed to read metadata from %s\n", filename);
       exit(EXIT_FAILURE);
     }
 
@@ -7900,8 +7903,7 @@ int main(int argc, char **argv) {
 
   if (xtrabackup_throttle && !xtrabackup_backup) {
     xtrabackup_throttle = 0;
-    msg("xtrabackup: warning: --throttle has effect "
-        "only with --backup\n");
+    msg("xtrabackup: warning: --throttle has effect only with --backup\n");
   }
 
   /* cannot execute both for now */


### PR DESCRIPTION
…as xtrabackup

1. Make xbstream, xbcrypt and xbcloud report xtrabackup version
2. Update year in copyright messages
3. Don't print grcypt version when encryption is not needed