### PR TITLE
PXB-1903: PXB is stuck with redo log corruption when master key is

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1692,10 +1692,7 @@ fil_write_encryption_parse(
 		if (!fsp_header_decode_encryption_info(key,
 						       iv,
 						       ptr)) {
-			recv_sys->found_corrupt_log = TRUE;
-			ib::warn() << "Encryption information"
-				<< " in the redo log of space "
-				<< space_id << " is invalid";
+			return(ptr + len);
 		}
 	} else {
 		ulint master_key_id = mach_read_from_4(

--- a/storage/innobase/xtrabackup/test/t/pxb-1903.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1903.sh
@@ -1,0 +1,24 @@
+#
+# PXB-1903: PXB is stuck with redo log corruption when master key is rotated
+#
+
+require_server_version_higher_than 5.7.10
+
+. inc/keyring_file.sh
+
+start_server
+
+mysql -e "CREATE TABLE t (a INT) ENCRYPTION='y'" test
+
+for i in {1..100} ; do
+    mysql -e "INSERT INTO t VALUES ($i)" test
+    sleep 0.2s
+done 1>/dev/null 2>/dev/null &
+
+for i in {1..100} ; do
+    mysql -e "ALTER INSTANCE ROTATE INNODB MASTER KEY" test
+    sleep 0.2s
+done 1>/dev/null 2>/dev/null &
+
+xtrabackup --backup --transition-key=123 --target-dir=$topdir/backup
+xtrabackup --prepare --transition-key=123 --target-dir=$topdir/backup


### PR DESCRIPTION
rotated

Problem:

While copying the datafiles, xtrabackup also parsing redo logs. When
master key is rotated the record about reeencrypting the file header
goes into redo log. Xtrabackup is trying to parse it, but cannot find
new master key because the contents of the keyring file is cached by the
keyring plugin. xtrabackup prints corruption message and stops parsing
the redo log.

Fix:

We actually can skip this error silently because tablespace key has not
changed and there are two possible cases:

1 we have already decrypted the key for this tablespace, then backup
  will proceed without issues 2 we have not yet decrypted the kye for
  this tablespace, then backup will fail when trying to copy the
  tablespace

There is a small room for race condition between update of the keyring
file and the tablespace header which will lead to second case, but there
is no way to reliably fix this race condition. Aborted backup is the
best we can do.