### PR TITLE
PXB-1649: System tablespace encryption

### DIFF
--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -660,8 +660,14 @@ dberr_t Datafile::validate_first_page(space_id_t space_id, lsn_t *flush_lsn,
   can't be open. And for importing, we skip checking it. */
   if (FSP_FLAGS_GET_ENCRYPTION(m_flags) && !for_import &&
       (srv_backup_mode || !use_dumped_tablespace_keys)) {
-    m_encryption_key = static_cast<byte *>(ut_zalloc_nokey(ENCRYPTION_KEY_LEN));
-    m_encryption_iv = static_cast<byte *>(ut_zalloc_nokey(ENCRYPTION_KEY_LEN));
+    if (m_encryption_key == nullptr) {
+      m_encryption_key =
+          static_cast<byte *>(ut_zalloc_nokey(ENCRYPTION_KEY_LEN));
+    }
+    if (m_encryption_iv == nullptr) {
+      m_encryption_iv =
+          static_cast<byte *>(ut_zalloc_nokey(ENCRYPTION_KEY_LEN));
+    }
 #ifdef UNIV_ENCRYPT_DEBUG
     fprintf(stderr, "Got from file %lu:", m_space_id);
 #endif

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -2037,10 +2037,6 @@ bool write_backup_config_file() {
     << "innodb_undo_log_encrypt=" << (srv_undo_log_encrypt ? "ON" : "OFF")
     << "\n";
 
-  if (innobase_doublewrite_file) {
-    s << "innodb_doublewrite_file=" << innobase_doublewrite_file << "\n";
-  }
-
   if (innobase_buffer_pool_filename) {
     s << "innodb_buffer_pool_filename=" << innobase_buffer_pool_filename
       << "\n";

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -125,9 +125,8 @@ xb_fil_cur_result_t xb_fil_cur_open(
       /* The following call prints an error message */
       os_file_get_last_error(TRUE);
 
-      msg("[%02u] xtrabackup: error: cannot open "
-          "tablespace %s\n",
-          thread_n, cursor->abs_path);
+      msg("[%02u] xtrabackup: error: cannot open tablespace %s\n", thread_n,
+          cursor->abs_path);
 
       return (XB_FIL_CUR_ERROR);
     }

--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -710,10 +710,8 @@ bool xb_tablespace_keys_dump(ds_ctxt_t *ds_ctxt, const char *transition_key,
   }
 
   if (ds_write(stream, transition_key_name, sizeof(transition_key_name))) {
-    msg_ts(
-        "Error writing %s: failed to write "
-        "transition key name.\n",
-        XTRABACKUP_KEYS_FILE);
+    msg_ts("Error writing %s: failed to write transition key name.\n",
+           XTRABACKUP_KEYS_FILE);
     goto error;
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -288,7 +288,6 @@ long innobase_open_files = 300L;
 
 longlong innobase_page_size = (1LL << 14); /* 16KB */
 static ulong innobase_log_block_size = 512;
-char *innobase_doublewrite_file = NULL;
 char *innobase_buffer_pool_filename = NULL;
 char *innobase_directories = NULL;
 
@@ -309,7 +308,6 @@ char *innobase_temp_data_file_path = NULL;
 values */
 
 ulong innobase_fast_shutdown = 1;
-bool innobase_use_doublewrite = TRUE;
 bool innobase_use_checksums = TRUE;
 bool innobase_use_large_pages = FALSE;
 bool innobase_file_per_table = FALSE;
@@ -571,7 +569,6 @@ enum options_xtrabackup {
   OPT_INNODB_DATA_FILE_PATH,
   OPT_INNODB_DATA_HOME_DIR,
   OPT_INNODB_ADAPTIVE_HASH_INDEX,
-  OPT_INNODB_DOUBLEWRITE,
   OPT_INNODB_FAST_SHUTDOWN,
   OPT_INNODB_FILE_PER_TABLE,
   OPT_INNODB_FLUSH_LOG_AT_TRX_COMMIT,
@@ -596,7 +593,6 @@ enum options_xtrabackup {
   OPT_INNODB_PAGE_SIZE,
   OPT_INNODB_LOG_BLOCK_SIZE,
   OPT_INNODB_EXTRA_UNDOSLOTS,
-  OPT_INNODB_DOUBLEWRITE_FILE,
   OPT_INNODB_BUFFER_POOL_FILENAME,
   OPT_INNODB_FORCE_RECOVERY,
   OPT_INNODB_LOCK_WAIT_TIMEOUT,
@@ -1280,11 +1276,6 @@ Disable with --skip-innodb-checksums.",
     {"innodb_data_home_dir", OPT_INNODB_DATA_HOME_DIR,
      "The common part for InnoDB table spaces.", &innobase_data_home_dir,
      &innobase_data_home_dir, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-    {"innodb_doublewrite", OPT_INNODB_DOUBLEWRITE,
-     "Enable InnoDB doublewrite buffer (enabled by default). \
-Disable with --skip-innodb-doublewrite.",
-     (G_PTR *)&innobase_use_doublewrite, (G_PTR *)&innobase_use_doublewrite, 0,
-     GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
     {"innodb_io_capacity", OPT_INNODB_IO_CAPACITY,
      "Number of IOPs the server can do. Tunes the background IO rate",
      (G_PTR *)&srv_io_capacity, (G_PTR *)&srv_io_capacity, 0, GET_ULONG,
@@ -1366,11 +1357,6 @@ Disable with --skip-innodb-doublewrite.",
      (G_PTR *)&innobase_log_block_size, (G_PTR *)&innobase_log_block_size, 0,
      GET_ULONG, REQUIRED_ARG, 512, 512, 1 << UNIV_PAGE_SIZE_SHIFT_MAX, 0, 1L,
      0},
-    {"innodb_doublewrite_file", OPT_INNODB_DOUBLEWRITE_FILE,
-     "Path to special datafile for doublewrite buffer. (default is "
-     ": not used)",
-     (G_PTR *)&innobase_doublewrite_file, (G_PTR *)&innobase_doublewrite_file,
-     0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
     {"innodb_buffer_pool_filename", OPT_INNODB_BUFFER_POOL_FILENAME,
      "Filename to/from which to dump/load the InnoDB buffer pool",
      (G_PTR *)&innobase_buffer_pool_filename,
@@ -1628,11 +1614,6 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
     case OPT_INNODB_LOG_BLOCK_SIZE:
 
       ADD_PRINT_PARAM_OPT(innobase_log_block_size);
-      break;
-
-    case OPT_INNODB_DOUBLEWRITE_FILE:
-
-      ADD_PRINT_PARAM_OPT(innobase_doublewrite_file);
       break;
 
     case OPT_INNODB_UNDO_DIRECTORY:
@@ -1985,7 +1966,7 @@ static bool innodb_init_param(void) {
 
   srv_force_recovery = (ulint)innobase_force_recovery;
 
-  srv_use_doublewrite_buf = (ibool)innobase_use_doublewrite;
+  srv_use_doublewrite_buf = false;
 
   if (!innobase_use_checksums) {
     srv_checksum_algorithm = SRV_CHECKSUM_ALGORITHM_NONE;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -100,7 +100,6 @@ extern bool xtrabackup_move_back;
 extern bool xtrabackup_decrypt_decompress;
 
 extern char *innobase_data_file_path;
-extern char *innobase_doublewrite_file;
 extern char *xtrabackup_encrypt_key;
 extern char *xtrabackup_encrypt_key_file;
 extern longlong innobase_log_file_size;

--- a/storage/innobase/xtrabackup/test/t/argument_handling.sh
+++ b/storage/innobase/xtrabackup/test/t/argument_handling.sh
@@ -12,7 +12,7 @@ xml=1
 
 echo "$my_cnf" >$topdir/my-arg.cnf
 
-run_cmd_expect_failure $XB_BIN --defaults-file=$topdir/my-arg.cnf --innodb_doublewrite=0 --backup --password=foo --some-arg --target-dir=$topdir/backup 2>&1 | tee $topdir/xb.output
+run_cmd_expect_failure $XB_BIN --defaults-file=$topdir/my-arg.cnf --backup --password=foo --some-arg --target-dir=$topdir/backup 2>&1 | tee $topdir/xb.output
 
 grep 'recognized client arguments' $topdir/xb.output > $topdir/client.args
 grep 'recognized server arguments' $topdir/xb.output > $topdir/server.args
@@ -51,9 +51,3 @@ if ! grep "innodb_undo_tablespaces=8" $topdir/server.args ; then
   echo "Can't find the correct innodb_undo_tablespaces in the server arguments"
   exit 1
 fi
-
-if ! grep "innodb_doublewrite=0" $topdir/server.args ; then
-  echo "Can't find the correct innodb_doublewrite in the server arguments"
-  exit 1
-fi
-

--- a/storage/innobase/xtrabackup/test/t/shared_tablespace_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/shared_tablespace_encryption.sh
@@ -1,0 +1,50 @@
+#
+# Basic test for InnoDB shared tablespace encryption (ibdata1)
+#
+
+require_xtradb
+require_server_version_higher_than 8.0.13
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb-sys-tablespace-encrypt
+innodb-encrypt-tables=FORCE
+"
+
+. inc/keyring_file.sh
+
+start_server
+
+mysql -e "CREATE TABLE t (a INT PRIMARY KEY, b TEXT)" test
+mysql -e "INSERT INTO t (a, b) VALUES (1, 'a')" test
+
+# use transition-key
+
+xtrabackup --backup --transition-key=1234 --target-dir=$topdir/backup
+xtrabackup --prepare --transition-key=1234 --target-dir=$topdir/backup
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --transition-key=1234 --generate-new-master-key --target-dir=$topdir/backup
+
+start_server
+
+mysql -e "SELECT * FROM t" test
+
+rm -rf $topdir/backup
+
+# don't use transition-key
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+mysql -e "SELECT * FROM t" test

--- a/storage/innobase/xtrabackup/test/t/system_tablespace_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/system_tablespace_encryption.sh
@@ -1,0 +1,54 @@
+#
+# Basic test for InnoDB system tablespace encryption (mysql.ibd)
+#
+
+require_server_version_higher_than 8.0.15
+
+. inc/keyring_file.sh
+
+start_server
+
+mysql -e "ALTER TABLESPACE mysql ENCRYPTION='y'"
+
+# mysql.ibd contains the data dictionary among others.
+# Lets create some tables to alter the data.
+
+for i in {1..10} ; do
+    mysql -e "CREATE TABLE t$i (a INT PRIMARY KEY, b TEXT)" test
+done
+
+# use transition key
+
+xtrabackup --backup --transition-key=1234 --target-dir=$topdir/backup
+xtrabackup --prepare --transition-key=1234 --target-dir=$topdir/backup
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --transition-key=1234 --generate-new-master-key --target-dir=$topdir/backup
+
+start_server
+
+for i in {1..10} ; do
+    mysql -e "SELECT * FROM t$i" test
+done
+
+rm -rf $topdir/backup
+
+# don't use transition-key
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+for i in {1..10} ; do
+    mysql -e "SELECT * FROM t$i" test
+done


### PR DESCRIPTION
- added tests for innodb system (mysql.ibd) and shared system (ibdata1)
  tablespace encryption
- removed assertions that system shared tablespace cannot be encrypted
- disabled use of doublewrite buffer on prepare
- added the code to read encryption information from the system shared
  tablespace at startup (both for backup and prepare)