### PR TITLE
PXB-1708: PXB crashes when trying to use changed page bitmaps

### DIFF
--- a/storage/innobase/xtrabackup/src/changed_page_bitmap.h
+++ b/storage/innobase/xtrabackup/src/changed_page_bitmap.h
@@ -68,7 +68,7 @@ xb_page_bitmap_range *xb_page_bitmap_range_init(
 ulint xb_page_bitmap_range_get_next_bit(
     /*==============================*/
     xb_page_bitmap_range *bitmap_range, /*!< in/out: bitmap range */
-    ibool bit_value);                   /*!< in: bit value */
+    bool bit_value);                    /*!< in: bit value */
 
 /****************************************************************/ /**
  Free the bitmap range iterator. */


### PR DESCRIPTION
There were several issues:

1. stat was running on the parent directory instead of the file
2. lambda did not modify global variables
3. free was used instead of ut_free