### PR TITLE
PXB-1781: Support MySQL 8.0.14 binlog encryption

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -10177,7 +10177,8 @@ byte *fil_tablespace_redo_encryption(byte *ptr, const byte *end,
     if (Encryption::s_master_key_id < master_key_id) {
       Encryption::s_master_key_id = master_key_id;
     }
-    xb_fetch_tablespace_key(space_id, key, iv);
+    bool found = xb_fetch_tablespace_key(space_id, key, iv);
+    ut_a(found);
   }
 
   ut_ad(len == ENCRYPTION_INFO_SIZE);

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -28,30 +28,25 @@ extern bool opt_lock_ddl_per_table;
 
 extern bool use_dumped_tablespace_keys;
 
-/******************************************************************************
-Callback used in buf_page_io_complete() to detect compacted pages.
-@return TRUE if the page is marked as compacted, FALSE otherwise. */
-ibool buf_page_is_compacted(
-    /*==================*/
-    const byte *page); /*!< in: a database page */
-
 /** Fetch tablespace key from "xtrabackup_keys".
 @param[in]	space_id	tablespace id
 @param[out]	key		fetched tablespace key
 @param[out]	key		fetched tablespace iv */
-void xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
+bool xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv)
+    MY_ATTRIBUTE((warn_unused_result));
 
 /** Save tablespace key for later use.
 @param[in]  space_id    tablespace id
 @param[in]  key     tablespace key
 @param[in]  key     tablespace iv */
-void xb_insert_tablespace_key(ulint space_id, byte *key, byte *iv);
+void xb_insert_tablespace_key(ulint space_id, const byte *key, const byte *iv);
 
 /** Fetch tablespace key from "xtrabackup_keys" and set the encryption
 type for the tablespace.
 @param[in]	space		tablespace
 @return DB_SUCCESS or error code */
-dberr_t xb_set_encryption(fil_space_t *space);
+dberr_t xb_set_encryption(fil_space_t *space)
+    MY_ATTRIBUTE((warn_unused_result));
 
 /** Add file to tablespace map.
 @param[in]	file_name	file name

--- a/storage/innobase/xtrabackup/src/keyring_plugins.h
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.h
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <mysql.h>
 #include <os0file.h>
+#include "datasink.h"
 
 /** Initialize keyring plugin for backup. Config is read from live mysql server.
 @param[in]	connection	mysql connection
@@ -71,6 +72,23 @@ bool xb_tablespace_keys_load(const char *dir, const char *transition_key,
 @return true if success */
 bool xb_tablespace_keys_dump(ds_ctxt_t *ds_ctxt, const char *transition_key,
                              size_t transition_key_len);
+
+/**
+  Store binlog password into a backup
+
+  @param[in]  binlog_file_path  binlog file path
+  @return     true if success
+*/
+bool xb_binlog_password_store(const char *binlog_file_path);
+
+/**
+  Reencrypt the password in the binlog file header and store the master
+  key int a keyring.
+
+  @param[in]  binlog_file_path  binlog file path
+  @return     true if success
+*/
+bool xb_binlog_password_reencrypt(const char *binlog_file_path);
 
 /** Shutdown keyring plugins. */
 void xb_keyring_shutdown();

--- a/storage/innobase/xtrabackup/src/wsrep.cc
+++ b/storage/innobase/xtrabackup/src/wsrep.cc
@@ -154,7 +154,7 @@ void xb_write_galera_info(bool incremental_prepare)
 /*==================*/
 {
   FILE *fp;
-  XID xid;
+  XID xid = XID();
   char uuid_str[40];
   wsrep_seqno_t seqno;
   MY_STAT statinfo;
@@ -166,7 +166,6 @@ void xb_write_galera_info(bool incremental_prepare)
     return;
   }
 
