### PR TITLE
PXB-1714: Backup of server with open trx is not restored correctly

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug1340717.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1340717.sh
@@ -25,7 +25,9 @@ load_sakila
 start_uncomitted_transaction &
 job_master=$!
 
-sleep 5;
+while ! mysql -e 'SHOW PROCESSLIST' | grep 'SELECT SLEEP' ; do
+    sleep 1;
+done
 
 xtrabackup --backup --include="sakila.actor" --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1714.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1714.sh
@@ -1,0 +1,60 @@
+#
+# Instant ALTER TABLE ADD COLUMN breaks the backup
+#
+
+. inc/common.sh
+
+start_server
+
+mysql test <<EOF
+CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 ADD COLUMN f2 INTEGER;
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+INSERT INTO t1 (f1) VALUES ('node1_committed_during');
+COMMIT;
+EOF
+
+################################################################################
+# Start an uncommitted transaction pause "indefinitely" to keep the connection
+# open
+################################################################################
+function start_uncomitted_transaction()
+{
+    mysql test <<EOF
+START TRANSACTION;
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
+SELECT SLEEP(100000);
+EOF
+}
+
+start_uncomitted_transaction &
+trx_job=$!
+
+while ! mysql -e 'SHOW PROCESSLIST' | grep 'SELECT SLEEP' ; do
+    sleep 1;
+done
+
+xtrabackup --backup  --target-dir=$topdir/backup
+
+kill -SIGKILL $trx_job
+stop_server
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+if mysql -e "CHECK TABLE t1" test | grep Corrupt ; then
+  die "Table is corrupt"
+fi


### PR DESCRIPTION
MySQL 8.0.12 introduced instant add column, which not only changed row
format, but also added new properties to data dictionary object and
internal InnoDB objects.

xtrabackup did not set number of instant columns properly when converted
from DD into dict_table_t.