### PR TITLE
PXB-1844: xbcloud crashes with swift storage when project options are

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -322,14 +322,6 @@ bool Keystone_client::auth_v3(const std::string &swift_region,
           }
         }
 
-    or
-
-        "scope": {
-          "domain": {
-            "id": "default"
-          }
-        }
-
       }
     }
   */
@@ -422,10 +414,6 @@ bool Keystone_client::auth_v3(const std::string &swift_region,
       write_domain(writer, project_domain, project_domain_id);
     }
     writer.EndObject();  // project
-    writer.EndObject();  // scope
-  } else if (!domain.empty() || domain_id.empty()) {
-    writer.Key("scope");
-    write_domain(writer, domain, domain_id);
     writer.EndObject();  // scope
   }
   writer.EndObject();  // auth

--- a/storage/innobase/xtrabackup/test/t/unittests.sh
+++ b/storage/innobase/xtrabackup/test/t/unittests.sh
@@ -1,0 +1,7 @@
+#
+# run unittests
+#
+
+if which xbcloud-t ; then
+    run_cmd xbcloud-t
+fi


### PR DESCRIPTION
not included

Keystone client tried to build malformed JSON and crashed when project
was not specified.

Fixed by making keystone client to avoid adding the scope into auth
request. Now two types of authentication are supported:

- project-scoped when project or project-id is specified
- unscoped when none of the above is specified