### PR TITLE
PXB-1864: External XA-prepared transactions are rolled back after pre…

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -59,6 +59,14 @@ xb_compact_rebuild_indexes(void);
 void
 xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
 
+/***********************************************************************//**
+Check if a given WSREP XID is valid.
+
+@return true if valid.
+*/
+bool
+wsrep_is_wsrep_xid(const void* xid_ptr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/storage/innobase/xtrabackup/src/wsrep.cc
+++ b/storage/innobase/xtrabackup/src/wsrep.cc
@@ -47,6 +47,7 @@ permission notice:
 #include <trx0sys.h>
 
 #include "common.h"
+#include "xb0xb.h"
 
 #define WSREP_XID_PREFIX "WSREPXid"
 #define WSREP_XID_PREFIX_LEN 8
@@ -76,7 +77,6 @@ Check if a given WSREP XID is valid.
 
 @return true if valid.
 */
-static
 bool
 wsrep_is_wsrep_xid(
 /*===============*/

--- a/storage/innobase/xtrabackup/test/t/xb_external_xa_prepared.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_external_xa_prepared.sh
@@ -1,0 +1,42 @@
+############################################################################
+# Test external XA prepare transactions in backup result are not rolled back
+# after --prepare
+############################################################################
+
+. inc/common.sh
+
+vlog "start server with gtid enabled"
+start_server --gtid-mode=ON --enforce-gtid-consistency=ON --log-bin --log-slave-updates
+
+mysql test -e "create table t1(id int, primary key(id)) engine=innodb"
+mysql test -e "xa start 'test1'; insert t1 values (1); xa end 'test1'; xa prepare 'test1'"
+mysql test -e "xa start 'test2'; insert t1 values (2); update t1 set id = 3 where id = 2; xa end 'test2'; xa prepare 'test2'"
+
+mysql test -e "xa recover" | grep "test1"
+mysql test -e "xa recover" | grep "test2"
+
+vlog "Make full backup"
+mkdir $topdir/backup
+xtrabackup --backup --target-dir=$topdir/backup
+
+vlog "Prepare backup"
+xtrabackup --prepare --target-dir=$topdir/backup
+
+vlog "Shutdown server and cleanup data"
+stop_server
+rm -rf $mysql_datadir/*
+
+vlog "Copying files to their original locations"
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+vlog "Start up server"
+start_server --gtid-mode=ON --enforce-gtid-consistency=ON --log-bin --log-slave-updates
+
+vlog "Check external XA preapred transactions still exist"
+mysql test -e "xa recover" | grep "test1"
+mysql test -e "xa recover" | grep "test2"
+
+if ! grep -q "will be kept in prepared state" $OUTFILE
+then
+    die "Not found keep prepared message!"
+fi


### PR DESCRIPTION
…pare

Desctription
============
Starting MySQL 5.7, the new XA_prepare_log_event binlog event type is
introduced to persist XA-prepared transactions into binary log, so that
prepared XA-transaction will survive both a client reconnects or the server
restarts (see WL#6860).

But currently PXB will always rollback prepared transactions, this strategy
is based on 2PC implementation prior to MySQL 5.7, and is not suitable now.

Suppose an external xa transaction record in binlog like bellow, the 1st
column is position:

10 | GTID:1
20 | XA START 'test1'
30 | Update_rows
40 | XA END 'test1'
50 | XA PREPARE 'test1'

---- Backup finished here ----

60 | GTID:2
70 | XA COMMIT 'test1'

And suppose the backup finished after XA PREARE but before XA COMMIT, when
the backup result is prepared, the XA-repared transaction 'test1' is rolled
back.

If we setup the replication from the new instance prepared from backup, to
the source instnace, and start replication from position 60 (the position
recorded in backup result), the replication will broke with error.

Solution
========
From MySQL 5.7, external XA-prepared is designed to survive both client
reconnects or the server restarts, so PXB backup and restore should follow
this design.

When prepare a backup, only rollback the internal XA-prepared transactions,
but keep the external XA-prepared transactions in prepared state.