### PR TITLE
PXB-1616: Invalid tablespaces are not cleaned properly for SYS_TABLES…

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -957,5 +957,50 @@ function is_64bit()
     uname -m 2>&1 | grep 'x86_64'
 }
 
+# Return number of dirty pages
+########################################################################
+function innodb_n_dirty_pages()
+{
+    result=$( $MYSQL $MYSQL_ARGS -se \
+        "SHOW STATUS LIKE 'innodb_buffer_pool_pages_dirty'" | \
+        awk '{ print $2 }' )
+    echo "Dirty pages left $result"
+    return $result
+}
+
+# Wait for InnoDB to flush all dirty pages
+########################################################################
+function innodb_wait_for_flush_all()
+{
+    while ! innodb_n_dirty_pages ; do
+        sleep 1
+    done
+}
+
+# Return current LSN
+########################################################################
+function innodb_lsn()
+{
+    ${MYSQL} ${MYSQL_ARGS} -e "SHOW ENGINE InnoDB STATUS\G" | \
+        grep "Log sequence number" | awk '{ print $4 }'
+}
+
+# Return flushed LSN
+########################################################################
+function innodb_flushed_lsn()
+{
+    ${MYSQL} ${MYSQL_ARGS} -e "SHOW ENGINE InnoDB STATUS\G" | \
+        grep "Log flushed up to" | awk '{ print $5 }'
+}
+
+# Return checkpoint LSN
+########################################################################
+function innodb_checkpoint_lsn()
+{
+    ${MYSQL} ${MYSQL_ARGS} -e "SHOW ENGINE InnoDB STATUS\G" | \
+        grep "Last checkpoint at" | awk '{ print $4 }'
+}
+
+
 # To avoid unbound variable error when no server have been started
 SRV_MYSQLD_IDS=

--- a/storage/innobase/xtrabackup/test/t/pxb-1536.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1536.sh
@@ -1,0 +1,113 @@
+#
+# PXB-1536: xtrabackup 2.4 does not remove missing tables
+#
+
+start_server --innodb_file_per_table
+
+mysql -e 'CREATE DATABASE db1'
+mysql -e 'CREATE DATABASE db2'
+mysql -e 'CREATE DATABASE db3'
+mysql -e 'CREATE DATABASE db4'
+
+mysql -e 'CREATE TABLE t (a INT)' db1
+mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db1
+
+mysql -e 'CREATE TABLE t (a INT)' db2
+mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db2
+
+mysql -e 'CREATE TABLE t (a INT)' db3
+mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db3
+
+if is_server_version_higher_than 5.7.0 ; then
+  mysql -e 'CREATE TABLESPACE q ADD DATAFILE "q.ibd"'
+  mysql -e 'CREATE TABLE qt (a INT) TABLESPACE q' db4
+  mysql -e 'INSERT INTO qt VALUES (1), (1), (3)' db4
+
+  mysql -e 'CREATE TABLESPACE p ADD DATAFILE "p.ibd"'
+  mysql -e 'CREATE TABLE pt (a INT) TABLESPACE p' db4
+  mysql -e 'INSERT INTO pt VALUES (1), (1), (3)' db4
+fi
+
+innodb_wait_for_flush_all
+
+flushed_lsn=`innodb_flushed_lsn`
+
+while [ `innodb_checkpoint_lsn` -lt "$flushed_lsn" ] ; do
+  sleep 1
+done
+
+( while true ; do
+    mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db3
+  done ) &
+
+xtrabackup --backup --tables="mysql,sys,performance_schema,db1,p" --target-dir=$topdir/backup
+
+ls -alh $mysql_datadir
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+mysql -e 'SELECT * FROM t' db1
+
+if is_server_version_higher_than 5.7.0 ; then
+  diff -u <(mysql -Nse "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES \
+                        WHERE NAME NOT LIKE '%mysql%' AND NAME NOT LIKE '%sys%' \
+                        ORDER BY NAME") - <<EOF
+db1/t
+db4/pt
+EOF
+elif is_server_version_higher_than 5.6.0 ; then
+  diff -u <(mysql -Nse "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES \
+                        WHERE NAME NOT LIKE '%mysql%' AND NAME NOT LIKE '%sys%' \
+                        ORDER BY NAME") - <<EOF
+db1/t
+EOF
+fi
+
+if is_server_version_higher_than 5.7.0 ; then
+    diff -u <(mysql -Nse "SELECT PATH FROM INFORMATION_SCHEMA.INNODB_SYS_DATAFILES \
+                          WHERE PATH NOT LIKE '%mysq%' AND PATH NOT LIKE '%sys%' \
+                          ORDER BY PATH") - <<EOF
+./db1/t.ibd
+./p.ibd
+EOF
+  diff -u <(mysql -Nse "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES \
+                        WHERE NAME NOT LIKE '%mysq%' AND NAME NOT LIKE '%sys%' \
+                        ORDER BY NAME") - <<EOF
+db1/t
+p
+EOF
+elif is_server_version_higher_than 5.6.0 ; then
+    diff -u <(mysql -Nse "SELECT PATH FROM INFORMATION_SCHEMA.INNODB_SYS_DATAFILES \
+                          WHERE PATH NOT LIKE '%mysq%' AND PATH NOT LIKE '%sys%' \
+                          ORDER BY PATH") - <<EOF
+./db1/t.ibd
+EOF
+  diff -u <(mysql -Nse "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES \
+                        WHERE NAME NOT LIKE '%mysq%' AND NAME NOT LIKE '%sys%' \
+                        ORDER BY NAME") - <<EOF
+db1/t
+EOF
+fi
+
+mysql -e 'CREATE DATABASE db2'
+mysql -e 'CREATE DATABASE db3'
+
+mysql -e 'CREATE TABLE t (a INT)' db2
+mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db2
+
+mysql -e 'CREATE TABLE t (a INT)' db3
+mysql -e 'INSERT INTO t VALUES (1), (1), (3)' db3
+
+if is_server_version_higher_than 5.7.0 ; then
+  mysql -e 'CREATE TABLESPACE q ADD DATAFILE "q.ibd"'
+  mysql -e 'CREATE TABLE qt (a INT) TABLESPACE q' db4
+  mysql -e 'INSERT INTO qt VALUES (1), (1), (3)' db4
+fi


### PR DESCRIPTION
…PACES and SYS_DATAFILES during recover

As described in the bug report, delete from SYS_TABLESPACES statement is
looking for space_id by querying SYS_TABLES, however it never able to
find the space_id because the table has already been deleted from
SYS_TABLES.