### PR TITLE
PXB-1711: Incremental backups do not create/update xtrabackup_binlog_…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2042,7 +2042,9 @@ xtrabackup_print_metadata(char *buf, size_t buf_len)
 		 xtrabackup_compact ?
 			(xtrabackup_backup ||
 				xtrabackup_compact_need_expand ? 1 : 2) : 0,
-		 MY_TEST(opt_binlog_info == BINLOG_INFO_LOCKLESS));
+		 MY_TEST((xtrabackup_backup &&
+			  (opt_binlog_info == BINLOG_INFO_LOCKLESS)) ||
+			 (xtrabackup_prepare && recover_binlog_info)));
 }
 
 /***********************************************************************

--- a/storage/innobase/xtrabackup/test/t/bug1523687.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1523687.sh
@@ -30,3 +30,11 @@ do
 		diff -u $topdir/full/$i $topdir/inc/$i
 	fi
 done
+
+#
+# PXB-1711: Incremental backups do not create/update xtrabackup_binlog_info
+#
+
+if has_backup_safe_binlog_info ; then
+	diff -u $topdir/full/xtrabackup_binlog_info $topdir/full/xtrabackup_binlog_pos_innodb
+fi


### PR DESCRIPTION
…info

With lockless binlog info support, xtrabackup generates
xtrabackup_binlog_info on prepare. In order to make it generate that
file, recover_binlog_info = 1 is written to the xtrabackup_checkpoints
file during the backup.

xtrabackup_checkpoints gets overwritten during prepare. Due to the bug,
recover_binlog_info always set to zero. It makes incremental prepare to
skip saving of xtrabackup_binlog_info.

Fix is to preserve previous value of recover_binlog_info when updating
metadata on prepare.