### PR TITLE
PXB-1902: PXB is unable to connect to the database with transition-ke…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1385,8 +1385,7 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    0, 0, 0},
 
   {"transition-key", OPT_TRANSITION_KEY, "Transition key to encrypt "
-   "tablespace keys with.", &opt_transition_key, &opt_transition_key,
-   0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+   "tablespace keys with.", 0, 0, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
   {"xtrabackup-plugin-dir", OPT_XTRA_PLUGIN_DIR,
    "Directory for xtrabackup plugins.",
@@ -1718,7 +1717,7 @@ xb_get_one_option(int optid,
     if (argument)
     {
       char *start = argument;
-      my_free(opt_password);
+      my_free(opt_transition_key);
       opt_transition_key = my_strdup(PSI_NOT_INSTRUMENTED,
                                      argument,MYF(MY_FAE));
       while (*argument) *argument++= 'x';         /* Destroy argument */

--- a/storage/innobase/xtrabackup/test/t/pxb-1902.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1902.sh
@@ -1,0 +1,12 @@
+#
+# PXB-1902: PXB is unable to connect to the database with transition-key when password is specified
+#
+
+start_server
+
+mysql -e "CREATE USER 'bkpuser'@'localhost' IDENTIFIED BY '111'"
+mysql -e "GRANT RELOAD, LOCK TABLES, PROCESS, REPLICATION CLIENT ON *.* TO 'bkpuser'@'localhost';"
+mysql -e "GRANT ALL ON PERCONA_SCHEMA.* TO 'bkpuser'@'localhost';"
+
+xtrabackup -ubkpuser -p111 --backup --target-dir=$topdir/backup \
+	   --transition-key=abcd


### PR DESCRIPTION
…y when

password is specified

Problem:

Code get_one_option to scrape transition key is a copy-paste of the same code
used to scrape the password. One occurence of opt_password was not replaced and
the code for transition key freed memory allocated for password thus making
password invalid when transition key was specified.

Fix:

Do not free the password. Free transition key instead.