### PR TITLE
PXB-1884: Xbstream does not decompress lz4 when decryption is also be…

### DIFF
--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -566,7 +566,8 @@ static int mode_extract(int n_threads, int argc __attribute__((unused)),
     if (ds_decompress_quicklz_ctxt) {
       ds_decrypt_quicklz_ctxt = ds_create(".", DS_TYPE_DECRYPT);
       ds_set_pipe(ds_decrypt_quicklz_ctxt, ds_decompress_quicklz_ctxt);
-    } else {
+    }
+    if (ds_decompress_lz4_ctxt) {
       ds_decrypt_lz4_ctxt = ds_create(".", DS_TYPE_DECRYPT);
       ds_set_pipe(ds_decrypt_lz4_ctxt, ds_decompress_lz4_ctxt);
     }

--- a/storage/innobase/xtrabackup/test/t/xbstream_parallel_decrypt_decompress_lz4.sh
+++ b/storage/innobase/xtrabackup/test/t/xbstream_parallel_decrypt_decompress_lz4.sh
@@ -1,0 +1,12 @@
+#################################################################################################
+# Test streaming + parallel + compression + encryption + decryption + decompression with xbstream
+#################################################################################################
+
+
+encrypt_algo="AES256"
+encrypt_key="percona_xtrabackup_is_awesome___"
+stream_format=xbstream
+stream_extract_cmd="(xbstream -xv --parallel=16 --decompress --decompress-threads=4 --decrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4) <"
+xtrabackup_options="--parallel=16 --compress=lz4 --compress-threads=4 --encrypt=$encrypt_algo --encrypt-key=$encrypt_key --encrypt-threads=4 --encrypt-chunk-size=8K"
+
+. inc/xb_stream_common.sh


### PR DESCRIPTION
…ing done

xbstream did not decompress .lz4.xbstream files.

Fix is to initialize lz4 decompression datasink at startup, it was not
initialized by mistake.

Patch also renames *compress* typedefs to *compress_lz4* to avoid
linker conflicts.