### PR TITLE
PXB-1837: various issues with xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -45,6 +45,9 @@ inline curl_easy_unique_ptr make_curl_easy() {
   return curl_easy_unique_ptr(curl_easy_init(), curl_easy_cleanup);
 }
 
+bool http_init();
+void http_cleanup();
+
 std::string uri_escape_string(const std::string &s);
 std::string uri_escape_path(const std::string &path);
 
@@ -239,7 +242,7 @@ class Http_connection {
     curl_easy_setopt(curl_.get(), CURLOPT_ERRORBUFFER, error_);
   };
 
-  ~Http_connection() {}
+  ~Http_connection() { curl_slist_free_all(headers_); }
 
   CURL *curl_easy() const { return curl_.get(); };
 
@@ -254,7 +257,6 @@ class Http_connection {
     if (callback_) {
       callback_(rc, this);
     }
-    curl_slist_free_all(headers_);
   }
 
   upload_state_t *upload_state() { return &upload_state_; }
@@ -267,12 +269,14 @@ class Event_handler {
   struct ev_loop *loop{nullptr};
   struct ev_timer timer_event;
   struct ev_async queue_event;
+  struct ev_timer kickoff_event;
   CURLM *curl_multi{nullptr};
   int running_handles{0};
   std::mutex queue_mutex;
   size_t n_queued{0};
   size_t max_requests;
   bool final{false};
+  bool loop_running{false};
 
   struct Curl_socket_info {
     curl_socket_t sockfd;
@@ -305,6 +309,8 @@ class Event_handler {
 
   static void ev_timer_callback(EV_P_ struct ev_timer *timer, int events);
 
+  static void ev_kickoff_callback(EV_P_ struct ev_timer *timer, int events);
+
   static void ev_queue_callback(EV_P_ ev_async *ev, int revents);
 
   void main_loop();
@@ -323,8 +329,6 @@ class Event_handler {
   void add_connection(Http_connection *conn, bool nowait = false);
 
   void stop();
-
-  bool running() const { return running_handles > 0; };
 };
 
 bool retriable_curl_error(CURLcode rc);

--- a/storage/innobase/xtrabackup/src/xbcloud/object_store.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/object_store.h
@@ -57,6 +57,7 @@ class Object_store {
   virtual Http_buffer download_object(const std::string &container,
                                       const std::string &name,
                                       bool &success) = 0;
+  virtual ~Object_store(){};
 };
 
 }  // namespace xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -489,7 +489,6 @@ bool S3_client::upload_object(const std::string &bucket,
                               const Http_buffer &contents) {
   Http_request req(Http_request::PUT, protocol, hostname(bucket),
                    bucketname(bucket) + "/" + name);
-  req.add_header("Content-Length", std::to_string(contents.size()));
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload(contents);
   signer->sign_request(hostname(bucket), bucket, req, time(0));
@@ -588,7 +587,6 @@ bool S3_client::async_upload_object(
            bucket.c_str(), name.c_str());
     return false;
   }
-  req->add_header("Content-Length", std::to_string(contents.size()));
   req->add_header("Content-Type", "application/octet-stream");
   for (const auto &h : extra_http_headers) {
     req->add_header(h.first, h.second);

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -51,6 +51,7 @@ class S3_signer {
   virtual void sign_request(const std::string &hostname,
                             const std::string &bucket, Http_request &req,
                             time_t t) = 0;
+  virtual ~S3_signer(){};
 };
 
 class S3_signerV4 : public S3_signer {

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -732,7 +732,6 @@ bool Swift_client::upload_object(const std::string &container,
   Http_request req(Http_request::PUT, protocol, host,
                    path + container + "/" + name);
   req.append_payload(contents);
-  req.add_header("Content-Length", std::to_string(contents.size()));
   req.add_header("Content-Type", "application/octet-stream");
   req.add_header("X-Auth-Token", token);
   req.add_header("ETag", hex_encode(req.payload().md5()));
@@ -770,7 +769,6 @@ bool Swift_client::async_upload_object(const std::string &container,
     return false;
   }
   req->append_payload(contents);
-  req->add_header("Content-Length", std::to_string(contents.size()));
   req->add_header("Content-Type", "application/octet-stream");
   req->add_header("X-Auth-Token", token);
   req->add_header("ETag", hex_encode(req->payload().md5()));

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -45,7 +45,7 @@ vlog "take full backup"
 
 xtrabackup --backup --stream=xbstream --extra-lsndir=$full_backup_dir \
 	   --target-dir=$full_backup_dir | \
-    xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+    run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
 	    --parallel=4 \
 	    ${full_backup_name}
 
@@ -54,7 +54,7 @@ vlog "take incremental backup"
 xtrabackup --backup --incremental-basedir=$full_backup_dir \
 	   --stream=xbstream --target-dir=inc_backup_dir \
 	   --parallel=4 | \
-    xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+    run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
             --parallel=4 \
 	    ${inc_backup_name}
 
@@ -92,6 +92,8 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 
 xbstream -xv -C $topdir/partial < $topdir/partial/partial.xbs \
 	 2> $topdir/partial/partial.list
+
+sort -o $topdir/partial/partial.list $topdir/partial/partial.list
 
 diff -u $topdir/partial/partial.list - <<EOF
 ibdata1


### PR DESCRIPTION
- Memory allocated on stack by xblcoud_<put/delete/download> may have
  been accessed by the callbacks after the function has exited. Fixed by
  making xblcoud_<put/delete/download> to wait for completion of all
  asynchronous requests.

- xbcloud/xbstream on centos 7 did not preserve alphabetical
  order. Fixed by passing ls output through the sort command.

- Older libcurl used on Centos 6 freed internal structures of an
  easy_handle when curl_multi_remove_handle was called. These structures
  were than accessed in Http_connection::finalize. Fix swaps two calls.

- Older libcurl version used in Centos 6 could fail to return valid
  value for CURLINFO_EFFECTIVE_URL. Error code check was added.

- Older libcurl version used in Centos 6 does not understand
  Content-Length header passed manually and ended up sending two
  Content-Length headers. Which broke S3 authentication.

- Older libcurl version used in Centos 6 can return
  CURLM_CALL_MULTI_PERFORM in response to curl_multi_socket_action. This
  error code was not handled by mcode_or_die.

- Class Object_store did not have virtual destructor which caused memory
  leaks of small amount of resources.

- Because of the bad timings, event loop could have started after we
  pushed some work into the queue which caused missed async events and
  timeouts. Fixed by adding a kickoff timer who's only goal is to
  indicate that event loop has started.

- Even though libcurl claims to be thread-safe, this is not always true
  when it comes to using it with OpenSSL. xbcloud makes all HTTP
  requests using curl_multi in single thread. There is another thread
  which can call curl_easy_escape. curl_easy handle was created for each
  of such calls. Crash was observed on Debian 9 and the stack trace
  included curl_easy_cleanup followed by OpenSSL cleanup code. It is
  known that in order to use older versions of OpenSSL in multi-threaded
  environment, one needed to provide locking callbacks. Debian 9,
  however, comes with OpenSSL 1.1.0j, which has built-in support for
  multi-threading which should just work. Fix (more a workaround) is to
  use single curl_easy for all curl_easy_escape calls, guard the calls
  with mutex (which is not really needed at the moment, because all url
  escape calls come from one thread).
