### PR TITLE
PXB-1867: Encrypted and compressed tables are not restored correctly

### DIFF
--- a/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_encryption.sh
@@ -142,11 +142,13 @@ function cleanup_keyring() {
 }
 
 test_do "ENCRYPTION='y'" "" "top-secret"
+test_do "ENCRYPTION='y'" "ROW_FORMAT=COMPRESSED" "none"
+test_do "ENCRYPTION='y'" "ROW_FORMAT=COMPRESSED" "top-secret"
+test_do "ENCRYPTION='y'" "COMPRESSION='zlib'" "top-secret"
 
 # cleanup environment variables
 MYSQLD_EXTRA_MY_CNF_OPTS=
 XB_EXTRA_MY_CNF_OPTS=
-
 
 # and rerun with keyring_vault
 
@@ -163,45 +165,13 @@ function cleanup_keyring() {
 trap "keyring_vault_unmount" EXIT
 
 test_do "ENCRYPTION='y'" "" "top-secret"
-
-keyring_vault_unmount
-trap "" EXIT
-
-# cleanup environment variables
-MYSQLD_EXTRA_MY_CNF_OPTS=
-XB_EXTRA_MY_CNF_OPTS=
-
-
-# run with keyring_file plugin first
-
-. inc/keyring_file.sh
-
-function cleanup_keyring() {
-	rm -rf $keyring_file
-}
-
-test_do "ENCRYPTION='y'" "COMPRESSION='lz4'" "none"
-
-# cleanup environment variables
-MYSQLD_EXTRA_MY_CNF_OPTS=
-XB_EXTRA_MY_CNF_OPTS=
-
-
-# and rerun with keyring_vault
-
-. inc/keyring_vault.sh
-
-keyring_vault_ping || skip_test "Keyring vault server is not avaliable"
-
-keyring_vault_mount
-
-function cleanup_keyring() {
-	keyring_vault_remove_all_keys
-}
-
-trap "keyring_vault_unmount" EXIT
-
+test_do "ENCRYPTION='y'" "ROW_FORMAT=COMPRESSED" "none"
+test_do "ENCRYPTION='y'" "ROW_FORMAT=COMPRESSED" "top-secret"
 test_do "ENCRYPTION='y'" "COMPRESSION='zlib'" "generate"
 
 keyring_vault_unmount
 trap "" EXIT
+
+# cleanup environment variables
+MYSQLD_EXTRA_MY_CNF_OPTS=
+XB_EXTRA_MY_CNF_OPTS=


### PR DESCRIPTION
when generate-new-master-key is used

After re-encrypting the tablespace header for generate-new-master-key,
xtrabackup updates the page checksum. Checksum for InnoDB-compressed
pages calculated differently from usual pages. Xtrabackup did not update
the checksum correctly for such pages.