### PR TITLE
Fix new GCC 9 warning:

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -2047,7 +2047,7 @@ String *Item_func_format::val_str_ascii(String *str) {
     char *start_dst = dst;
 
     /* Put the fractional part */
-    if (dec) {
+    if (dec > 0) {
       dst -= (dec + 1);
       *dst = lc->decimal_point;
       memcpy(dst + 1, src + 2, dec);


### PR DESCRIPTION
[  874s] In function 'void* memcpy(void*, const void*, size_t)',
[  874s]     inlined from 'virtual String* Item_func_format::val_str_ascii(String*)' at /home/abuild/rpmbuild/BUILD/percona-xtrabackup-2.4.12/sql/item_strfunc.cc:3214:13:
[  874s] /usr/include/bits/string_fortified.h:34:33: warning: 'void* __builtin_memcpy(void*, const void*, unsigned int)' writing 1 or more bytes into a region of size 0 overflows the destination [-Wstringop-overflow=]
[  874s]    34 |   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));

It's analyzed here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89350