### PR TITLE
PXB-1832: Xbcloud does not exit when a piped command fails

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -816,6 +816,13 @@ bool xbcloud_download(Object_store *store, Event_handler *h,
                 std::cout.write(&contents[0], contents.size());
                 std::cout.flush();
                 download_state->complete_chunk(basename);
+                if (std::cout.fail()) {
+                  msg_ts(
+                      "%s: Download failed. Cannot write to the standard "
+                      "output.\n",
+                      my_progname);
+                  *error = true;
+                }
               },
               std::placeholders::_1, std::placeholders::_2, object_name,
               it->first, &download_state, &error));
@@ -832,7 +839,9 @@ bool xbcloud_download(Object_store *store, Event_handler *h,
 
 struct main_exit_hook {
   ~main_exit_hook() {
-    free_defaults(defaults_argv);
+    if (defaults_argv != nullptr) {
+      free_defaults(defaults_argv);
+    }
     my_end(0);
   }
 };

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -21,7 +21,7 @@ require_server_version_higher_than 5.7.0
 is_galera && skip_test "skipping"
 
 [ "${XBCLOUD_CREDENTIALS:-unset}" == "unset" ] && \
-	skip_test "Requires XBCLOUD_CREDENTIALS"
+    skip_test "Requires XBCLOUD_CREDENTIALS"
 
 start_server --innodb_file_per_table
 
@@ -97,6 +97,16 @@ diff -u $topdir/partial/partial.list - <<EOF
 ibdata1
 sakila/payment.ibd
 EOF
+
+# PXB-1832: Xbcloud does not exit when a piped command fails
+xbcloud --defaults-file=$topdir/xbcloud.cnf get 2>$topdir/pxb-1832.log | true
+if [ "${PIPESTATUS[0]}" == "0" ] ; then
+    die 'xbcloud did not exit with error'
+fi
+
+if [ ! grep failed 2>$topdir/pxb-1832.log ] ; then
+    die 'xbcloud did not exit with error'
+fi
 
 # cleanup
 run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf delete \


### PR DESCRIPTION
PXB-1834: Xbcloud crashes if defaults file cannot be opened

Made download to fail when it was unable to write into the output file.
Made exit hook to check that the value passed to free_deaults is not
NULL.