### PR TITLE
PXB-1552: Preparing an incremental backup will crash if compressed

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -929,8 +929,10 @@ srv_undo_tablespaces_init(
 		for (uint i = 0; i < dir->number_off_files; ++i) {
 			const fileinfo& file = dir->dir_entry[i];
 			ulint id = 0;
+			int pos;
 			if (MY_S_ISREG(file.mystat->st_mode) &&
-			    sscanf(file.name, "undo%03lu", &id) == 1) {
+			    sscanf(file.name, "undo%03lu%n", &id, &pos) == 1 &&
+			    pos == (int) strlen(file.name)) {
 				undo_tablespace_ids[j++] = id;
 			}
 		}

--- a/storage/innobase/xtrabackup/test/t/pxb-1552.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1552.sh
@@ -1,0 +1,29 @@
+#
+# PXB-1552: Preparing an incremental backup will crash if compressed InnoDB undo
+#           tablespaces are not removed beforehand
+#
+
+require_server_version_higher_than 5.6.0
+require_qpress
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_file_per_table=1
+innodb_undo_tablespaces=4
+"
+
+start_server
+
+load_sakila
+
+xtrabackup --backup --compress --target-dir=$topdir/backup
+
+mysql -e "DELETE FROM payment LIMIT 100" sakila
+
+xtrabackup --backup --compress --target-dir=$topdir/inc --incremental-basedir=$topdir/backup
+
+xtrabackup --decompress --target-dir=$topdir/backup
+xtrabackup --decompress --target-dir=$topdir/inc
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/backup


### PR DESCRIPTION
InnoDB undo tablespaces are not removed beforehand

xtrabackup discovered undo tablespaces by matching file names against
the undoXXX pattern. It was done using sscanf which matches the
beginning of the string instead of the entire string.

The fix is to verify that sscanf matched the entire string.