### PR TITLE
Test pxb-1536.sh is unstable with MySQL 8.0.16

### DIFF
--- a/storage/innobase/xtrabackup/test/t/pxb-1536.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1536.sh
@@ -46,7 +46,7 @@ stop_server
 
 rm -rf $mysql_datadir
 
-xtrabackup --prepare --target-dir=$topdir/backup
+xtrabackup --prepare --rollback-prepared-trx --target-dir=$topdir/backup
 
 xtrabackup --copy-back --target-dir=$topdir/backup
 


### PR DESCRIPTION
Default behavior in xtrabackup since 8.0 is to skip rollback of prepared
XA transactions. This is done to let MySQL decide on startup whether to
rollback or commit these transactions.

Combined with partial backups this may crash the server on startup if XA
transactions are touching missing tables. To avoid this, one must pass
the --rollback-prepared-trx option when preparing partial backups.