### PR TITLE
Support multiple replication channels/threads on --safe-slave-backup

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1563,8 +1563,10 @@ backup_finish()
 
 	if (opt_safe_slave_backup && sql_thread_started) {
 		msg("Starting slave SQL thread\n");
-		xb_mysql_query(mysql_connection,
-				"START SLAVE SQL_THREAD", false);
+        if(supports_multiple_replication_channels)
+            restart_slave_sql_threads(mysql_connection, server_flavor);
+        else
+            xb_mysql_query(mysql_connection, "START SLAVE SQL_THREAD", false);
 	}
 
 	/* Copy buffer pool dump or LRU dump */

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -31,6 +31,9 @@ extern std::string mysql_slave_position;
 extern char *mysql_binlog_position;
 extern char *buffer_pool_filename;
 
+extern bool supports_multiple_replication_channels;
+extern std::set<std::string> sql_thread_running_set;
+
 /** connection to mysql server */
 extern MYSQL *mysql_connection;
 
@@ -125,4 +128,13 @@ dump_innodb_buffer_pool(MYSQL *connection);
 void
 check_dump_innodb_buffer_pool(MYSQL *connection);
 
+void
+restart_slave_sql_threads(MYSQL *connection, unsigned short vendor_dialect);
+
+void
+get_channel_name_and_status_position(MYSQL_RES *res, const std::string &channel_field_name,
+                                     short &channel_name_position, short &sql_thread_status_position);
+
+bool
+build_channel_name_status_set(MYSQL_RES *res, short channel_name_position, short sql_thread_status_position);
 #endif


### PR DESCRIPTION
Current implementation of `--safe-slave-backup` does not support multiple replication channels/connections due to the following issues:

- Does not consider status of non-default replication connections in MariaDB, since it only uses `SHOW SLAVE STATUS`, instead of `SHOW ALL SLAVES STATUS`
- On MariaDB, only stops (and later, starts) the SQL thread for the default replication connection, since it uses `STOP SLAVE SQL_THREAD` and `START SLAVE SQL_THREAD` instead of `STOP ALL SLAVES 'slave_name' SQL_THREAD` and `START SLAVE 'slave_name' SQL_THREAD`.
- On Oracle MySQL and compatible, it starts the SQL thread for all replication channels regardless of whether it was originally stopped or not, since it uses `START SLAVE SQL_THREAD` instead of `START SLAVE SQL_THREAD FOR CHANNEL 'channel_name'`.

This pull request aims at addressing this. 