### PR TITLE
PXB-1874: xbcloud doesn't update Date header when retrying

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -429,7 +429,7 @@ bool retriable_curl_error(CURLcode rc) {
 }
 
 bool retriable_http_error(long code) {
-  if (code == 503 || code == 500 || code == 504) {
+  if (code == 503 || code == 500 || code == 504 || code == 408) {
     return true;
   }
   return false;

--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -158,6 +158,7 @@ class Http_request {
   void add_header(const std::string &name, const std::string &value) {
     headers_[name] = value;
   }
+  void remove_header(const std::string &name) { headers_.erase(name); }
   void add_param(const std::string &name, const std::string &value);
   void add_param(const std::string &name) { params_.push_back(name); }
   template <typename T>

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -147,6 +147,14 @@ class S3_client {
     }
   }
 
+  static void upload_callback(S3_client *client, std::string bucket,
+                              std::string name, Http_request *req,
+                              Http_response *resp,
+                              const Http_client *http_client, Event_handler *h,
+                              S3_client::async_upload_callback_t callback,
+                              CURLcode rc, const Http_connection *conn,
+                              int count);
+
  public:
   S3_client(const Http_client *client, const std::string &region,
             const std::string &access_key, const std::string &secret_key)

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3488,13 +3488,13 @@ xtrabackup_init_datasinks(void)
 
 		/* Use a 1 MB buffer for compressed output stream */
 		ds = ds_create(xtrabackup_target_dir, DS_TYPE_BUFFER);
-		ds_buffer_set_size(ds, 1024 * 1024);
+		ds_buffer_set_size(ds, opt_read_buffer_size);
 		xtrabackup_add_datasink(ds);
 		ds_set_pipe(ds, ds_data);
 		if (ds_data != ds_redo) {
 			ds_data = ds;
 			ds = ds_create(xtrabackup_target_dir, DS_TYPE_BUFFER);
-			ds_buffer_set_size(ds, 1024 * 1024);
+			ds_buffer_set_size(ds, opt_read_buffer_size);
 			xtrabackup_add_datasink(ds);
 			ds_set_pipe(ds, ds_redo);
 			ds_redo = ds;


### PR DESCRIPTION
PXB-1875: xbcloud doesn't handle Google's HTTP 408 error correctly

Patch does following:

- recalculate AWS signature when retry
- don't try to S3 parse response as XML unless content type is
  application/xml
- set buffer size equal to read_buffer_size for buffered datasink
- retry http error 408