### PR TITLE
PXB-1557: xbstream creates non-sparse ibd files and breaks

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -97,15 +97,6 @@ static std::mutex rsync_mutex;
 /* skip these files on copy-back */
 static std::set<std::string> skip_copy_back_list;
 
-/* the purpose of file copied */
-enum file_purpose_t {
-  FILE_PURPOSE_DATAFILE,
-  FILE_PURPOSE_REDO_LOG,
-  FILE_PURPOSE_UNDO_LOG,
-  FILE_PURPOSE_BINLOG,
-  FILE_PURPOSE_OTHER
-};
-
 class datadir_queue {
   std::queue<datadir_entry_t> queue;
   mysql_mutex_t mutex;
@@ -209,9 +200,7 @@ static bool datafile_open(const char *file, datafile_cur_t *cursor,
     /* The following call prints an error message */
     os_file_get_last_error(TRUE);
 
-    msg("[%02u] error: cannot open "
-        "file %s\n",
-        thread_n, cursor->abs_path);
+    msg("[%02u] error: cannot open file %s\n", thread_n, cursor->abs_path);
 
     return (false);
   }
@@ -460,7 +449,7 @@ static bool datafile_copy_backup(const char *filepath, uint thread_n) {
   }
 
   if (filename_matches(filepath, ext_list)) {
-    return copy_file(ds_data, filepath, filepath, thread_n);
+    return copy_file(ds_data, filepath, filepath, thread_n, FILE_PURPOSE_OTHER);
   }
 
   return (true);
@@ -631,15 +620,69 @@ static bool run_data_threads(const char *dir, F func, uint n,
 }
 
 /************************************************************************
+Write buffer into .ibd file and preserve it's sparsiness. */
+bool write_ibd_buffer(ds_file_t *file, unsigned char *buf, size_t buf_len,
+                      size_t page_size, size_t block_size) {
+  ut_a(buf_len % page_size == 0);
+
+  if (ds_is_sparse_write_supported(file) && page_size > block_size) {
+    std::vector<ds_sparse_chunk_t> sparse_map;
+    size_t skip = 0, len = 0;
+    for (ulint i = 0, page_offs = 0; i < buf_len / page_size;
+         ++i, page_offs += page_size) {
+      const auto page = buf + page_offs;
+
+      if (Compression::is_compressed_page(page) ||
+          fil_page_get_type(page) == FIL_PAGE_COMPRESSED_AND_ENCRYPTED) {
+        ut_ad(page_size % block_size == 0);
+        size_t compressed_len =
+            mach_read_from_2(page + FIL_PAGE_COMPRESS_SIZE_V1) + FIL_PAGE_DATA;
+        if (fil_page_get_type(page) == FIL_PAGE_COMPRESSED_AND_ENCRYPTED) {
+          compressed_len = ut_calc_align(compressed_len, block_size);
+        }
+        sparse_map.push_back(ds_sparse_chunk_t{skip, len + compressed_len});
+        skip = page_size - compressed_len;
+        len = 0;
+      } else {
+        len += page_size;
+      }
+    }
+    sparse_map.push_back(ds_sparse_chunk_t{skip, len});
+
+    if (sparse_map.size() > 1) {
+      size_t src_pos = 0, dst_pos = 0;
+      for (size_t i = 0; i < sparse_map.size(); ++i) {
+        src_pos += sparse_map[i].skip;
+        memmove(buf + dst_pos, buf + src_pos, sparse_map[i].len);
+        src_pos += sparse_map[i].len;
+        dst_pos += sparse_map[i].len;
+      }
+      if (ds_write_sparse(file, buf, dst_pos, sparse_map.size(),
+                          &sparse_map[0])) {
+        return (false);
+      }
+      return (true);
+    }
+  }
+
+  if (ds_write(file, buf, buf_len)) {
+    return (false);
+  }
+  return (true);
+}
+
+/************************************************************************
 Copy file for backup/restore.
 @return true in case of success. */
 bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
-               const char *dst_file_path, uint thread_n, ssize_t pos) {
+               const char *dst_file_path, uint thread_n,
+               file_purpose_t file_purpose, ssize_t pos) {
   char dst_name[FN_REFLEN];
   ds_file_t *dstfile = NULL;
   datafile_cur_t cursor;
   xb_fil_cur_result_t res;
   const char *action;
+  page_size_t page_size{0, 0, false};
 
   if (!datafile_open(src_file_path, &cursor, thread_n)) {
     goto error;
@@ -674,8 +717,14 @@ bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
 
   /* The main copy loop */
   while ((res = datafile_read(&cursor)) == XB_FIL_CUR_SUCCESS) {
-    if (ds_write(dstfile, cursor.buf, cursor.buf_read)) {
-      goto error;
+    if (file_purpose == FILE_PURPOSE_DATAFILE) {
+      if (cursor.buf_offset == cursor.buf_read)
+        page_size.copy_from(fsp_header_get_page_size(cursor.buf));
+      if (!write_ibd_buffer(dstfile, cursor.buf, cursor.buf_read,
+                            page_size.physical(), cursor.statinfo.st_blksize))
+        goto error;
+    } else {
+      if (ds_write(dstfile, cursor.buf, cursor.buf_read)) goto error;
     }
   }
 
@@ -708,7 +757,7 @@ different devices fall back to copy and unlink.
 @return true in case of success. */
 static bool move_file(ds_ctxt_t *datasink, const char *src_file_path,
                       const char *dst_file_path, const char *dst_dir,
-                      uint thread_n) {
+                      uint thread_n, file_purpose_t file_purpose) {
   char errbuf[MYSYS_STRERROR_SIZE];
   char dst_file_path_abs[FN_REFLEN];
   char dst_dir_abs[FN_REFLEN];
@@ -736,7 +785,8 @@ static bool move_file(ds_ctxt_t *datasink, const char *src_file_path,
   if (my_rename(src_file_path, dst_file_path_abs, MYF(0)) != 0) {
     if (my_errno() == EXDEV) {
       bool ret;
-      ret = copy_file(datasink, src_file_path, dst_file_path, thread_n);
+      ret = copy_file(datasink, src_file_path, dst_file_path, thread_n,
+                      file_purpose);
       msg_ts("[%02u] Removing %s\n", thread_n, src_file_path);
       if (unlink(src_file_path) != 0) {
         msg("Error: unlink %s failed: %s\n", src_file_path,
@@ -874,7 +924,6 @@ static bool copy_or_move_file(const char *src_file_path,
   char external_dir[FN_REFLEN];
 
   if (Fil_path::type_of_path(dst_file_path) == Fil_path::absolute) {
-
     /* Make sure that destination directory exists */
     size_t dirname_length;
 
@@ -890,10 +939,11 @@ static bool copy_or_move_file(const char *src_file_path,
     dst_dir = external_dir;
   }
 
-  ret = (xtrabackup_copy_back
-             ? copy_file(datasink, src_file_path, dst_file_path, thread_n)
-             : move_file(datasink, src_file_path, dst_file_path, dst_dir,
-                         thread_n));
+  ret =
+      (xtrabackup_copy_back ? copy_file(datasink, src_file_path, dst_file_path,
+                                        thread_n, file_purpose)
+                            : move_file(datasink, src_file_path, dst_file_path,
+                                        dst_dir, thread_n, file_purpose));
 
   if (opt_generate_new_master_key && (file_purpose == FILE_PURPOSE_DATAFILE ||
                                       file_purpose == FILE_PURPOSE_UNDO_LOG)) {
@@ -1214,7 +1264,7 @@ static void par_copy_rocksdb_files(const Myrocks_datadir::const_iterator &start,
       continue;
     }
     if (!copy_file(ds, it->path.c_str(), it->rel_path.c_str(), thread_n,
-                   it->file_size)) {
+                   FILE_PURPOSE_OTHER, it->file_size)) {
       *result = false;
     }
     if (!*result) {
@@ -1228,7 +1278,7 @@ static void backup_rocksdb_files(const Myrocks_datadir::const_iterator &start,
                                  size_t thread_n, bool *result) {
   for (auto it = start; it != end; it++) {
     if (!copy_file(ds_uncompressed_data, it->path.c_str(), it->rel_path.c_str(),
-                   thread_n, it->file_size)) {
+                   thread_n, FILE_PURPOSE_OTHER, it->file_size)) {
       *result = false;
     }
     if (!*result) {
@@ -1381,10 +1431,10 @@ bool backup_finish(Backup_context &context) {
       const char *dst_name;
 
       dst_name = trim_dotslash(buffer_pool_filename);
-      copy_file(ds_data, buffer_pool_filename, dst_name, 0);
+      copy_file(ds_data, buffer_pool_filename, dst_name, 0, FILE_PURPOSE_OTHER);
     }
     if (file_exists("ib_lru_dump")) {
-      copy_file(ds_data, "ib_lru_dump", "ib_lru_dump", 0);
+      copy_file(ds_data, "ib_lru_dump", "ib_lru_dump", 0, FILE_PURPOSE_OTHER);
     }
   }
 
@@ -1423,7 +1473,8 @@ bool copy_if_ext_matches(const char **ext_list, const datadir_entry_t &entry,
     unlink(entry.rel_path.c_str());
   }
 
-  if (!copy_file(ds_data, entry.path.c_str(), entry.rel_path.c_str(), 1)) {
+  if (!copy_file(ds_data, entry.path.c_str(), entry.rel_path.c_str(), 1,
+                 FILE_PURPOSE_OTHER)) {
     msg("Failed to copy file %s\n", entry.path.c_str());
     return false;
   }
@@ -1605,7 +1656,8 @@ bool copy_incremental_over_full() {
                src_name);
 
       if (file_exists(path)) {
-        ret = copy_file(ds_data, path, innobase_buffer_pool_filename, 0);
+        ret = copy_file(ds_data, path, innobase_buffer_pool_filename, 0,
+                        FILE_PURPOSE_OTHER);
       }
     }
 
@@ -1623,7 +1675,7 @@ bool copy_incremental_over_full() {
         if (file_exists(sup_files[i])) {
           unlink(sup_files[i]);
         }
-        ret = copy_file(ds_data, path, sup_files[i], 0);
+        ret = copy_file(ds_data, path, sup_files[i], 0, FILE_PURPOSE_OTHER);
         if (!ret) {
           goto cleanup;
         }
@@ -1652,7 +1704,8 @@ bool copy_incremental_over_full() {
       for (auto file : binlog.files()) {
         fn_format(fullpath, file.c_str(), xtrabackup_incremental_dir, "",
                   MYF(MY_RELATIVE_PATH));
-        ret = copy_file(ds_data, fullpath, file.c_str(), 0);
+        ret =
+            copy_file(ds_data, fullpath, file.c_str(), 0, FILE_PURPOSE_BINLOG);
         if (!ret) {
           goto cleanup;
         }
@@ -1710,8 +1763,8 @@ cleanup:
   return (ret);
 }
 
-/* Removes empty directories and files in database subdirectories if those files
-match given list of file extensions.
+/* Removes empty directories and files in database subdirectories if those
+files match given list of file extensions.
 @param[in]	ext_list	list of extensions to match against
 @param[in]	entry		datadir entry
 @param[in]	arg		unused
@@ -1856,16 +1909,18 @@ static void copy_back_thread_func(datadir_thread_ctxt_t *ctx) {
     }
 
     file_purpose_t file_purpose;
-    if (Fil_path::has_suffix(IBD, entry.path) ||
-        Fil_path::has_suffix(IBU, entry.path)) {
+    if (Fil_path::has_suffix(IBD, entry.path)) {
       file_purpose = FILE_PURPOSE_DATAFILE;
+    } else if (Fil_path::has_suffix(IBU, entry.path)) {
+      file_purpose = FILE_PURPOSE_UNDO_LOG;
     } else {
       file_purpose = FILE_PURPOSE_OTHER;
     }
 
     std::string dst_path = entry.rel_path;
 
-    if (file_purpose == FILE_PURPOSE_DATAFILE) {
+    if (file_purpose == FILE_PURPOSE_DATAFILE ||
+        file_purpose == FILE_PURPOSE_UNDO_LOG) {
       std::string tablespace_name = entry.path;
       /* Remove starting ./ and trailing .ibd/.ibu from tablespace name */
       tablespace_name = tablespace_name.substr(2, tablespace_name.length() - 6);
@@ -2132,7 +2187,8 @@ bool copy_back(int argc, char **argv) {
       }
       ret = xb_binlog_password_reencrypt(target.path.c_str());
       if (!ret) {
-        msg("xtrabackup: Error: failed to reencrypt binary log file header.\n");
+        msg("xtrabackup: Error: failed to reencrypt binary log file "
+            "header.\n");
       }
       /* make sure we don't copy binary log and .index files twice */
       skip_copy_back_list.insert(binlog.name.c_str());

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -22,11 +22,26 @@ bool backup_file_printf(const char *filename, const char *fmt, ...)
 Return true if first and second arguments are the same path. */
 bool equal_paths(const char *first, const char *second);
 
+/* the purpose of file copied */
+enum file_purpose_t {
+  FILE_PURPOSE_DATAFILE,
+  FILE_PURPOSE_REDO_LOG,
+  FILE_PURPOSE_UNDO_LOG,
+  FILE_PURPOSE_BINLOG,
+  FILE_PURPOSE_OTHER
+};
+
+/************************************************************************
+Write buffer into .ibd file and preserve it's sparsiness. */
+bool write_ibd_buffer(ds_file_t *file, unsigned char *buf, size_t buf_len,
+                      size_t page_size, size_t block_size);
+
 /************************************************************************
 Copy file for backup/restore.
 @return true in case of success. */
 bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
-               const char *dst_file_path, uint thread_n, ssize_t pos = -1);
+               const char *dst_file_path, uint thread_n,
+               file_purpose_t file_purpose, ssize_t pos = -1);
 
 /* Backup non-InnoDB data.
 @return true if success. */

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1511,9 +1511,9 @@ bool write_current_binlog_file(MYSQL *connection) {
 
   snprintf(filepath, sizeof(filepath), "%s%c%s", log_bin_dir, FN_LIBCHAR,
            log_status.filename.c_str());
-  result =
-      copy_file(ds_data, filepath, log_status.filename.c_str(), 0,
-                log_status.position + binlog_encryption_header_size(filepath));
+  result = copy_file(
+      ds_data, filepath, log_status.filename.c_str(), 0, FILE_PURPOSE_BINLOG,
+      log_status.position + binlog_encryption_header_size(filepath));
   if (!result) {
     goto cleanup;
   }

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -111,6 +111,29 @@ int ds_write(ds_file_t *file, const void *buf, size_t len) {
 }
 
 /************************************************************************
+Check if sparse files are supported.
+@return 1 if yes. */
+int ds_is_sparse_write_supported(ds_file_t *file) {
+  if (file->datasink->write_sparse != nullptr) {
+    return 1;
+  }
+  return 0;
+}
+
+/************************************************************************
+Write sparse chunk if supported.
+@return 0 on success, 1 on error. */
+int ds_write_sparse(ds_file_t *file, const void *buf, size_t len,
+                    size_t sparse_map_size,
+                    const ds_sparse_chunk_t *sparse_map) {
+  if (file->datasink->write_sparse != nullptr) {
+    return file->datasink->write_sparse(file, buf, len, sparse_map_size,
+                                        sparse_map);
+  }
+  return 1;
+}
+
+/************************************************************************
 Close a datasink file.
 @return 0 on success, 1, on error. */
 int ds_close(ds_file_t *file) { return file->datasink->close(file); }

--- a/storage/innobase/xtrabackup/src/datasink.h
+++ b/storage/innobase/xtrabackup/src/datasink.h
@@ -43,10 +43,18 @@ typedef struct {
   datasink_t *datasink;
 } ds_file_t;
 
+typedef struct {
+  size_t skip;
+  size_t len;
+} ds_sparse_chunk_t;
+
 struct datasink_struct {
   ds_ctxt_t *(*init)(const char *root);
   ds_file_t *(*open)(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat);
   int (*write)(ds_file_t *file, const void *buf, size_t len);
+  int (*write_sparse)(ds_file_t *file, const void *buf, size_t len,
+                      size_t sparse_map_size,
+                      const ds_sparse_chunk_t *sparse_map);
   int (*close)(ds_file_t *file);
   void (*deinit)(ds_ctxt_t *ctxt);
 };
@@ -78,6 +86,18 @@ ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat);
 Write to a datasink file.
 @return 0 on success, 1 on error. */
 int ds_write(ds_file_t *file, const void *buf, size_t len);
+
+/************************************************************************
+Check if sparse files are supported.
+@return 1 if yes. */
+int ds_is_sparse_write_supported(ds_file_t *file);
+
+/************************************************************************
+Write sparse chunk if supported.
+@return 0 on success, 1 on error. */
+int ds_write_sparse(ds_file_t *file, const void *buf, size_t len,
+                    size_t sparse_map_size,
+                    const ds_sparse_chunk_t *sparse_map);
 
 /************************************************************************
 Close a datasink file.

--- a/storage/innobase/xtrabackup/src/ds_buffer.cc
+++ b/storage/innobase/xtrabackup/src/ds_buffer.cc
@@ -50,8 +50,8 @@ static int buffer_write(ds_file_t *file, const void *buf, size_t len);
 static int buffer_close(ds_file_t *file);
 static void buffer_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_buffer = {&buffer_init, &buffer_open, &buffer_write,
-                              &buffer_close, &buffer_deinit};
+datasink_t datasink_buffer = {&buffer_init, &buffer_open,  &buffer_write,
+                              nullptr,      &buffer_close, &buffer_deinit};
 
 /* Change the default buffer size */
 void ds_buffer_set_size(ds_ctxt_t *ctxt, size_t size) {

--- a/storage/innobase/xtrabackup/src/ds_compress.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress.cc
@@ -68,7 +68,8 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len);
 static int compress_close(ds_file_t *file);
 static void compress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_compress = {&compress_init, &compress_open, &compress_write,
+datasink_t datasink_compress = {&compress_init,  &compress_open,
+                                &compress_write, nullptr,
                                 &compress_close, &compress_deinit};
 
 static inline int write_uint32_le(ds_file_t *file, uint32_t n);

--- a/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
@@ -68,9 +68,9 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len);
 static int compress_close(ds_file_t *file);
 static void compress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_compress_lz4 = {&compress_init, &compress_open,
-                                    &compress_write, &compress_close,
-                                    &compress_deinit};
+datasink_t datasink_compress_lz4 = {&compress_init,  &compress_open,
+                                    &compress_write, nullptr,
+                                    &compress_close, &compress_deinit};
 
 static inline int write_uint32_le(ds_file_t *file, uint32_t n);
 

--- a/storage/innobase/xtrabackup/src/ds_decompress.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress.cc
@@ -83,9 +83,9 @@ static int decompress_write(ds_file_t *file, const void *buf, size_t len);
 static int decompress_close(ds_file_t *file);
 static void decompress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decompress = {&decompress_init, &decompress_open,
-                                  &decompress_write, &decompress_close,
-                                  &decompress_deinit};
+datasink_t datasink_decompress = {&decompress_init,  &decompress_open,
+                                  &decompress_write, nullptr,
+                                  &decompress_close, &decompress_deinit};
 
 static int decompress_process_metadata(ds_decompress_file_t *file,
                                        const char **ptr, size_t *len);

--- a/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
@@ -288,9 +288,9 @@ static int decompress_write(ds_file_t *file, const void *buf, size_t len);
 static int decompress_close(ds_file_t *file);
 static void decompress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decompress_lz4 = {&decompress_init, &decompress_open,
-                                      &decompress_write, &decompress_close,
-                                      &decompress_deinit};
+datasink_t datasink_decompress_lz4 = {&decompress_init,  &decompress_open,
+                                      &decompress_write, nullptr,
+                                      &decompress_close, &decompress_deinit};
 
 static ds_ctxt_t *decompress_init(const char *root) {
   ds_decompress_lz4_ctxt_t *decompress_ctxt = new ds_decompress_lz4_ctxt_t;

--- a/storage/innobase/xtrabackup/src/ds_decrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_decrypt.cc
@@ -120,8 +120,8 @@ static int decrypt_write(ds_file_t *file, const void *buf, size_t len);
 static int decrypt_close(ds_file_t *file);
 static void decrypt_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decrypt = {&decrypt_init, &decrypt_open, &decrypt_write,
-                               &decrypt_close, &decrypt_deinit};
+datasink_t datasink_decrypt = {&decrypt_init, &decrypt_open,  &decrypt_write,
+                               nullptr,       &decrypt_close, &decrypt_deinit};
 
 static ds_ctxt_t *decrypt_init(const char *root) {
   if (xb_crypt_init(NULL)) {

--- a/storage/innobase/xtrabackup/src/ds_stdout.cc
+++ b/storage/innobase/xtrabackup/src/ds_stdout.cc
@@ -35,8 +35,8 @@ static int stdout_write(ds_file_t *file, const void *buf, size_t len);
 static int stdout_close(ds_file_t *file);
 static void stdout_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_stdout = {&stdout_init, &stdout_open, &stdout_write,
-                              &stdout_close, &stdout_deinit};
+datasink_t datasink_stdout = {&stdout_init, &stdout_open,  &stdout_write,
+                              nullptr,      &stdout_close, &stdout_deinit};
 
 static ds_ctxt_t *stdout_init(const char *root) {
   ds_ctxt_t *ctxt;

--- a/storage/innobase/xtrabackup/src/ds_tmpfile.cc
+++ b/storage/innobase/xtrabackup/src/ds_tmpfile.cc
@@ -50,8 +50,8 @@ static int tmpfile_write(ds_file_t *file, const void *buf, size_t len);
 static int tmpfile_close(ds_file_t *file);
 static void tmpfile_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_tmpfile = {&tmpfile_init, &tmpfile_open, &tmpfile_write,
-                               &tmpfile_close, &tmpfile_deinit};
+datasink_t datasink_tmpfile = {&tmpfile_init, &tmpfile_open,  &tmpfile_write,
+                               nullptr,       &tmpfile_close, &tmpfile_deinit};
 
 extern MY_TMPDIR mysql_tmpdir_list;
 

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -35,8 +35,43 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "read_filt.h"
 #include "xtrabackup.h"
 
-/* Size of read buffer in pages (640 pages = 10M for 16K sized pages) */
-#define XB_FIL_CUR_PAGES 640
+/***********************************************************************
+Reads the space flags from a given data file and returns the
+page size and whether the file is compressable. */
+static bool xb_get_zip_size(pfs_os_file_t file, byte *buf,
+                            page_size_t &page_size, bool &is_compressable) {
+  IORequest read_request(IORequest::READ | IORequest::NO_COMPRESSION);
+  const auto ret = os_file_read(read_request, file, buf, 0, UNIV_PAGE_SIZE_MIN);
+  if (!ret) {
+    return (false);
+  }
+
+  space_id_t space = mach_read_from_4(buf + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
+  const auto flags = fsp_header_get_flags(buf);
+
+  if (space == 0) {
+    page_size.copy_from(univ_page_size);
+  } else {
+    page_size.copy_from(page_size_t(flags));
+  }
+
+  if (page_size.is_compressed() || FSP_FLAGS_GET_ENCRYPTION(flags)) {
+    is_compressable = false;
+  } else {
+    const auto ret =
+        os_file_read(read_request, file, buf, 0, page_size.physical() * 2);
+    if (!ret) {
+      return (false);
+    }
+    if (Compression::is_compressed_page(buf + page_size.physical())) {
+      is_compressable = false;
+    } else {
+      is_compressable = true;
+    }
+  }
+
+  return (true);
+}
 
 /***********************************************************************
 Extracts the relative path ("database/table.ibd") of a tablespace from a
@@ -155,9 +190,16 @@ xb_fil_cur_result_t xb_fil_cur_open(
 
   posix_fadvise(cursor->file.m_file, 0, 0, POSIX_FADV_SEQUENTIAL);
 
+  /* Allocate read buffer */
+  ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
+  cursor->buf_size = opt_read_buffer_size;
+  cursor->orig_buf =
+      static_cast<byte *>(ut_malloc_nokey(cursor->buf_size + UNIV_PAGE_SIZE));
+  cursor->buf = static_cast<byte *>(ut_align(cursor->orig_buf, UNIV_PAGE_SIZE));
+
   /* Determine the page size */
-  page_size.copy_from(xb_get_zip_size(cursor->file, &success));
-  if (!success) {
+  if (!xb_get_zip_size(cursor->file, cursor->buf, page_size,
+                       cursor->is_compressable)) {
     xb_fil_cur_close(cursor);
     return (XB_FIL_CUR_SKIP);
   } else if (page_size.is_compressed()) {
@@ -178,13 +220,6 @@ xb_fil_cur_result_t xb_fil_cur_open(
   cursor->page_size_shift = page_size_shift;
   cursor->zip_size = page_size.is_compressed() ? page_size.physical() : 0;
 
-  ut_a(opt_read_buffer_size >= UNIV_PAGE_SIZE);
-  /* Allocate read buffer */
-  cursor->buf_size = opt_read_buffer_size;
-  cursor->orig_buf =
-      static_cast<byte *>(ut_malloc_nokey(cursor->buf_size + UNIV_PAGE_SIZE));
-  cursor->buf = static_cast<byte *>(ut_align(cursor->orig_buf, UNIV_PAGE_SIZE));
-
   cursor->buf_read = 0;
   cursor->buf_npages = 0;
   cursor->buf_offset = 0;
@@ -192,6 +227,7 @@ xb_fil_cur_result_t xb_fil_cur_open(
   cursor->thread_n = thread_n;
 
   cursor->space_size = cursor->statinfo.st_size / page_size.physical();
+  cursor->block_size = node->block_size;
 
   cursor->read_filter = read_filter;
   cursor->read_filter->init(&cursor->read_filter_ctxt, cursor, node->space->id);
@@ -257,11 +293,9 @@ xb_fil_cur_result_t xb_fil_cur_read(
   if (to_read % cursor->page_size != 0 &&
       offset + to_read == (ib_uint64_t)cursor->statinfo.st_size) {
     if (to_read < (ib_uint64_t)cursor->page_size) {
-      msg("[%02u] xtrabackup: Warning: junk at the end of "
-          "%s:\n",
+      msg("[%02u] xtrabackup: Warning: junk at the end of %s:\n",
           cursor->thread_n, cursor->abs_path);
-      msg("[%02u] xtrabackup: Warning: offset = %llu, "
-          "to_read = %llu\n",
+      msg("[%02u] xtrabackup: Warning: offset = %llu, to_read = %llu\n",
           cursor->thread_n, (unsigned long long)offset,
           (unsigned long long)to_read);
 
@@ -316,13 +350,14 @@ read_retry:
   for (page = cursor->buf, i = 0; i < npages; page += cursor->page_size, i++) {
     page_to_check = page;
     if (Encryption::is_encrypted_page(page)) {
-      dberr_t ret;
       Encryption encryption(read_request.encryption_algorithm());
 
       page_to_check = cursor->decrypt;
       memcpy(cursor->decrypt, page, cursor->page_size);
-      ret = encryption.decrypt(read_request, cursor->decrypt, cursor->page_size,
-                               cursor->scratch, cursor->page_size);
+
+      const auto ret =
+          encryption.decrypt(read_request, cursor->decrypt, cursor->page_size,
+                             cursor->scratch, cursor->page_size);
       if (ret != DB_SUCCESS) {
         goto corruption;
       }
@@ -353,24 +388,20 @@ read_retry:
           page_no < FSP_EXTENT_SIZE * 3) {
         /* skip doublewrite buffer pages */
         xb_a(cursor->page_size == UNIV_PAGE_SIZE);
-        msg("[%02u] xtrabackup: "
-            "Page %lu is a doublewrite buffer page, "
+        msg("[%02u] xtrabackup: Page %lu is a doublewrite buffer page, "
             "skipping.\n",
             cursor->thread_n, page_no);
       } else {
         retry_count--;
         if (retry_count == 0) {
-          msg("[%02u] xtrabackup: "
-              "Error: failed to read page after "
-              "10 retries. File %s seems to be "
-              "corrupted.\n",
+          msg("[%02u] xtrabackup: Error: failed to read page after 10 retries. "
+              "File %s seems to be corrupted.\n",
               cursor->thread_n, cursor->abs_path);
           ret = XB_FIL_CUR_ERROR;
           break;
         }
-        msg("[%02u] xtrabackup: "
-            "Database page corruption detected at page "
-            "%lu, retrying...\n",
+        msg("[%02u] xtrabackup: Database page corruption detected at page %lu, "
+            "retrying...\n",
             cursor->thread_n, page_no);
 
         os_thread_sleep(100000);
@@ -398,15 +429,9 @@ void xb_fil_cur_close(
 {
   cursor->read_filter->deinit(&cursor->read_filter_ctxt);
 
-  if (cursor->scratch != NULL) {
-    ut_free(cursor->scratch);
-  }
-  if (cursor->decrypt != NULL) {
-    ut_free(cursor->decrypt);
-  }
-  if (cursor->orig_buf != NULL) {
-    ut_free(cursor->orig_buf);
-  }
+  ut_free(cursor->scratch);
+  ut_free(cursor->decrypt);
+  ut_free(cursor->orig_buf);
   if (cursor->node != NULL) {
     fil_node_close_file(cursor->node);
     cursor->file = XB_FILE_UNDEFINED;

--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -46,6 +46,8 @@ struct xb_fil_cur_t {
                                otherwise */
   bool is_ibd;                 /*!< TRUE for IBD tablespace tablespace,
                                FALSE otherwise */
+  bool is_compressable;        /*!< TRUE for uncompressed and unencrypted
+                               tablespaces */
   xb_read_filt_t *read_filter; /*!< read filter */
   xb_read_filt_ctxt_t read_filter_ctxt;
   /*!< read filter context */

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -592,6 +592,7 @@ bool xbcloud_put(Object_store *store, const std::string &container,
     res = xb_stream_read_chunk(stream, &chunk);
     if (res != XB_STREAM_READ_CHUNK) {
       my_free(chunk.raw_data);
+      my_free(chunk.sparse_map);
       break;
     }
     if (chunk.type == XB_CHUNK_TYPE_UNKNOWN &&

--- a/storage/innobase/xtrabackup/src/xbstream.h
+++ b/storage/innobase/xtrabackup/src/xbstream.h
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include <my_base.h>
 #include <my_dir.h>
+#include <my_io.h>
+#include "datasink.h"
 
 /* Magic value in a chunk header */
 #define XB_STREAM_CHUNK_MAGIC "XBSTCK01"
@@ -58,6 +60,10 @@ xb_wstream_file_t *xb_stream_write_open(xb_wstream_t *stream, const char *path,
 
 int xb_stream_write_data(xb_wstream_file_t *file, const void *buf, size_t len);
 
+int xb_stream_write_sparse_data(xb_wstream_file_t *file, const void *buf,
+                                size_t len, size_t sparse_map_size,
+                                const ds_sparse_chunk_t *sparse_map);
+
 int xb_stream_write_close(xb_wstream_file_t *file);
 
 int xb_stream_write_done(xb_wstream_t *stream);
@@ -74,6 +80,7 @@ typedef enum {
 typedef enum {
   XB_CHUNK_TYPE_UNKNOWN = '\0',
   XB_CHUNK_TYPE_PAYLOAD = 'P',
+  XB_CHUNK_TYPE_SPARSE = 'S',
   XB_CHUNK_TYPE_EOF = 'E'
 } xb_chunk_type_t;
 
@@ -91,7 +98,11 @@ typedef struct {
   void *data;
   void *raw_data;
   ulong checksum;
+  ulong checksum_part;
   size_t buflen;
+  size_t sparse_map_alloc_size;
+  size_t sparse_map_size;
+  ds_sparse_chunk_t *sparse_map;
 } xb_rstream_chunk_t;
 
 xb_rstream_t *xb_stream_read_new(void);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1183,7 +1183,8 @@ struct my_option xb_client_options[] = {
      "Set datafile read buffer size, given value is scaled up to page size."
      " Default is 10Mb.",
      &opt_read_buffer_size, &opt_read_buffer_size, 0, GET_UINT, OPT_ARG,
-     10 * 1024 * 1024, UNIV_PAGE_SIZE_MAX, UINT_MAX, 0, UNIV_PAGE_SIZE_MAX, 0},
+     10 * 1024 * 1024, 2 * UNIV_PAGE_SIZE_MAX, UINT_MAX, 0, UNIV_PAGE_SIZE_MAX,
+     0},
 
 #include "caching_sha2_passwordopt-longopts.h"
 #include "sslopt-longopts.h"
@@ -2752,39 +2753,6 @@ bool check_if_skip_table(
   return (false);
 }
 
-/***********************************************************************
-Reads the space flags from a given data file and returns the
-page size. */
-const page_size_t xb_get_zip_size(pfs_os_file_t file, bool *success) {
-  byte *buf;
-  byte *page;
-  page_size_t page_size(0, 0, false);
-  ibool ret;
-  ulint space;
-  IORequest read_request(IORequest::READ);
-
-  buf = static_cast<byte *>(ut_malloc_nokey(2 * UNIV_PAGE_SIZE_MAX));
-  page = static_cast<byte *>(ut_align(buf, UNIV_PAGE_SIZE_MAX));
-
-  ret = os_file_read(read_request, file, page, 0, UNIV_PAGE_SIZE_MIN);
-  if (!ret) {
-    *success = false;
-    goto end;
-  }
-
-  space = mach_read_from_4(page + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
-  if (space == 0) {
-    page_size.copy_from(univ_page_size);
-  } else {
-    page_size.copy_from(page_size_t(fsp_header_get_flags(page)));
-  }
-  *success = true;
-end:
-  ut_free(buf);
-
-  return (page_size);
-}
-
 const char *xb_get_copy_action(const char *dflt) {
   const char *action;
 
@@ -2892,7 +2860,12 @@ static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
     goto error;
   }
 
-  dstfile = ds_open(ds_data, dst_name, &cursor.statinfo);
+  /* do not compress already compressed tablespaces */
+  if (cursor.is_compressable) {
+    dstfile = ds_open(ds_data, dst_name, &cursor.statinfo);
+  } else {
+    dstfile = ds_open(ds_uncompressed_data, dst_name, &cursor.statinfo);
+  }
   if (dstfile == NULL) {
     msg("[%02u] xtrabackup: error: cannot open the destination stream for %s\n",
         thread_n, dst_name);
@@ -5773,13 +5746,14 @@ static bool xtrabackup_apply_delta(
   byte *incremental_buffer;
 
   size_t offset;
+  os_file_stat_t stat_info;
 
   if (entry.is_empty_dir) {
     return true;
   }
 
   IORequest read_request(IORequest::READ);
-  IORequest write_request(IORequest::WRITE);
+  IORequest write_request(IORequest::WRITE | IORequest::PUNCH_HOLE);
 
   ut_a(xtrabackup_incremental);
 
@@ -5846,6 +5820,8 @@ static bool xtrabackup_apply_delta(
 
   os_file_set_nocache(dst_file.m_file, dst_path, "OPEN");
 
+  os_file_get_status(dst_path, &stat_info, false, false);
+
   /* allocate buffer for incremental backup */
   incremental_buffer_base = static_cast<byte *>(
       ut_malloc_nokey((page_size / 4 + 1) * page_size + UNIV_PAGE_SIZE_MAX));
@@ -5874,9 +5850,7 @@ static bool xtrabackup_apply_delta(
         last_buffer = true;
         break;
       default:
-        msg("xtrabackup: error: %s seems not "
-            ".delta file.\n",
-            src_path);
+        msg("xtrabackup: error: %s is not valid .delta file.\n", src_path);
         goto error;
     }
 
@@ -5899,18 +5873,34 @@ static bool xtrabackup_apply_delta(
                   POSIX_FADV_DONTNEED);
 
     for (page_in_buffer = 1; page_in_buffer < page_size / 4; page_in_buffer++) {
-      ulint offset_on_page;
-
-      offset_on_page =
+      const page_t *page = incremental_buffer + page_in_buffer * page_size;
+      const ulint offset_on_page =
           mach_read_from_4(incremental_buffer + page_in_buffer * 4);
 
       if (offset_on_page == 0xFFFFFFFFUL) break;
 
-      success = os_file_write(write_request, dst_path, dst_file,
-                              incremental_buffer + page_in_buffer * page_size,
-                              (offset_on_page << page_size_shift), page_size);
+      const auto offset_in_file = offset_on_page << page_size_shift;
+
+      success = os_file_write(write_request, dst_path, dst_file, page,
+                              offset_in_file, page_size);
       if (!success) {
         goto error;
+      }
+
+      if (IORequest::is_punch_hole_supported() &&
+          (Compression::is_compressed_page(page) ||
+           fil_page_get_type(page) == FIL_PAGE_COMPRESSED_AND_ENCRYPTED)) {
+        size_t compressed_len =
+            mach_read_from_2(page + FIL_PAGE_COMPRESS_SIZE_V1) + FIL_PAGE_DATA;
+        compressed_len = ut_calc_align(compressed_len, stat_info.block_size);
+        if (compressed_len < page_size) {
+          if (os_file_punch_hole(dst_file.m_file,
+                                 offset_in_file + compressed_len,
+                                 page_size - compressed_len) != DB_SUCCESS) {
+            msg("xtrabackup: os_file_punch_hole returned error\n");
+            goto error;
+          }
+        }
       }
     }
 
@@ -5926,8 +5916,8 @@ error:
   if (incremental_buffer_base) ut_free(incremental_buffer_base);
   if (src_file != XB_FILE_UNDEFINED) os_file_close(src_file);
   if (dst_file != XB_FILE_UNDEFINED) os_file_close(dst_file);
-  msg("xtrabackup: Error: xtrabackup_apply_delta(): "
-      "failed to apply %s to %s.\n",
+  msg("xtrabackup: Error: xtrabackup_apply_delta(): failed to apply %s to "
+      "%s.\n",
       src_path, dst_path);
   return false;
 }

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -217,11 +217,6 @@ ulint xb_data_files_init(void);
 Destroy the tablespace memory cache. */
 void xb_data_files_close(void);
 
-/***********************************************************************
-Reads the space flags from a given data file and returns the compressed
-page size, or 0 if the space is not compressed. */
-const page_size_t xb_get_zip_size(pfs_os_file_t file, bool *success);
-
 /************************************************************************
 Checks if a database specified by path should be skipped from backup based on
 the --databases, --databases_file or --databases_exclude options.

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -32,6 +32,8 @@ echo ${XBCLOUD_CREDENTIALS} | sed 's/ *--/\'$'\n/g' >> $topdir/xbcloud.cnf
 load_dbase_schema sakila
 load_dbase_data sakila
 
+mysql -e "ALTER TABLE payment COMPRESSION='lz4'" sakila
+
 now=$(date +%s)
 pwdpart=($(pwd | md5sum))
 


### PR DESCRIPTION
COMPRESSION='zlib'

Following implemented:

- added new datasink API call `ds_write_sparse' which takes a buffer and
  a sparse map and writes it preserving its sparseness.
- `ds_write_sparse' implemented in `ds_local' datasink using a
  combination of write and seek system calls
- `ds_write_sparse' implemented in `ds_xbstream' datasink. New sparse
  chunk type introduced which contains the data and the sparse map
- sparse chunk type support added to `xbstream' utility
- backup and copy back modified to detect sparse tablespaces and use
  `ds_write_sparse' to copy them
- xtrabackup will avoid compression of already compressed tablespaces
- xtrabackup when applying incremental deltas will use punch hole
  operation to preserve page sparseness

Limitations:

- `ds_write_sparse' is not supported by `ds_encrypt', encrypted backup
  will not be sparse. However, sparseness will be restored during
  prepare and copy-back.