### PR TITLE
PXB-1850: SIGPIPE handling in xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_getopt.h>
 #include <my_sys.h>
 #include <mysql/service_mysql_alloc.h>
+#include <signal.h>
 #include <typelib.h>
 #include <cstdlib>
 #include <fstream>
@@ -823,6 +824,7 @@ bool xbcloud_download(Object_store *store, const std::string &container,
     if (error && !download_state.empty()) {
       continue;
     }
+    if (error) break;
     for (auto it = chunks.begin(); it != chunks.end();) {
       if (error) break;
       if (!download_state.start_chunk(it->first)) {
@@ -894,6 +896,10 @@ struct main_exit_hook {
 
 int main(int argc, char **argv) {
   MY_INIT(argv[0]);
+
+#ifndef NO_SIGPIPE
+  signal(SIGPIPE, SIG_IGN);
+#endif
 
   http_init();
   crc_init();


### PR DESCRIPTION
When xbcloud output is piped to another command and this command is
terminated for some reason, xbcloud normally gets killed by SIGPIPE. It
is observed that in some environments xbcloud is not killed and hangs.

Fix makes xbcloud to always ignore SIGPIPE and exit with error when it
cannot write to the output file.