### PR TITLE
PXB-1683: Xbcrypt displays assertion failure and generates core if th…

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcrypt_common.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt_common.c
@@ -145,7 +145,6 @@ xb_crypt_init(uint *iv_len)
 
 	/* Set up the iv length */
 	encrypt_iv_len = gcry_cipher_get_algo_blklen(encrypt_algo);
-	xb_a(encrypt_iv_len > 0);
 	if (iv_len != NULL) {
 		*iv_len = encrypt_iv_len;
 	}
@@ -283,6 +282,9 @@ xb_crypt_decrypt(gcry_cipher_hd_t cipher_handle, const uchar *from,
 
 	} else {
 		memcpy(to, from, *to_len);
+		if (hash_appended) {
+			*to_len -= XB_CRYPT_HASH_LEN;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
…e required parameters are missing

xbcrypt defaults to encryption algorithm = NONE. It is fine for NONE to
have encryption IV length of 0.