### PR TITLE
PXB-1737: incorrect coordinates written to xtrabackup_slave_info by 8…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1323,20 +1323,20 @@ bool write_slave_info(MYSQL *connection) {
                              << "', channel name: '" << channel.channel_name
                              << "'\n";
     } else {
-      slave_info << "CHANGE MASTER TO MASTER_LOG_FILE='" << ch->second.filename
-                 << "', MASTER_LOG_POS=" << channel.relay_log_position
+      const auto filename = channel.relay_master_log_file.empty()
+                                ? ch->second.filename
+                                : channel.relay_master_log_file;
+      const auto position = channel.relay_master_log_file.empty()
+                                ? ch->second.position
+                                : channel.exec_master_log_position;
+      slave_info << "CHANGE MASTER TO MASTER_LOG_FILE='" << filename
+                 << "', MASTER_LOG_POS=" << position
                  << for_channel << ";\n";
 
-      mysql_slave_position_s
-          << "master host '" << ch->second.master << "', filename '"
-          << (channel.relay_master_log_file.empty()
-                  ? ch->second.filename
-                  : channel.relay_master_log_file)
-          << "', position '"
-          << (channel.relay_master_log_file.empty()
-                  ? ch->second.position
-                  : channel.exec_master_log_position)
-          << "', channel name: '" << channel.channel_name << "'\n";
+      mysql_slave_position_s << "master host '" << ch->second.master
+                             << "', filename '" << filename << "', position '"
+                             << position << "', channel name: '"
+                             << channel.channel_name << "'\n";
     }
   }
 


### PR DESCRIPTION
….0.x

Instead of writing Exec_master_log_pos, xtrabackup was writing
Relay_log_pos. File name was written correctly.

Fix writes correct position and expands the test case to make sure that
slave can be set up correctly using the xtrabackup_slave_info.