### PR TITLE
PXB-1887: Incorrect arguments for memset_s

### DIFF
--- a/plugin/keyring_vault/vault_base64.cc
+++ b/plugin/keyring_vault/vault_base64.cc
@@ -30,7 +30,7 @@ namespace keyring
     //data when they are empty. Calling reserve on those containers does not help.
     if (::base64_encode(src, src_len, base64_encoded_text.get()) != 0)
     {
-      memset_s(base64_encoded_text.get(), 0, memory_needed, memory_needed);
+      memset_s(base64_encoded_text.get(), memory_needed, 0, memory_needed);
       return true;
     }
     if (format == SINGLE_LINE)
@@ -40,7 +40,7 @@ namespace keyring
     }
     // base64 encode below returns data with NULL terminating string - which we do not care about
     encoded->assign(base64_encoded_text.get(), memory_needed - 1); 
-    memset_s(base64_encoded_text.get(), 0, memory_needed, memory_needed);
+    memset_s(base64_encoded_text.get(), memory_needed, 0, memory_needed);
 
     return false;
   }
@@ -52,7 +52,7 @@ namespace keyring
     if (decode(src, &data, &data_length))
       return true;    
     dst->assign(data, data_length);
-    memset_s(data, 0, data_length, data_length);
+    memset_s(data, data_length, 0, data_length);
     delete[] data;
     return false;
   }
@@ -65,7 +65,7 @@ namespace keyring
     int64 decoded_length = ::base64_decode(src.c_str(), src.length(), data.get(), NULL, 0);
     if (decoded_length <= 0)
     { 
-      memset_s(data.get(), 0, base64_length_of_memory_needed_for_decode, base64_length_of_memory_needed_for_decode);
+      memset_s(data.get(), base64_length_of_memory_needed_for_decode, 0, base64_length_of_memory_needed_for_decode);
       return true;
     }
     *dst = data.release();


### PR DESCRIPTION
Problem:

memset_s takes destination buffer size as second argument and fill
character as third one. Code in vault_base64.cc these two swapped.

Fix:

Use correct argument order.