### PR TITLE
PXB-1824: PXB crashes in incremental backup prepare when row format is

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2512,8 +2512,9 @@ fil_op_log_parse_or_replay(
 	ulint	space_id,	/*!< in: the space id of the tablespace in
 				question, or 0 if the log record should
 				only be parsed but not replayed */
-	ulint	log_flags)	/*!< in: redo log flags
+	ulint	log_flags,	/*!< in: redo log flags
 				(stored in the page number parameter) */
+	bool	apply)		/*!< in: whether to apply the record */
 {
 	ulint		name_len;
 	ulint		new_name_len;
@@ -2578,7 +2579,7 @@ fil_op_log_parse_or_replay(
 	printf("new name %s\n", new_name);
 	}
 	*/
-	if (!space_id || recv_is_making_a_backup) {
+	if (!space_id || recv_is_making_a_backup || !apply) {
 		return(ptr);
 	}
 

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1044,8 +1044,9 @@ fil_op_log_parse_or_replay(
 	ulint	space_id,	/*!< in: the space id of the tablespace in
 				question, or 0 if the log record should
 				only be parsed but not replayed */
-	ulint	log_flags);	/*!< in: redo log flags
+	ulint	log_flags,	/*!< in: redo log flags
 				(stored in the page number parameter) */
+	bool	apply);		/*!< in: whether to apply the record */
 
 /** Replay a file rename operation if possible.
 @param[in]	space_id	tablespace identifier

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -526,7 +526,8 @@ trx_sys_init_at_db_start(void)
 	purge_queue = UT_NEW_NOKEY(purge_pq_t());
 	ut_a(purge_queue != NULL);
 
-	if (srv_force_recovery < SRV_FORCE_NO_UNDO_LOG_SCAN) {
+	if (srv_force_recovery < SRV_FORCE_NO_UNDO_LOG_SCAN
+	    && !srv_apply_log_only) {
 		trx_rseg_array_init(purge_queue);
 	}
 

--- a/storage/innobase/xtrabackup/src/libarchive/build/pkgconfig/libarchive.pc
+++ b/storage/innobase/xtrabackup/src/libarchive/build/pkgconfig/libarchive.pc
@@ -8,4 +8,4 @@ Description: library that can create and read several streaming archive formats
 Version: 3.3.1
 Cflags: -I${includedir}
 Libs: -L${libdir} -larchive
-Libs.private:  -lz
+Libs.private:  -lz -lacl

--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -121,7 +121,7 @@ wf_incremental_process(xb_write_filt_ctxt_t *ctxt, ds_file_t *dstfile)
 	for (i = 0, page = cursor->buf; i < cursor->buf_npages;
 	     i++, page += page_size) {
 
-		if (incremental_lsn >= mach_read_from_8(page + FIL_PAGE_LSN)) {
+		if (incremental_lsn > mach_read_from_8(page + FIL_PAGE_LSN)) {
 
 			continue;
 		}

--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -26,7 +26,7 @@ $MYSQL $MYSQL_ARGS -Ns -e \
 
 binlog_stmts=$lock_binlog_used
 
-diff $topdir/status1 - <<EOF
+run_cmd diff -u $topdir/status1 - <<EOF
 Com_lock_tables	0
 Com_lock_tables_for_backup	1
 Com_lock_binlog_for_backup	$binlog_stmts
@@ -47,13 +47,13 @@ $MYSQL $MYSQL_ARGS -Ns -e \
 
 ((binlog_stmts+=lock_binlog_used)) || true
 
-diff $topdir/status2 - <<EOF
+run_cmd diff -u $topdir/status2 - <<EOF
 Com_lock_tables	0
 Com_lock_tables_for_backup	2
 Com_lock_binlog_for_backup	$binlog_stmts
 Com_unlock_binlog	$binlog_stmts
 Com_unlock_tables	2
-Com_flush	3
+Com_flush	2
 EOF
 
 ########################################################################
@@ -72,11 +72,11 @@ $MYSQL $MYSQL_ARGS -Ns -e \
        SHOW GLOBAL STATUS LIKE 'Com_flush%'" \
        > $topdir/status3
 
-diff $topdir/status3 - <<EOF
+run_cmd diff -u $topdir/status3 - <<EOF
 Com_lock_tables	0
 Com_lock_tables_for_backup	2
 Com_lock_binlog_for_backup	$binlog_stmts
 Com_unlock_binlog	$binlog_stmts
 Com_unlock_tables	3
-Com_flush	6
+Com_flush	5
 EOF

--- a/storage/innobase/xtrabackup/test/t/pxb-1824.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1824.sh
@@ -1,0 +1,82 @@
+#
+# PXB-1824: PXB crashes in incremental backup prepare when row format is changed
+#
+
+start_server
+
+require_server_version_higher_than 5.6.0
+require_xtradb
+
+for i in {1..10} ; do
+    cat <<EOF
+CREATE TABLE sbtest$i (
+  id int(10) unsigned NOT NULL AUTO_INCREMENT,
+  k int(10) unsigned NOT NULL DEFAULT '0',
+  c char(120) NOT NULL DEFAULT '',
+  pad char(60) NOT NULL DEFAULT '',
+  PRIMARY KEY (id),
+  KEY k_1 (k)
+) ENGINE=InnoDB;
+EOF
+done | mysql test
+
+for i in {1..1000} ; do
+    echo "INSERT INTO sbtest1 (id, k, c, pad) VALUES (0, FLOOR(RAND() * 100000), REPEAT(UUID(), 3), UUID());"
+done | mysql test
+
+for i in {2..10} ; do
+    mysql -e "INSERT INTO sbtest$i (k, c, pad) SELECT k, c, pad FROM sbtest1" test
+done
+
+while true ; do
+    for i in {1..10} ; do
+	mysql -e "INSERT INTO sbtest$i (k, c, pad) SELECT k, c, pad FROM sbtest$i LIMIT 20" test
+    done
+done >/dev/null 2>/dev/null &
+
+while true ; do
+      mysql -e "ALTER TABLE test.sbtest2 ROW_FORMAT=COMPRESSED"
+      mysql -e "ALTER TABLE test.sbtest2 ROW_FORMAT=DYNAMIC"
+      mysql -e "ALTER TABLE test.sbtest2 ROW_FORMAT=COMPACT"
+      mysql -e "ALTER TABLE test.sbtest2 ROW_FORMAT=REDUNDANT"
+
+      mysql -e "OPTIMIZE TABLE test.sbtest1"
+      mysql -e "ALTER TABLE test.sbtest1 FORCE"
+      mysql -e "TRUNCATE test.sbtest1"
+done >/dev/null 2>/dev/null &
+
+xtrabackup --lock-ddl --backup --target-dir=$topdir/backup --parallel=8
+xtrabackup --lock-ddl --backup --incremental-basedir=$topdir/backup \
+	   --target-dir=$topdir/inc --parallel=8
+xtrabackup --lock-ddl --backup --incremental-basedir=$topdir/inc \
+	   --target-dir=$topdir/inc1 --parallel=8
+
+if ! grep -q flushed_lsn $topdir/backup/xtrabackup_checkpoints ; then
+    die "flushed_lsn is missing"
+fi
+
+stop_server
+
+# apply log shoulnd't fail
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+	   --target-dir=$topdir/backup
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+	   --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+lsn1=$(grep -q flushed_lsn $topdir/backup/xtrabackup_checkpoints)
+lsn2=$(grep -q flushed_lsn $topdir/inc1/xtrabackup_checkpoints)
+
+if [ "$lsn1" != "$lsn2" ] ; then
+    die "flushed_lsn is not updated"
+fi
+
+rm -rf $mysql_datadir
+
+xtrabackup --move-back --parallel=8 --target-dir=$topdir/backup
+
+start_server
+
+mysql -e "CHECKSUM TABLE sbtest2 EXTENDED" test


### PR DESCRIPTION
changed

This patch fixes several issues.

First one is a 0-day bug in the incremental backups logic. Pages are not
included into incremental backup if page's LSN is less than or equal to
the incremental LSN. Page's LSN points to the end of the last log record
applied to the page. It means that this last record will be missing from
the incremental backup in the case when checkpoint LSN did not advance
between full and incremental backups, causing data corruption.

The fix is to change the condition in the incremental filter.

Second one is related to online alter skipping redo logs. Xtrabackup is
using LOCK TABLES FOR BACKUP in order to stop online DDL and rely on
InnoDB to flush the changes on disk. There is a caveat though,
xtrabackup copies the redo starting with checkpoint LSN which is earlier
than the last flushed LSN. Some DDL may rebuild table using following
sequence:

Lets say we rebuilding the table t.

1. Create the table tmp1
2. Build the new table in the tmp1 using fast index creation and
   skipping redo logs
3. Rename the table t into tmp2
4. Rename the tmp1 into t
5. Drop the tmp2

Backup has been started right after 5. Now if the checkpoint was after
5, xtrabackup is good. If checkpoint was before 1, xtrabackup will
delete the good table t flushed by server and replace it with the table
with some of the rows (or all of them) missing.

The fix is to remember the last flushed LSN at the beginning of the
backup and do not replay file operations for LSNs older than that.

Third one is a memory leak. Resurrected transactions were not rolled
back (this is a feature) and memory was not freed at shutdown (this is a
bug). Fix is to avoid undo log scan altogether when prepare is run with
apply-log-only.

Also backported fix for PXB-1773.