### PR TITLE
PXB-1770: Issues with prepared XA transactions

### DIFF
--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -551,6 +551,7 @@ extern bool srv_apply_log_only;
 
 extern bool srv_backup_mode;
 extern bool srv_close_files;
+extern bool srv_rollback_prepared_trx;
 
 /*-------------------------------------------*/
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -529,6 +529,7 @@ bool srv_apply_log_only = false;
 
 bool srv_backup_mode = false;
 bool srv_close_files = true;
+bool srv_rollback_prepared_trx = false;
 
 /*-------------------------------------------*/
 ulong srv_n_spin_wait_rounds = 30;

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -24,7 +24,7 @@ bool equal_paths(const char *first, const char *second);
 Copy file for backup/restore.
 @return true in case of success. */
 bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
-               const char *dst_file_path, uint thread_n);
+               const char *dst_file_path, uint thread_n, ssize_t pos = -1);
 
 /* Backup non-InnoDB data.
 @param  backup_lsn   backup LSN

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -561,6 +561,7 @@ enum options_xtrabackup {
   OPT_XTRA_ENCRYPT_CHUNK_SIZE,
   OPT_XTRA_SERVER_ID,
   OPT_LOG,
+  OPT_LOG_BIN_INDEX,
   OPT_INNODB,
   OPT_INNODB_CHECKSUMS,
   OPT_INNODB_DATA_FILE_PATH,
@@ -636,6 +637,7 @@ enum options_xtrabackup {
   OPT_NO_VERSION_CHECK,
 #endif
   OPT_NO_BACKUP_LOCKS,
+  OPT_ROLLBACK_PREPARED_TRX,
   OPT_DECOMPRESS,
   OPT_INCREMENTAL_HISTORY_NAME,
   OPT_INCREMENTAL_HISTORY_UUID,
@@ -993,6 +995,11 @@ struct my_option xb_client_options[] = {
      (uchar *)&opt_no_backup_locks, (uchar *)&opt_no_backup_locks, 0, GET_BOOL,
      NO_ARG, 0, 0, 0, 0, 0, 0},
 
+    {"rollback-prepared-trx", OPT_ROLLBACK_PREPARED_TRX,
+     "Force rollback prepared InnoDB transactions.",
+     (uchar *)&srv_rollback_prepared_trx, (uchar *)&srv_rollback_prepared_trx,
+     0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
     {"decompress", OPT_DECOMPRESS,
      "Decompresses all files with the .qp "
      "extension in a backup previously made with the --compress option.",
@@ -1182,6 +1189,10 @@ struct my_option xb_server_options[] = {
 
     {"log_bin", OPT_LOG, "Base name for the log sequence", &opt_log_bin,
      &opt_log_bin, 0, GET_STR_ALLOC, OPT_ARG, 0, 0, 0, 0, 0, 0},
+
+    {"log-bin-index", OPT_LOG_BIN_INDEX,
+     "File that holds the names for binary log files.", &opt_binlog_index_name,
+     &opt_binlog_index_name, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
     {"innodb", OPT_INNODB, "Ignored option for MySQL option compatibility",
      (G_PTR *)&innobase_ignored_opt, (G_PTR *)&innobase_ignored_opt, 0, GET_STR,
@@ -2237,6 +2248,10 @@ static bool innodb_init(bool init_dd, bool for_apply_log) {
 
   srv_start_threads(false);
 
+  while (trx_rollback_or_clean_is_active) {
+    os_thread_sleep(1000);
+  }
+
   innodb_inited = 1;
 
   return (false);
@@ -2249,11 +2264,6 @@ error:
 static bool innodb_end(void) {
   srv_fast_shutdown = (ulint)innobase_fast_shutdown;
   innodb_inited = 0;
-
-  while (trx_rollback_or_clean_is_active ||
-         !(srv_read_only_mode || srv_threads.m_master_thread_active)) {
-    os_thread_sleep(1000);
-  }
 
   msg("xtrabackup: starting shutdown with innodb_fast_shutdown = %lu\n",
       srv_fast_shutdown);

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -152,6 +152,7 @@ extern char *opt_socket;
 extern uint opt_port;
 extern char *opt_login_path;
 extern char *opt_log_bin;
+extern char *opt_binlog_index_name;
 
 extern const char *query_type_names[];
 

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -39,7 +39,46 @@ diff -u <( ( ( cd $dir1; find . | grep -v innodb_temp )
 ./client-key.pem
 ./mysql-bin.000001
 ./mysql-bin.000002
-./mysql-bin.index
+./mysqld1.err
+./private_key.pem
+./public_key.pem
+./server-cert.pem
+./server-key.pem
+EOF
+
+}
+
+function compare_files_inc() {
+
+dir1=$1
+dir2=$2
+
+# files that present in the backup directory, but not present in the datadir
+diff -u <( ( ( cd $dir1; find . | grep -v innodb_temp )
+             ( cd $dir2; find . | grep -v innodb_temp )
+             ( cd $dir2; find . | grep -v innodb_temp ) ) | sort | uniq -u ) - <<EOF
+./backup-my.cnf
+./xtrabackup_binlog_info
+./xtrabackup_binlog_pos_innodb
+./xtrabackup_checkpoints
+./xtrabackup_info
+./xtrabackup_logfile
+./xtrabackup_master_key_id
+./xtrabackup_tablespaces
+EOF
+
+# files that present in the datadir, but not present in the backup
+diff -u <( ( ( cd $dir1; find . | grep -v innodb_temp )
+             ( cd $dir1; find . | grep -v innodb_temp )
+             ( cd $dir2; find . | grep -v innodb_temp ) ) | sort | uniq -u ) - <<EOF
+./auto.cnf
+./ca-key.pem
+./ca.pem
+./client-cert.pem
+./client-key.pem
+./mysql-bin.000001
+./mysql-bin.000002
+./mysql-bin.000003
 ./mysqld1.err
 ./private_key.pem
 ./public_key.pem
@@ -61,4 +100,4 @@ mysql -e "CREATE TABLE t4 (a INT) ENGINE=InnoDB" test
 xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
 xtrabackup --prepare --target-dir=$topdir/full --apply-log-only
 xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
-compare_files $topdir/full $mysql_datadir
+compare_files_inc $topdir/full $mysql_datadir

--- a/storage/innobase/xtrabackup/test/t/binlog.sh
+++ b/storage/innobase/xtrabackup/test/t/binlog.sh
@@ -1,0 +1,76 @@
+
+function backup_restore() {
+
+  mkdir $topdir/binlog-dir1
+  mkdir $topdir/binlog-dir2
+
+  start_server $*
+
+  mysql -e "SHOW VARIABLES LIKE 'log%'";
+
+  mysql -e "CREATE TABLE t (a INT) engine=InnoDB" test
+  mysql -e "INSERT INTO t (a) VALUES (1), (2), (3)" test
+
+  xtrabackup --backup --target-dir=$topdir/backup
+  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+
+  mysql -e "INSERT INTO t (a) VALUES (1), (2), (3)" test
+
+  xtrabackup --backup --target-dir=$topdir/backup1 --incremental-basedir=$topdir/backup
+  xtrabackup --prepare --incremental-dir=$topdir/backup1 --target-dir=$topdir/backup
+
+  stop_server
+
+  rm -rf $mysql_datadir
+  rm -rf $topdir/binlog-dir1
+  rm -rf $topdir/binlog-dir2
+
+  xtrabackup --copy-back --target-dir=$topdir/backup $*
+
+  cd $mysql_datadir
+  for file in $FILES ; do
+    if ! [ -f $file ] ; then
+      die "File $file is not found!"
+    fi
+  done
+  cd -
+
+  start_server $*
+
+  mysql -e "SELECT * FROM t" test
+
+  stop_server
+
+  rm -rf $mysql_datadir
+  rm -rf $topdir/binlog-dir1
+  rm -rf $topdir/binlog-dir2
+  rm -rf $topdir/backup
+  rm -rf $topdir/backup1
+}
+
+FILES=""
+backup_restore --skip-log-bin
+
+FILES="mysql-bin.index mysql-bin.000004"
+backup_restore --log-bin
+
+FILES="binlog123.index binlog123.000003"
+backup_restore --log-bin=binlog123
+
+FILES="binlog898.index binlog123.000003"
+backup_restore --log-bin=binlog123 --log-bin-index=binlog898
+
+FILES="binlog898.index binlog123.000003"
+backup_restore --log-bin=binlog123 --log-bin-index=binlog898.index
+
+FILES="log.index $topdir/binlog-dir1/bin.000003"
+backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=log
+
+FILES="$topdir/binlog-dir1/idx.index binlog-abcd.000003"
+backup_restore --log-bin=binlog-abcd --log-bin-index=$topdir/binlog-dir1/idx
+
+FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000003"
+backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=$topdir/binlog-dir2/idx
+
+FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000003"
+backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=$topdir/binlog-dir2/idx.index

--- a/storage/innobase/xtrabackup/test/t/binlog_info.sh
+++ b/storage/innobase/xtrabackup/test/t/binlog_info.sh
@@ -26,9 +26,6 @@ EOF
     INSERT INTO t VALUES (1), (2), (3);
 EOF
 
-    binlog_file=`get_binlog_file`
-    binlog_pos=`get_binlog_pos`
-
     if [ $gtid = 1 ] ; then
         gtid_executed=`get_gtid_executed`
     fi
@@ -37,6 +34,10 @@ EOF
     xb_binlog_info_innodb=$topdir/backup/xtrabackup_binlog_pos_innodb
 
     xtrabackup --backup --target-dir=$topdir/backup
+
+    binlog_file=`get_binlog_file`
+    binlog_pos=`get_binlog_pos`
+
     verify_binlog_info_on
 
     rm -rf $topdir/backup
@@ -86,7 +87,5 @@ EOF
 
 test_binlog_info
 
-if is_server_version_higher_than 5.6.0 ; then
-    test_binlog_info --gtid-mode=ON --enforce-gtid-consistency=ON \
-                     --log-bin --log-slave-updates
-fi
+test_binlog_info --gtid-mode=ON --enforce-gtid-consistency=ON \
+                 --log-bin --log-slave-updates

--- a/storage/innobase/xtrabackup/test/t/bug1254227.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1254227.sh
@@ -32,7 +32,11 @@ echo "exit" >&3
 exec 3>&-
 wait $client_pid
 
-xtrabackup --prepare --target-dir=$topdir/full
+xtrabackup --prepare --target-dir=$topdir/full --rollback-prepared-trx
+
+if ! egrep -q "Rollback of trx with id [0-9]+ completed" $OUTFILE ; then
+  die "XA prepared transaction was not rolled back!"
+fi
 
 stop_server
 

--- a/storage/innobase/xtrabackup/test/t/xb_galera_sst.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_galera_sst.sh
@@ -42,7 +42,7 @@ load_sakila
 
 vlog "Setting password to 'password'"
 run_cmd ${MYSQL} ${MYSQL_ARGS} <<EOF
- SET PASSWORD FOR 'root'@'localhost' = PASSWORD('password');
+ SET PASSWORD FOR 'root'@'localhost' = 'password';
 EOF
 
 vlog "Starting server $node2"

--- a/storage/innobase/xtrabackup/test/t/xb_perm_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_perm_basic.sh
@@ -1,7 +1,13 @@
 # Test for fix of https://bugs.launchpad.net/percona-xtrabackup/+bug/691090
 . inc/common.sh
 
-start_server
+binlog=$topdir/xb-perm-basic-log-bin
+
+start_server --log-bin=$binlog
 
 chmod -R 500 $mysql_datadir
 xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+
+rm $binlog*

--- a/storage/innobase/xtrabackup/test/t/xb_perm_stream.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_perm_stream.sh
@@ -1,9 +1,15 @@
 # Test for fix of https://bugs.launchpad.net/percona-xtrabackup/+bug/691090
 . inc/common.sh
 
-start_server
+binlog=$topdir/xb-perm-stream-log-bin
+
+start_server --log-bin=$binlog
 
 # Take backup
 chmod -R 500 $mysql_datadir
 mkdir -p $topdir/backup
 xtrabackup --backup --stream=xbstream --target-dir=$topdir/backup > $topdir/backup/out.xbstream
+
+stop_server
+
+rm $binlog*


### PR DESCRIPTION
Xtrabackup behaviour prior to 8.0 was to always rollback prepared XA
transactions in the InnoDB prepare. It was fine since InnoDB was the
only transactional storage engine.

Now that we ship Percona Server with RocksDB, it is better to let server
to decide whether to rollback or commit prepared transactions at
startup. For this purpose we need also copy the binary log, because it
is eventually the source of truth for the server to decide whether to
commit or rollback (in combination with --tc-heuristic-recover).

On the other hand, PXC is the another example of the case where two
transnational storage engines are enabled and it always relied on old
xtrabackup behaviour to rollback transactions. For PXC we provide an
option --rollback-prepared-trx.