### PR TITLE
PXB-1879: xtrabackup does not take FS block size into account for

### DIFF
--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -65,6 +65,7 @@ struct xb_fil_cur_t {
 	uint		thread_n;	/*!< thread number for diagnostics */
 	ulint		space_id;	/*!< ID of tablespace */
 	ulint		space_size;	/*!< space size in pages */
+	ulint		block_size;	/*!< FS block size */
 
 	unsigned char	encryption_key[32];
 					/*!< encryption key */

--- a/storage/innobase/xtrabackup/test/t/pxb-1879.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1879.sh
@@ -1,0 +1,18 @@
+#
+# PXB-1879: xtrabackup does not take FS block size into account for compressed and encrypted tables
+#
+
+require_server_version_higher_than 5.7.10
+
+. inc/keyring_file.sh
+
+start_server
+
+load_sakila
+
+mysql -e "ALTER TABLE payment ENCRYPTION='y' COMPRESSION='lz4'" sakila
+
+innodb_wait_for_flush_all
+
+# this will crash with bug present
+xtrabackup --backup --target-dir=$topdir/backup --xtrabackup-plugin-dir=$plugin_dir


### PR DESCRIPTION
compressed and encrypted tables

Fix is to save block_size into file cursor and use it when
decompressing/decryting pages.