-  memset(&xid, 0, sizeof(xid));
   xid.set_format_id(-1);
 
   if (!trx_sys_read_wsrep_checkpoint(&xid)) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -5711,7 +5711,7 @@ static bool xtrabackup_apply_delta(
   pfs_os_file_t src_file = XB_FILE_UNDEFINED;
   pfs_os_file_t dst_file = XB_FILE_UNDEFINED;
   char src_path[FN_REFLEN];
-  char dst_path[FN_REFLEN];
+  char dst_path[FN_REFLEN * 2 + 1];
   char meta_path[FN_REFLEN];
   char space_name[FN_REFLEN];
   bool success;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -178,6 +178,7 @@ extern uint opt_read_buffer_size;
 
 extern char *opt_xtra_plugin_dir;
 extern char *opt_transition_key;
+extern bool opt_generate_transition_key;
 extern bool opt_generate_new_master_key;
 
 extern uint opt_dump_innodb_buffer_pool_timeout;

--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -62,7 +62,7 @@ case "$1" in
 
     innodb80)
         url="https://dev.mysql.com/get/Downloads/MySQL-8.0"
-        tarball="mysql-8.0.14-linux-glibc2.12-$arch.tar.xz"
+        tarball="mysql-8.0.15-linux-glibc2.12-$arch.tar.xz"
         ;;
 
     xtradb51)

--- a/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
@@ -139,8 +139,10 @@ EOF
 }
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
-innodb_redo_log_encrypt=ON
-innodb_undo_log_encrypt=ON
+innodb_redo_log_encrypt
+innodb_undo_log_encrypt
+binlog-encryption
+log-bin
 "
 
 # run with keyring_file plugin first
@@ -158,8 +160,10 @@ test_do "ENCRYPTION='y'" "top-secret"
 if is_xtradb && keyring_vault_ping ; then
 # cleanup environment variables
 MYSQLD_EXTRA_MY_CNF_OPTS="
-innodb_redo_log_encrypt=ON
-innodb_undo_log_encrypt=ON
+innodb_redo_log_encrypt
+innodb_undo_log_encrypt
+binlog-encryption
+log-bin
 "
 XB_EXTRA_MY_CNF_OPTS=
 
@@ -183,8 +187,10 @@ fi
 
 # cleanup environment variables
 MYSQLD_EXTRA_MY_CNF_OPTS="
-innodb_redo_log_encrypt=ON
-innodb_undo_log_encrypt=ON
+innodb_redo_log_encrypt
+innodb_undo_log_encrypt
+binlog-encryption
+log-bin
 "
 XB_EXTRA_MY_CNF_OPTS=
 
@@ -204,8 +210,10 @@ test_do "ENCRYPTION='y' COMPRESSION='lz4'" "none"
 if is_xtradb && keyring_vault_ping ; then
 # cleanup environment variables
 MYSQLD_EXTRA_MY_CNF_OPTS="
-innodb_redo_log_encrypt=ON
-innodb_undo_log_encrypt=ON
+innodb_redo_log_encrypt
+innodb_undo_log_encrypt
+binlog-encryption
+log-bin
 "
 XB_EXTRA_MY_CNF_OPTS=
 


### PR DESCRIPTION
MySQL 8.0.14 adds binary log encryption. It works similarly to InnoDB
encryption in terms of key management. There is a file password used to
encrypt the binary log file. It is stored in encrypted form in the file
header together with the master key ID and IV (used to decrypt file
password). The encryption key for the file password (master key) is
stored in the keyring.  Server never changes the file password.

When copying the binary log file, xtrabackup makes sure to add the
encryption header size to the binary log position so that binary log
data isn't truncated.

When transition-key is specified for backup, xtrabackup decrypts the
file password from the binary log header and stores it into the
"xtrabackup_keys" file with the SPACE_ID = -1 and IV =
"MYSQL-BINARY-LOG" to distinguish it from the InnoDB keys.

When generate-new-master-key is specified for the copy-back, xtrabackup
generates new master key, stores it into the keyring, and reencrypts the
binlog file header with the newly generated master key.