### PR TITLE
PXB-1901: Compressed lz4 files are also copied in restored data dir

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1260,6 +1260,7 @@ static void par_copy_rocksdb_files(const Myrocks_datadir::const_iterator &start,
                                    bool *result) {
   for (auto it = start; it != end; it++) {
     if (ends_with(it->path.c_str(), ".qp") ||
+        ends_with(it->path.c_str(), ".lz4") ||
         ends_with(it->path.c_str(), ".xbcrypt")) {
       continue;
     }
@@ -1833,6 +1834,7 @@ bool should_skip_file_on_copy_back(const char *filepath) {
                             "xtrabackup_checkpoints",
                             "xtrabackup_tablespaces",
                             ".qp",
+                            ".lz4",
                             ".pmap",
                             ".tmp",
                             ".xbcrypt",

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -862,6 +862,16 @@ function require_qpress()
     fi
 }
 
+########################################################################
+# Skip the test if qpress binary is not available
+########################################################################
+function require_lz4()
+{
+    if ! which lz4 > /dev/null 2>&1 ; then
+        skip_test "Requires lz4 to be installed"
+    fi
+}
+
 function require_tokudb()
 {
     if ! [ -a $(dirname ${MYSQLD})/../lib/mysql/plugin/ha_tokudb.so ]; then

--- a/storage/innobase/xtrabackup/test/t/pxb-1901.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1901.sh
@@ -1,0 +1,26 @@
+#
+# PXB-1901: Compressed lz4 files are also copied in restored data dir
+#
+
+require_lz4
+
+start_server
+
+mysql -e "CREATE TABLE t (a INT)" test
+
+xtrabackup --backup --compress=lz4 --compress-threads=4 \
+           --target-dir=$topdir/backup
+
+xtrabackup --decompress --target-dir=$topdir/backup
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+if [ -f $mysql_datadir/test/t.ibd.lz4 ] ; then
+    die 'lz4 file has been copied to the datadir'
+fi
+


### PR DESCRIPTION
Problem:

LZ4 compressed files were copied back to the datadir with

xtrabackup --copy-back

Fix:

Add .lz4 to the skip list for copy-back