### PR TITLE
PXB-1784: ALTER UNDO TABLESPACE fails after restore when undo tablespace

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4401,7 +4401,7 @@ void xtrabackup_backup_func(void) {
     debug_sync_point("xtrabackup_suspend_at_start");
 
     if (xtrabackup_incremental) {
-      if (!xtrabackup_incremental_force_scan) {
+      if (!xtrabackup_incremental_force_scan && have_changed_page_bitmaps) {
         changed_page_bitmap = xb_page_bitmap_init();
       }
       if (!changed_page_bitmap) {

--- a/storage/innobase/xtrabackup/test/t/pxb-1784.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1784.sh
@@ -1,0 +1,43 @@
+#
+# PXB-1784: ALTER UNDO TABLESPACE fails after restore when undo tablespace
+#           state is changed during backup
+#
+
+start_server
+
+mysql -e "CREATE UNDO TABLESPACE undo1 ADD DATAFILE 'undo1.ibu'"
+
+while true ; do
+    mysql -e "ALTER UNDO TABLESPACE undo1 SET INACTIVE"
+    mysql -e "ALTER UNDO TABLESPACE undo1 SET ACTIVE"
+done &
+
+xtrabackup --lock-ddl --backup --target-dir=$topdir/backup
+
+mysql -e "CREATE UNDO TABLESPACE undo2 ADD DATAFILE 'undo2.ibu'"
+
+while true ; do
+    mysql -e "ALTER UNDO TABLESPACE undo2 SET INACTIVE"
+    mysql -e "ALTER UNDO TABLESPACE undo2 SET ACTIVE"
+done &
+
+xtrabackup --lock-ddl --backup --incremental-basedir=$topdir/backup --target-dir=$topdir/inc
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+ls -al $topdir/backup
+
+start_server
+
+mysql -e "ALTER UNDO TABLESPACE undo1 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE undo1 SET ACTIVE"
+
+mysql -e "ALTER UNDO TABLESPACE undo2 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE undo2 SET ACTIVE"


### PR DESCRIPTION
state is changed during backup

This bug is a result of unfortunate combination of two conditions:

1. xb_page_bitmap_init creates a bitmap object when incremental_lsn
   equals to last checkpoint lsn
2. LOCK INSTANCE FOR BACKUP paused ALTER UNDO TABLESPACE at the moment
   when it has flushed all changes

As a result even though vanilla mysql does not support changed page
bitmaps, xtrabackup opted to use changed page bitmaps read filter and
produced zero sized .delta file for undo tablespace (which is the only
one changed between full and incremental backups).

The fix is to check if server indeed support changed page bitmaps when
choosing the read filter.