### PR TITLE
PXB-1846: Test innodb_redo_log_encrypt.sh is unstable with PS 8.0.15

### DIFF
--- a/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
@@ -21,7 +21,7 @@ function start_workload()
 {
 	mysql -e 'INSERT INTO t (a) VALUES (1), (2), (3), (4)' test
 	( while true ; do
-		echo 'INSERT INTO t (a) SELECT a FROM t;'
+		echo 'INSERT INTO t (a) SELECT a FROM t LIMIT 200;'
 		sleep 1
 	done ) | mysql test
 }


### PR DESCRIPTION
The error

    error: log block numbers mismatch:
    xtrabackup: error: expected log block no. 119813, but got no. 316413 from the log file.
    xtrabackup: error: it looks like InnoDB log has wrapped around before xtrabackup could process all records due to either log copying being too slow, or  log files being too small.

Means that xtrabackup could not catch up with the server running heavy
write workload. This can happen with xtrabackup debug builds.

Fix is to throttle insert load a little.