### PR TITLE
PXB-1704: xtrabackup deadlocks on insert buffer merge

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2284,7 +2284,13 @@ files_checked:
 			respective file pages, for the last batch of
 			recv_group_scan_log_recs(). */
 
-			recv_apply_hashed_log_recs(TRUE);
+			if (!srv_read_only_mode) {
+				log_mutex_enter();
+				recv_apply_hashed_log_recs(FALSE);
+				log_mutex_exit();
+			} else {
+				recv_apply_hashed_log_recs(TRUE);
+			}
 			DBUG_PRINT("ib_log", ("apply completed"));
 
 			if (recv_needed_recovery) {


### PR DESCRIPTION
The last batch of recv_apply_hashed_log_recs allows merge of insert
buffer changes. When merge is performed, InnoDB needs to use redo log.
There is not enough room in the xtrabackup_logfiles to add an extra log
records. It causes log_checkpoint to be called, which in turn is calling
recv_apply_hashed_log_recs. Internal logic in recv_apply_hashed_log_recs
makes it deadlock when recv_apply_hashed_log_recs is called recursively.

Fix is to perform the last recv_apply_hashed_log_recs batch with ibuf
merge disabled when doing crash recovery. When xtrabackup is running in
read-only mode, recv_apply_hashed_log_recs is invoked as usual because
the logic behing the srv_read_only_mode otherwise breaks.