### PR TITLE
PXB-1771: Copy-back thread reports an error when is has not done

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1785,11 +1785,12 @@ bool should_skip_file_on_copy_back(const char *filepath) {
 
 os_thread_ret_t
 copy_back_thread_func(void* data) {
-	bool ret = false;
+	bool ret = true;
 	datadir_thread_ctxt_t* ctx = (datadir_thread_ctxt_t*)data;
-	datadir_node_t node;
+	datadir_node_t node = datadir_node_t();
 
 	if (my_thread_init()) {
+		ret = false;
 		goto cleanup;
 	}
 


### PR DESCRIPTION
anything

Return value in copy_back_thread_func is initialized to false (means
error). Inside of the loop through the files it's value gets assigned to
the result of the file copy operation. However if there was not a single
file to copy by this thread, ret remains false and the thread reports
back an error.

Fix is to initialize ret as true at the beginning.