### PR TITLE
PXB-1801: Xtrabackup fails if log_bin_index is defined in my.cnf

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1457,7 +1457,13 @@ bool write_current_binlog_file(MYSQL *connection) {
 
   if (opt_binlog_index_name != nullptr) {
     free(log_bin_index);
-    log_bin_index = strdup(opt_binlog_index_name);
+    std::string index = opt_binlog_index_name;
+    if (index.length() < 6 ||
+        index.compare(index.length() - 6, index.length(), ".index") != 0) {
+      /* doesn't end with .index */
+      index.append(".index");
+    }
+    log_bin_index = strdup(index.c_str());
   } else if (log_bin_index == nullptr) {
     /* if index file name is not set, compose it from the current log file name
     by replacing its number with ".index" */

--- a/storage/innobase/xtrabackup/test/t/binlog.sh
+++ b/storage/innobase/xtrabackup/test/t/binlog.sh
@@ -48,29 +48,110 @@ function backup_restore() {
   rm -rf $topdir/backup1
 }
 
+vlog "------- TEST 1 -------"
 FILES=""
 backup_restore --skip-log-bin
 
+vlog "------- TEST 2 -------"
 FILES="mysql-bin.index mysql-bin.000004"
 backup_restore --log-bin
 
+vlog "------- TEST 3 -------"
 FILES="binlog123.index binlog123.000003"
 backup_restore --log-bin=binlog123
 
+vlog "------- TEST 4 -------"
 FILES="binlog898.index binlog123.000003"
 backup_restore --log-bin=binlog123 --log-bin-index=binlog898
 
+vlog "------- TEST 5 -------"
 FILES="binlog898.index binlog123.000003"
 backup_restore --log-bin=binlog123 --log-bin-index=binlog898.index
 
+vlog "------- TEST 6 -------"
 FILES="log.index $topdir/binlog-dir1/bin.000003"
 backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=log
 
+vlog "------- TEST 7 -------"
 FILES="$topdir/binlog-dir1/idx.index binlog-abcd.000003"
 backup_restore --log-bin=binlog-abcd --log-bin-index=$topdir/binlog-dir1/idx
 
+vlog "------- TEST 8 -------"
 FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000003"
 backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=$topdir/binlog-dir2/idx
 
+vlog "------- TEST 9 -------"
 FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000003"
 backup_restore --log-bin=$topdir/binlog-dir1/bin --log-bin-index=$topdir/binlog-dir2/idx.index
+
+
+# do the same, but with updating my.cnf
+
+vlog "------- TEST 10 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+skip-log-bin
+"
+FILES=""
+backup_restore
+
+vlog "------- TEST 11 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin
+"
+FILES="mysql-bin.index mysql-bin.000004"
+backup_restore
+
+vlog "------- TEST 12 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=binlog123
+"
+FILES="binlog123.index binlog123.000004"
+backup_restore
+
+vlog "------- TEST 13 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=binlog123
+log-bin-index=binlog898
+"
+FILES="binlog898.index binlog123.000004"
+backup_restore
+
+vlog "------- TEST 14 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=binlog123
+log-bin-index=binlog898.index
+"
+FILES="binlog898.index binlog123.000004"
+backup_restore
+
+vlog "------- TEST 15 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=$topdir/binlog-dir1/bin
+log-bin-index=log
+"
+FILES="log.index $topdir/binlog-dir1/bin.000004"
+backup_restore
+
+vlog "------- TEST 16 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=binlog-abcd
+log-bin-index=$topdir/binlog-dir1/idx
+"
+FILES="$topdir/binlog-dir1/idx.index binlog-abcd.000004"
+backup_restore
+
+vlog "------- TEST 17 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=$topdir/binlog-dir1/bin
+log-bin-index=$topdir/binlog-dir2/idx
+"
+FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000004"
+backup_restore
+
+vlog "------- TEST 18 -------"
+MYSQLD_EXTRA_MY_CNF_OPTS="
+log-bin=$topdir/binlog-dir1/bin
+log-bin-index=$topdir/binlog-dir2/idx.index
+"
+FILES="$topdir/binlog-dir2/idx.index $topdir/binlog-dir1/bin.000004"
+backup_restore


### PR DESCRIPTION
xtrabackup did not append .index when log-bin-index value was not ending
with .index and was read from my.cnf.