### PR TITLE
PXB-1839: PXB 8.0.5 crashes when preparing MySQL 8.0.16

### DIFF
--- a/sql/dd/impl/sdi.cc
+++ b/sql/dd/impl/sdi.cc
@@ -408,12 +408,14 @@ bool generic_deserialize(
   RJ_Value &sdi_version_val = doc["sdi_version"];
   DBUG_ASSERT(sdi_version_val.IsUint64());
   std::uint64_t sdi_version_ = sdi_version_val.GetUint64();
+#if !defined(XTRABACKUP)
   if (sdi_version_ != sdi_version) {
     // Incompatible change
     my_error(ER_IMP_INCOMPATIBLE_SDI_VERSION, MYF(0), sdi_version_,
              sdi_version);
     return true;
   }
+#endif
 
   DBUG_ASSERT(doc.HasMember("dd_object_type"));
   RJ_Value &dd_object_type_val = doc["dd_object_type"];

--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -62,7 +62,7 @@ case "$1" in
 
     innodb80)
         url="https://dev.mysql.com/get/Downloads/MySQL-8.0"
-        tarball="mysql-8.0.15-linux-glibc2.12-$arch.tar.xz"
+        tarball="mysql-8.0.16-linux-glibc2.12-$arch.tar.xz"
         ;;
 
     xtradb51)


### PR DESCRIPTION
MySQL 8.0.16 bumped SDI version number. Xtrabackup failed to accept this
version. Changes like this not necessary break prepare. Xtrabackup is
made to accept newer SDI versions.