### PR TITLE
PXB-1894: PXB crashes during incremental backup prepare for tablespace

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1842,9 +1842,10 @@ recv_parse_or_apply_log_rec_body(
 	        Otherwise, redo will not find the key to decrypt
 		the data pages. */
 		if (page_no == 0 && !is_system_tablespace(space_id)) {
-			return(fil_write_encryption_parse(ptr,
-							  end_ptr,
-							  space_id));
+			if (fil_write_encryption_parse(ptr, end_ptr,
+						       space_id) == NULL) {
+				return(NULL);
+			}
 		}
 		break;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3651,10 +3651,12 @@ xb_load_single_table_tablespace(
 			if (srv_backup_mode || !use_dumped_tablespace_keys) {
 				byte*	key = file->m_encryption_key;
 				byte*	iv = file->m_encryption_iv;
-				ut_ad(key && iv);
 
-				err = fil_set_encryption(space->id,
-					Encryption::AES, key, iv);
+				if (key && iv) {
+					err = fil_set_encryption(
+						space->id,
+						Encryption::AES, key, iv);
+				}
 			} else {
 				byte key[ENCRYPTION_KEY_LEN];
 				byte iv[ENCRYPTION_KEY_LEN];


### PR DESCRIPTION
encryption

Problem:

When encrypted table have just been created it already has encryption
flag in its tablespace header, but may not have encryption information
yet on its first page. This may happen because tablespace flags are
written synchronously and encryption information goes through the buffer
pool and will be flushed later.

Xtrabackup will skip such table in hope that it will be created on
prepare from the redo log. The problem is that crash recovery does not
actually save encryption information when it see it in the redo
log. Instead crash recovery only updates in-memory data structures. It
works in most cases but one, when both full and incremental backups
happened before InnoDB flushed the first page.

Fix:

Make crash recovery to actually apply log record to the first page when
encryption information is saved.

Because xtrabackup parsing redo log as it does the backup, it can get
encryption information for newly created encrypted table from the redo
log and include its .ibd file into a backup.