### PR TITLE
PXB-1700: PXB8 crashes with ssl-mode option

### DIFF
--- a/include/sslopt-case.h
+++ b/include/sslopt-case.h
@@ -26,7 +26,7 @@
 
 #if defined(HAVE_OPENSSL)
 
-#ifdef MYSQL_SERVER
+#if defined(MYSQL_SERVER) && !defined(XTRABACKUP)
 #error This header is supposed to be used only in the client
 #endif
 

--- a/include/sslopt-longopts.h
+++ b/include/sslopt-longopts.h
@@ -25,7 +25,7 @@
 */
 
 #if defined(HAVE_OPENSSL)
-#ifndef MYSQL_SERVER
+#if !defined(MYSQL_SERVER) || defined(XTRABACKUP)
 {"ssl-mode",
  OPT_SSL_MODE,
  "SSL connection mode.",
@@ -179,7 +179,7 @@
 #else
      "permitted values are: OFF",
 #endif
-#ifdef MYSQL_SERVER
+#if defined(MYSQL_SERVER) && !defined(XTRABACKUP)
      0,
      0,
 #else

--- a/include/sslopt-vars.h
+++ b/include/sslopt-vars.h
@@ -36,7 +36,7 @@
 
 #if defined(HAVE_OPENSSL)
 
-#ifdef MYSQL_SERVER
+#if defined(MYSQL_SERVER) && !defined(XTRABACKUP)
 #error This header is supposed to be used only in the client
 #endif
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -453,21 +453,7 @@ extern const char *innodb_flush_method_names[];
 /** Enumeration of innodb_flush_method */
 extern TYPELIB innodb_flush_method_typelib;
 
-uint opt_ssl_mode;
-extern char *opt_ssl_ca;
-extern char *opt_ssl_capath;
-extern char *opt_ssl_cert;
-extern char *opt_ssl_cipher;
-extern char *opt_ssl_key;
-extern char *opt_ssl_crl;
-extern char *opt_ssl_crlpath;
-extern char *opt_tls_version;
-extern ulong opt_ssl_fips_mode;
-bool ssl_mode_set_explicitly;
-
-TYPELIB ssl_mode_typelib;
-TYPELIB ssl_fips_mode_typelib;
-
+#include "sslopt-vars.h"
 #include "caching_sha2_passwordopt-vars.h"
 
 extern struct rand_struct sql_rand;

--- a/storage/innobase/xtrabackup/test/t/pxb-1700.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1700.sh
@@ -1,0 +1,8 @@
+#
+# PXB-1700: PXB8 crashes with ssl-mode option
+#
+
+start_server
+
+xtrabackup --backup --ssl-fips-mode=ON --ssl-mode=PREFERRED --target-dir=$topdir/backup
+


### PR DESCRIPTION
Server and client versions of SSL variables were mixed in xtrabackup.
This commit makes xtrabackup to recognize client SSL variables and avoid
linking against server SSL variables.