### PR TITLE
PXB-1914: Add timeout options for FTWRL, LTFB, LBFB

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1508,7 +1508,9 @@ backup_start()
 
 		history_lock_time = time(NULL);
 
-		if (!lock_tables_maybe(mysql_connection)) {
+		if (!lock_tables_maybe(mysql_connection,
+				       opt_backup_lock_timeout,
+				       opt_backup_lock_retry_count)) {
 			return(false);
 		}
 	}
@@ -1529,7 +1531,8 @@ backup_start()
 	}
 
 	if (opt_slave_info) {
-		lock_binlog_maybe(mysql_connection);
+		lock_binlog_maybe(mysql_connection, opt_backup_lock_timeout,
+				  opt_backup_lock_retry_count);
 
 		if (!write_slave_info(mysql_connection)) {
 			return(false);
@@ -1550,8 +1553,8 @@ backup_start()
 	}
 
 	if (opt_binlog_info == BINLOG_INFO_ON) {
-
-		lock_binlog_maybe(mysql_connection);
+		lock_binlog_maybe(mysql_connection, opt_backup_lock_timeout,
+				  opt_backup_lock_retry_count);
 		write_binlog_info(mysql_connection);
 	}
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -84,13 +84,13 @@ bool
 write_backup_config_file();
 
 bool
-lock_binlog_maybe(MYSQL *connection);
+lock_binlog_maybe(MYSQL *connection, int timeout, int retry_count);
 
 bool
-lock_tables_for_backup(MYSQL *connection, int timeout = 31536000);
+lock_tables_for_backup(MYSQL *connection, int timeout, int retry_count);
 
 bool
-lock_tables_maybe(MYSQL *connection);
+lock_tables_maybe(MYSQL *connection, int timeout, int retry_count);
 
 bool
 wait_for_safe_slave(MYSQL *connection);

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -174,6 +174,9 @@ extern uint		opt_lock_wait_threshold;
 extern uint		opt_debug_sleep_before_unlock;
 extern uint		opt_safe_slave_backup_timeout;
 
+extern uint		opt_backup_lock_timeout;
+extern uint		opt_backup_lock_retry_count;
+
 extern const char	*opt_history;
 extern my_bool		opt_decrypt;
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1914.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1914.sh
@@ -1,0 +1,33 @@
+#
+# PXB-1914: Add timeout options for FTWRL, LTFB, LBFB
+#
+
+start_server
+
+has_backup_locks || skip_test "Requires backup locks support"
+
+mysql -e "SET GLOBAL general_log = 'ON'"
+mysql -e "SET GLOBAL log_output = 'TABLE'"
+
+xtrabackup --backup --target-dir=$topdir/bak1 --binlog-info=ON
+
+rm -rf $topdir/bak1
+
+xtrabackup --backup --backup-lock-retry-count=5 --backup-lock-timeout=3 \
+	   --target-dir=$topdir/bak1 --binlog-info=ON
+
+rm -rf $topdir/bak1
+
+xtrabackup --backup --backup-lock-timeout=2 --backup-lock-retry-count=4 \
+	   --no-backup-locks --target-dir=$topdir/bak1
+
+rm -rf $topdir/bak1
+
+mysql -e "SELECT argument FROM mysql.general_log WHERE argument LIKE 'SET SESSION lock_wait_timeout%'" > $topdir/log
+
+run_cmd diff -u $topdir/log - <<EOF
+argument
+SET SESSION lock_wait_timeout=31536000
+SET SESSION lock_wait_timeout=3
+SET SESSION lock_wait_timeout=2
+EOF


### PR DESCRIPTION
Added two options:

- backup-lock-timeout: timeout in seconds for attempts to acquire
  metadata locks

- backup-lock-retry-count: number of attempts to acquire metadata
  locks