### PR TITLE
PXB-1870: xtrabackup prepare get stuck if ib_sdi_get return

### DIFF
--- a/storage/innobase/api/api0api.cc
+++ b/storage/innobase/api/api0api.cc
@@ -3071,7 +3071,7 @@ dberr_t ib_sdi_get(uint32_t tablespace_id, const ib_sdi_key_t *ib_sdi_key,
 
       /* If the passed memory is not sufficient, we
       return failure and the actual length of SDI. */
-      if (buf_len < *uncomp_sdi_len) {
+      if (buf_len < *comp_sdi_len) {
         ib_tuple_delete(tuple);
         ib_tuple_delete(key_tpl);
         ib_cursor_close(ib_crsr);

--- a/storage/innobase/xtrabackup/test/t/pxb-1870.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1870.sh
@@ -1,0 +1,27 @@
+#
+# PXB-1870: xtrabackup prepare get stuck if ib_sdi_get return DB_OUT_OF_MEMORY
+#
+
+start_server
+
+mysql test <<EOF
+CREATE TABLE user (
+  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  cid int(11) NOT NULL DEFAULT '0',
+  uid int(11) NOT NULL DEFAULT '0',
+  gold int(11) NOT NULL DEFAULT '0',
+  coin int(11) NOT NULL DEFAULT '0',
+  price int(11) NOT NULL DEFAULT '0',
+  time datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  type int(11) NOT NULL DEFAULT '0',
+  chapterid int(11) NOT NULL DEFAULT '0',
+  platformid int(11) NOT NULL,
+  productlineid int(11) NOT NULL,
+  PRIMARY KEY (id,uid)
+) ENGINE=InnoDB
+PARTITION BY HASH (uid) 
+PARTITIONS 3000;
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup


### PR DESCRIPTION
DB_OUT_OF_MEMORY

When DB_OUT_OF_MEMORY returned, is trying to allocate new buffer of size
"uncompressed_sdi_len", but due to MySQL bug 95606, ib_sdi_get rejected
this buffer putting the caller into infinite loop.

Fix is to fix ib_sdi_get and change the caller to manage compressed and
uncompressed buffers independently.