### PR TITLE
PXB-1793: Full backup fails when PS is initialized and started with

### DIFF
--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -241,10 +241,6 @@ xb_fil_cur_result_t xb_fil_cur_read(
       cursor->page_size, cursor->zip_size != 0);
   IORequest read_request(IORequest::READ);
 
-  read_request.encryption_algorithm(Encryption::AES);
-  read_request.encryption_key(cursor->encryption_key, cursor->encryption_klen,
-                              cursor->encryption_iv);
-
   cursor->read_filter->get_next_batch(&cursor->read_filter_ctxt, &offset,
                                       &to_read);
 
@@ -307,6 +303,10 @@ read_retry:
     }
     return (XB_FIL_CUR_ERROR);
   }
+
+  read_request.encryption_algorithm(Encryption::AES);
+  read_request.encryption_key(cursor->encryption_key, cursor->encryption_klen,
+                              cursor->encryption_iv);
 
   npages = n_read >> cursor->page_size_shift;
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1793.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1793.sh
@@ -1,0 +1,23 @@
+#
+# PXB-1793: Full backup fails when PS is initialized and
+#           started with encryption options
+#
+
+require_xtradb
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+binlog-encryption
+innodb-undo-log-encrypt
+innodb-redo-log-encrypt
+innodb_encrypt_tables=ON
+innodb_encrypt_online_alter_logs=ON
+innodb_temp_tablespace_encrypt=ON
+encrypt-tmp-files
+"
+
+. inc/keyring_file.sh
+
+start_server
+
+# backup fails if bug is present
+xtrabackup --backup --target-dir=$topdir/backup


### PR DESCRIPTION
encryption options

xtrabackup reading data files in 10M chunks using
os_file_read. os_file_read may decrypt the data which has been
read. Decryption doesn't handle large chunks. It expects data to be read
in pages, else it may crash.

Fix is to read the data files with decryption disabled.