### PR TITLE
PXB-1912: Support log archiving feature in PXB 8.0

### DIFF
--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -666,6 +666,9 @@ bool recv_sys_add_to_parsing_buf(const byte *log_block, lsn_t scanned_lsn,
 /** Moves the parsing buffer data left to the buffer start. */
 void recv_reset_buffer();
 
+/** Resize the recovery parsing buffer upto log_buffer_size */
+bool recv_sys_resize_buf();
+
 /** Parse log records from a buffer and optionally store them to a
 hash table to wait merging to file pages.
 @param[in]  checkpoint_lsn  the LSN of the latest checkpoint */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -398,7 +398,7 @@ void recv_sys_create() {
 }
 
 /** Resize the recovery parsing buffer upto log_buffer_size */
-static bool recv_sys_resize_buf() {
+bool recv_sys_resize_buf() {
   ut_ad(recv_sys->buf_len <= srv_log_buffer_size);
 
   /* If the buffer cannot be extended further, return false. */

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -100,6 +100,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   keyring_plugins.cc
   kdf.cc
   space_map.cc
+  redo_log.cc
   ${CMAKE_SOURCE_DIR}/sql-common/client_authentication.cc
   )
 

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -291,7 +291,7 @@ static bool ends_with(const char *str, const char *suffix) {
 
 /** Create directories recursively.
 @return 0 if directories created successfully. */
-static int mkdirp(const char *pathname, int Flags, myf MyFlags) {
+int mkdirp(const char *pathname, int Flags, myf MyFlags) {
   char parent[PATH_MAX], *p;
 
   /* make a parent directory path */
@@ -303,12 +303,14 @@ static int mkdirp(const char *pathname, int Flags, myf MyFlags) {
 
   *p = 0;
 
-  /* try to make parent directory */
-  if (p != parent && mkdirp(parent, Flags, MyFlags) != 0) {
-    return (-1);
+  /* try to create parent directory if it doesn't exist */
+  if (!file_exists(parent)) {
+    if (p != parent && mkdirp(parent, Flags, MyFlags) != 0) {
+      return (-1);
+    }
   }
 
-  /* make this one if parent has been made */
+  /* create this one if parent has been created */
   if (my_mkdir(pathname, Flags, MyFlags) == 0) {
     return (0);
   }

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -1,3 +1,20 @@
+/******************************************************
+Copyright (c) 2011-2019 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
 
 #ifndef XTRABACKUP_BACKUP_COPY_H
 #define XTRABACKUP_BACKUP_COPY_H
@@ -59,5 +76,6 @@ void version_check();
 #endif
 bool is_path_separator(char);
 bool directory_exists(const char *dir, bool create);
+int mkdirp(const char *pathname, int Flags, myf MyFlags);
 
 #endif

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -224,7 +224,9 @@ MYSQL_RES *xb_mysql_query(MYSQL *connection, const char *query, bool use_result,
     if ((mysql_result = mysql_store_result(connection)) == NULL) {
       msg("Error: failed to fetch query result %s: %s\n", query,
           mysql_error(connection));
-      exit(EXIT_FAILURE);
+      if (die_on_error) {
+        exit(EXIT_FAILURE);
+      }
     }
 
     if (!use_result) {
@@ -245,11 +247,6 @@ my_ulonglong xb_mysql_numrows(MYSQL *connection, const char *query,
   }
   return rows_count;
 }
-
-struct mysql_variable {
-  const char *name;
-  char **value;
-};
 
 /*********************************************************************/ /**
  Read mysql_variable from MYSQL_RES, return number of rows consumed. */
@@ -294,14 +291,14 @@ static int read_mysql_variables_from_result(MYSQL_RES *mysql_result,
   return rows_read;
 }
 
-static void read_mysql_variables(MYSQL *connection, const char *query,
-                                 mysql_variable *vars, bool vertical_result) {
+void read_mysql_variables(MYSQL *connection, const char *query,
+                          mysql_variable *vars, bool vertical_result) {
   MYSQL_RES *mysql_result = xb_mysql_query(connection, query, true);
   read_mysql_variables_from_result(mysql_result, vars, vertical_result);
   mysql_free_result(mysql_result);
 }
 
-static void free_mysql_variables(mysql_variable *vars) {
+void free_mysql_variables(mysql_variable *vars) {
   mysql_variable *var;
 
   for (var = vars; var->name; var++) {

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -1,3 +1,21 @@
+/******************************************************
+Copyright (c) 2011-2019 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
 #ifndef XTRABACKUP_BACKUP_MYSQL_H
 #define XTRABACKUP_BACKUP_MYSQL_H
 
@@ -39,6 +57,11 @@ struct log_status_t {
   lsn_t lsn_checkpoint;
   std::vector<replication_channel_status_t> channels;
   std::vector<rocksdb_wal_t> rocksdb_wal_files;
+};
+
+struct mysql_variable {
+  const char *name;
+  char **value;
 };
 
 #define ROCKSDB_SUBDIR ".rocksdb"
@@ -151,6 +174,11 @@ my_ulonglong xb_mysql_numrows(MYSQL *connection, const char *query,
                               bool die_on_error);
 
 char *read_mysql_one_value(MYSQL *connection, const char *query);
+
+void read_mysql_variables(MYSQL *connection, const char *query,
+                          mysql_variable *vars, bool vertical_result);
+
+void free_mysql_variables(mysql_variable *vars);
 
 void unlock_all(MYSQL *connection);
 

--- a/storage/innobase/xtrabackup/src/changed_page_bitmap.cc
+++ b/storage/innobase/xtrabackup/src/changed_page_bitmap.cc
@@ -564,7 +564,7 @@ static bool xb_find_lsn_in_bitmap_file(
 
  @return the built bitmap tree or NULL if unable to read the full interval for
  any reason. */
-xb_page_bitmap *xb_page_bitmap_init(void)
+xb_page_bitmap *xb_page_bitmap_init(lsn_t checkpoint_lsn_start)
 /*=====================*/
 {
   log_online_bitmap_file_t bitmap_file;

--- a/storage/innobase/xtrabackup/src/changed_page_bitmap.h
+++ b/storage/innobase/xtrabackup/src/changed_page_bitmap.h
@@ -41,7 +41,7 @@ typedef struct xb_page_bitmap_range_struct xb_page_bitmap_range;
  LSN interval incremental_lsn to checkpoint_lsn_start.
 
  @return the built bitmap tree */
-xb_page_bitmap *xb_page_bitmap_init(void);
+xb_page_bitmap *xb_page_bitmap_init(lsn_t checkpoint_lsn_start);
 /*=====================*/
 
 /****************************************************************/ /**

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1,0 +1,1114 @@
+/******************************************************
+Copyright (c) 2019 Percona LLC and/or its affiliates.
+
+Data sink interface.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#include "redo_log.h"
+
+#include <dict0dict.h>
+#include <log0log.h>
+#include <ut0ut.h>
+#include <univ.i>
+
+#include <sstream>
+
+#include "backup_copy.h"
+#include "backup_mysql.h"
+#include "common.h"
+#include "xtrabackup.h"
+
+#define XB_LOG_FILENAME "xtrabackup_logfile"
+
+extern ds_ctxt_t *ds_redo;
+
+Redo_Log_Reader::Redo_Log_Reader() {
+  log_hdr_buf.create(LOG_FILE_HDR_SIZE);
+  log_buf.create(redo_log_read_buffer_size);
+}
+
+bool Redo_Log_Reader::find_start_checkpoint_lsn() {
+  ulint max_cp_field;
+  auto err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
+
+  if (err != DB_SUCCESS) {
+    msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+    return (false);
+  }
+
+  log_files_header_read(*log_sys, max_cp_field);
+
+  checkpoint_lsn_start =
+      mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_LSN);
+  checkpoint_no_start =
+      mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_NO);
+
+  while (true) {
+    err = fil_io(IORequest(IORequest::READ), true,
+                 page_id_t(log_sys->files_space_id, 0), univ_page_size, 0,
+                 LOG_FILE_HDR_SIZE, log_hdr_buf, nullptr);
+
+    if (err != DB_SUCCESS) {
+      msg("xtrabackup: Error: fil_io() failed.\n");
+      return (false);
+    }
+
+    err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
+
+    if (err != DB_SUCCESS) {
+      msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+      return (false);
+    }
+
+    log_files_header_read(*log_sys, max_cp_field);
+
+    if (checkpoint_no_start !=
+        mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_NO)) {
+      checkpoint_lsn_start =
+          mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_LSN);
+      checkpoint_no_start =
+          mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_NO);
+      continue;
+    }
+
+    break;
+  }
+
+  log_scanned_lsn = checkpoint_lsn_start;
+
+  return (true);
+}
+
+bool Redo_Log_Reader::find_last_checkpoint_lsn(lsn_t *lsn) {
+  ulint max_cp_field;
+  auto err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
+
+  if (err != DB_SUCCESS) {
+    msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+    return (false);
+  }
+
+  log_files_header_read(*log_sys, max_cp_field);
+
+  *lsn = mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_LSN);
+
+  return (true);
+}
+
+byte *Redo_Log_Reader::get_header() const { return log_hdr_buf; }
+
+byte *Redo_Log_Reader::get_buffer() const { return log_buf; }
+
+lsn_t Redo_Log_Reader::get_scanned_lsn() const { return (log_scanned_lsn); }
+
+lsn_t Redo_Log_Reader::get_contiguous_lsn() const {
+  return ut_uint64_align_down(log_scanned_lsn, OS_FILE_LOG_BLOCK_SIZE);
+}
+
+lsn_t Redo_Log_Reader::get_start_checkpoint_lsn() const {
+  return (checkpoint_lsn_start);
+}
+
+void Redo_Log_Reader::read_log_seg(log_t &log, byte *buf, lsn_t start_lsn,
+                                   lsn_t end_lsn) {
+  do {
+    lsn_t source_offset;
+
+    source_offset = log_files_real_offset_for_lsn(log, start_lsn);
+
+    ut_a(end_lsn - start_lsn <= ULINT_MAX);
+
+    ulint len;
+
+    len = (ulint)(end_lsn - start_lsn);
+
+    ut_ad(len != 0);
+
+    if ((source_offset % log.file_size) + len > log.file_size) {
+      /* If the above condition is true then len
+      (which is ulint) is > the expression below,
+      so the typecast is ok */
+      len = (ulint)(log.file_size - (source_offset % log.file_size));
+    }
+
+    ++log.n_log_ios;
+
+    ut_a(source_offset / UNIV_PAGE_SIZE <= PAGE_NO_MAX);
+
+    const page_no_t page_no =
+        static_cast<page_no_t>(source_offset / univ_page_size.physical());
+
+    dberr_t
+
+        err = fil_redo_io(
+            IORequestLogRead, page_id_t(log.files_space_id, page_no),
+            univ_page_size, (ulint)(source_offset % univ_page_size.physical()),
+            len, buf);
+
+    ut_a(err == DB_SUCCESS);
+
+    start_lsn += len;
+    buf += len;
+
+  } while (start_lsn != end_lsn);
+}
+
+ssize_t Redo_Log_Reader::read_logfile(bool is_last, bool *finished) {
+  log_t &log = *log_sys;
+
+  lsn_t contiguous_lsn =
+      ut_uint64_align_down(log_scanned_lsn, OS_FILE_LOG_BLOCK_SIZE);
+  lsn_t start_lsn = contiguous_lsn;
+  lsn_t scanned_lsn = start_lsn;
+
+  size_t len = 0;
+
+  *finished = false;
+
+  while (!*finished && len <= redo_log_read_buffer_size - RECV_SCAN_SIZE) {
+    lsn_t end_lsn = start_lsn + RECV_SCAN_SIZE;
+
+    read_log_seg(log, log_buf + len, start_lsn, end_lsn);
+
+    auto size =
+        scan_log_recs(log_buf + len, is_last, start_lsn, &contiguous_lsn,
+                      &scanned_lsn, log_scanned_lsn, finished);
+
+    if (size < 0) {
+      msg("xtrabackup: Error: read_logfile() failed.\n");
+      return (-1);
+    }
+
+    start_lsn = end_lsn;
+    len += size;
+  }
+
+  log_scanned_lsn = scanned_lsn;
+
+  return (len);
+}
+
+ssize_t Redo_Log_Reader::scan_log_recs(byte *buf, bool is_last, lsn_t start_lsn,
+                                       lsn_t *contiguous_lsn,
+                                       lsn_t *read_upto_lsn,
+                                       lsn_t checkpoint_lsn, bool *finished) {
+  lsn_t scanned_lsn{start_lsn};
+  const byte *log_block{buf};
+
+  *finished = false;
+
+  ulint scanned_checkpoint_no{0};
+
+  while (log_block < buf + RECV_SCAN_SIZE && !*finished) {
+    auto no = log_block_get_hdr_no(log_block);
+    auto scanned_no = log_block_convert_lsn_to_no(scanned_lsn);
+    auto checksum_is_ok = log_block_checksum_is_ok(log_block);
+
+    if (no != scanned_no && checksum_is_ok) {
+      auto blocks_in_group =
+          log_block_convert_lsn_to_no(log_sys->lsn_real_capacity) - 1;
+
+      if ((no < scanned_no && ((scanned_no - no) % blocks_in_group) == 0) ||
+          no == 0 ||
+          /* Log block numbers wrap around at 0x3FFFFFFF */
+          ((scanned_no | 0x40000000UL) - no) % blocks_in_group == 0) {
+        /* old log block, do nothing */
+        *finished = true;
+        break;
+      }
+
+      msg("xtrabackup: error: log block numbers mismatch:\n"
+          "xtrabackup: error: expected log block no. %lu,"
+          " but got no. %lu from the log file.\n",
+          static_cast<ulong>(scanned_no), static_cast<ulong>(no));
+
+      if ((no - scanned_no) % blocks_in_group == 0) {
+        msg("xtrabackup: error:"
+            " it looks like InnoDB log has wrapped"
+            " around before xtrabackup could"
+            " process all records due to either"
+            " log copying being too slow, or "
+            " log files being too small.\n");
+      }
+
+      return (-1);
+
+    } else if (!checksum_is_ok) {
+      /* Garbage or an incompletely written log block */
+      msg("xtrabackup: warning: Log block checksum mismatch"
+          " (block no %lu at lsn " LSN_PF
+          "): \n"
+          "expected %lu, calculated checksum %lu\n",
+          static_cast<ulong>(no), scanned_lsn,
+          static_cast<ulong>(log_block_get_checksum(log_block)),
+          static_cast<ulong>(log_block_calc_checksum(log_block)));
+      msg("xtrabackup: warning: this is possible when the "
+          "log block has not been fully written by the "
+          "server, will retry later.\n");
+      *finished = true;
+      break;
+    }
+
+    if (log_block_get_flush_bit(log_block)) {
+      /* This block was a start of a log flush operation:
+      we know that the previous flush operation must have
+      been completed for all log groups before this block
+      can have been flushed to any of the groups. Therefore,
+      we know that log data is contiguous up to scanned_lsn
+      in all non-corrupt log groups. */
+
+      if (scanned_lsn > *contiguous_lsn) {
+        *contiguous_lsn = scanned_lsn;
+      }
+    }
+
+    auto data_len = log_block_get_data_len(log_block);
+
+    if ((scanned_checkpoint_no > 0) &&
+        (log_block_get_checkpoint_no(log_block) < scanned_checkpoint_no) &&
+        (scanned_checkpoint_no - log_block_get_checkpoint_no(log_block) >
+         0x80000000UL)) {
+      /* Garbage from a log buffer flush which was made
+      before the most recent database recovery */
+
+      *finished = true;
+      break;
+    }
+
+    scanned_lsn = scanned_lsn + data_len;
+    scanned_checkpoint_no = log_block_get_checkpoint_no(log_block);
+
+    if (data_len < OS_FILE_LOG_BLOCK_SIZE) {
+      /* Log data for this group ends here */
+
+      *finished = true;
+    } else {
+      log_block += OS_FILE_LOG_BLOCK_SIZE;
+    }
+  }
+
+  *read_upto_lsn = scanned_lsn;
+
+  ssize_t write_size;
+
+  if (!*finished) {
+    write_size = RECV_SCAN_SIZE;
+  } else {
+    write_size =
+        ut_uint64_align_up(scanned_lsn, OS_FILE_LOG_BLOCK_SIZE) - start_lsn;
+    if (!is_last && scanned_lsn % OS_FILE_LOG_BLOCK_SIZE) {
+      write_size -= OS_FILE_LOG_BLOCK_SIZE;
+    }
+  }
+
+  return (write_size);
+}
+
+void Redo_Log_Reader::seek_logfile(lsn_t lsn) { log_scanned_lsn = lsn; }
+
+bool Redo_Log_Parser::parse_log(const byte *buf, size_t len, lsn_t start_lsn,
+                                lsn_t checkpoint_lsn) {
+  const byte *log_block = buf;
+  lsn_t scanned_lsn = start_lsn;
+  bool more_data = false;
+
+  do {
+    ulint data_len = log_block_get_data_len(log_block);
+
+    if (!recv_sys->parse_start_lsn &&
+        log_block_get_first_rec_group(log_block) > 0) {
+      /* We found a point from which to start the parsing
+      of log records */
+
+      recv_sys->parse_start_lsn =
+          scanned_lsn + log_block_get_first_rec_group(log_block);
+
+      msg("Starting to parse redo log at lsn = " LSN_PF "\n",
+          recv_sys->parse_start_lsn);
+
+      if (recv_sys->parse_start_lsn < recv_sys->checkpoint_lsn) {
+        /* We start to parse log records even before
+        checkpoint_lsn, from the beginning of the log
+        block which contains the checkpoint_lsn.
+
+        That's because the first group of log records
+        in the log block, starts before checkpoint_lsn,
+        and checkpoint_lsn could potentially point to
+        the middle of some log record. We need to find
+        the first group of log records that starts at
+        or after checkpoint_lsn. This could be only
+        achieved by traversing all groups of log records
+        that start within the log block since the first
+        one (to discover their beginnings we need to
+        parse them). However, we don't want to report
+        missing tablespaces for space_id in log records
+        before checkpoint_lsn. Hence we need to ignore
+        those records and that's why we need a counter
+        of bytes to ignore. */
+
+        recv_sys->bytes_to_ignore_before_checkpoint =
+            recv_sys->checkpoint_lsn - recv_sys->parse_start_lsn;
+
+        ut_a(recv_sys->bytes_to_ignore_before_checkpoint <=
+             OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_HDR_SIZE);
+
+        ut_a(recv_sys->checkpoint_lsn % OS_FILE_LOG_BLOCK_SIZE +
+                 LOG_BLOCK_TRL_SIZE <
+             OS_FILE_LOG_BLOCK_SIZE);
+
+        ut_a(recv_sys->parse_start_lsn % OS_FILE_LOG_BLOCK_SIZE >=
+             LOG_BLOCK_HDR_SIZE);
+      }
+
+      recv_sys->scanned_lsn = recv_sys->parse_start_lsn;
+      recv_sys->recovered_lsn = recv_sys->parse_start_lsn;
+    }
+
+    scanned_lsn += data_len;
+
+    if (scanned_lsn > recv_sys->scanned_lsn) {
+      /* We were able to find more log data: add it to the
+      parsing buffer if parse_start_lsn is already
+      non-zero */
+
+      if (recv_sys->len + 4 * OS_FILE_LOG_BLOCK_SIZE >= recv_sys->buf_len) {
+        if (!recv_sys_resize_buf()) {
+          recv_sys->found_corrupt_log = true;
+        }
+      }
+
+      if (!recv_sys->found_corrupt_log) {
+        more_data =
+            recv_sys_add_to_parsing_buf(log_block, scanned_lsn, data_len);
+      }
+
+      recv_sys->scanned_lsn = scanned_lsn;
+
+      recv_sys->scanned_checkpoint_no = log_block_get_checkpoint_no(log_block);
+    }
+
+    if (data_len < OS_FILE_LOG_BLOCK_SIZE) {
+      /* Log data for this group ends here */
+
+      break;
+
+    } else {
+      log_block += OS_FILE_LOG_BLOCK_SIZE;
+    }
+
+  } while (log_block < buf + len);
+
+  if (more_data && !recv_sys->found_corrupt_log) {
+    /* Try to parse more log records */
+
+    recv_parse_log_recs(checkpoint_lsn);
+
+    if (recv_sys->recovered_offset > recv_sys->buf_len / 4) {
+      /* Move parsing buffer data to the buffer start */
+
+      recv_reset_buffer();
+    }
+  }
+
+  return (true);
+}
+
+Redo_Log_Writer::Redo_Log_Writer() { scratch_buf.create(16 * 1024 * 1024); }
+
+bool Redo_Log_Writer::create_logfile(const char *name) {
+  MY_STAT stat_info;
+
+  memset(&stat_info, 0, sizeof(MY_STAT));
+  log_file = ds_open(ds_redo, XB_LOG_FILENAME, &stat_info);
+
+  if (log_file == NULL) {
+    msg("xtrabackup: error: failed to open the target stream for '%s'.\n",
+        XB_LOG_FILENAME);
+    return (false);
+  }
+
+  return (true);
+}
+
+bool Redo_Log_Writer::write_header(byte *hdr) {
+  const auto creator = "xtrabkup ";
+  const auto creator_size = sizeof "xtrabkup " - 1;
+
+  memcpy(hdr + LOG_HEADER_CREATOR, creator, creator_size);
+  ut_sprintf_timestamp(reinterpret_cast<char *>(hdr) +
+                       (LOG_HEADER_CREATOR + creator_size));
+
+  if (ds_write(log_file, hdr, LOG_FILE_HDR_SIZE)) {
+    msg("xtrabackup: error: write to logfile failed\n");
+    return (false);
+  }
+
+  return (true);
+}
+
+bool Redo_Log_Writer::close_logfile() {
+  if (ds_close(log_file) != 0) {
+    msg("xtrabackup: error: failed to close logfile\n");
+    return (false);
+  }
+  return (true);
+}
+
+bool Redo_Log_Writer::write_buffer(byte *buf, size_t len) {
+  byte *write_buf = buf;
+
+  if (srv_redo_log_encrypt) {
+    IORequest req_type(IORequestLogWrite);
+    fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
+    fil_io_set_encryption(req_type, page_id_t(space->id, 0), space);
+    Encryption encryption(req_type.encryption_algorithm());
+    ulint dst_len = len;
+    write_buf =
+        encryption.encrypt_log(req_type, buf, len, scratch_buf, &dst_len);
+    ut_a(len == dst_len);
+  }
+
+  if (ds_write(log_file, write_buf, len)) {
+    msg("xtrabackup: Error: write to logfile failed\n");
+    return (false);
+  }
+
+  return (true);
+}
+
+Archived_Redo_Log_Reader::Archived_Redo_Log_Reader() {
+  log_buf.create(redo_log_read_buffer_size);
+  scratch_buf.create(UNIV_PAGE_SIZE_MAX);
+}
+
+void Archived_Redo_Log_Reader::set_fd(File fd) { file = fd; }
+
+ssize_t Archived_Redo_Log_Reader::read_logfile(bool *finished) {
+  auto read_size =
+      ut_uint64_align_down(redo_log_read_buffer_size, OS_FILE_LOG_BLOCK_SIZE);
+
+  auto len = my_read(file, log_buf, read_size, MYF(MY_WME | MY_FULL_IO));
+  if (len == MY_FILE_ERROR) {
+    return (-1);
+  }
+
+  ut_a(len % OS_FILE_LOG_BLOCK_SIZE == 0);
+
+  log_scanned_lsn += len;
+
+  if (len < redo_log_read_buffer_size) {
+    *finished = true;
+  }
+
+  if (srv_redo_log_encrypt) {
+    IORequest req_type(IORequestLogWrite);
+    fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
+    fil_io_set_encryption(req_type, page_id_t(space->id, 0), space);
+    Encryption encryption(req_type.encryption_algorithm());
+    auto err = encryption.decrypt_log(req_type, log_buf, len, scratch_buf,
+                                      UNIV_PAGE_SIZE_MAX);
+    ut_a(err == DB_SUCCESS);
+  }
+
+  for (const byte *log_block = log_buf; log_block < log_buf + len;
+       log_block += OS_FILE_LOG_BLOCK_SIZE) {
+    ut_a(log_block_checksum_is_ok(log_block));
+  }
+
+  return (len);
+}
+
+bool Archived_Redo_Log_Reader::seek_logfile(lsn_t lsn) {
+  lsn = ut_uint64_align_down(lsn, OS_FILE_LOG_BLOCK_SIZE);
+  if (lsn < archive_start_lsn) {
+    return (false);
+  }
+
+  auto pos = lsn - archive_start_lsn;
+
+  my_seek(file, 0, MY_SEEK_END, MYF(MY_FAE));
+  auto file_size = my_tell(file, MYF(MY_FAE));
+
+  if (file_size < pos) {
+    my_seek(file, 0, MY_SEEK_END, MYF(MY_FAE));
+    file_size = my_tell(file, MYF(MY_FAE));
+
+    return (false);
+  }
+
+  my_seek(file, pos, MY_SEEK_SET, MYF(MY_FAE));
+
+  log_scanned_lsn = lsn;
+
+  return (true);
+}
+
+void Archived_Redo_Log_Reader::set_start_lsn(lsn_t lsn) {
+  ut_a(lsn % OS_FILE_LOG_BLOCK_SIZE == 0);
+
+  archive_start_lsn = lsn;
+  log_scanned_lsn = lsn + OS_FILE_LOG_BLOCK_SIZE;
+}
+
+byte *Archived_Redo_Log_Reader::get_buffer() const { return (log_buf); }
+
+lsn_t Archived_Redo_Log_Reader::get_contiguous_lsn() const {
+  return (log_scanned_lsn);
+}
+
+Archived_Redo_Log_Monitor::Archived_Redo_Log_Monitor() {
+  event = os_event_create("archived_redo_log_monitor");
+}
+
+Archived_Redo_Log_Monitor::~Archived_Redo_Log_Monitor() {
+  os_event_destroy(event);
+}
+
+void Archived_Redo_Log_Monitor::start() {
+  thread = os_thread_create(PFS_NOT_INSTRUMENTED, [this] { thread_func(); });
+  thread.start();
+}
+
+void Archived_Redo_Log_Monitor::stop() {
+  stopped = true;
+  os_event_set(event);
+  thread.join();
+}
+
+Archived_Redo_Log_Reader &Archived_Redo_Log_Monitor::get_reader() {
+  return reader;
+}
+
+bool Archived_Redo_Log_Monitor::is_ready() const { return ready; }
+
+uint32_t Archived_Redo_Log_Monitor::get_first_log_block_no() const {
+  return first_log_block_no;
+}
+
+uint32_t Archived_Redo_Log_Monitor::get_first_log_block_checksum() const {
+  return first_log_block_checksum;
+}
+
+void Archived_Redo_Log_Monitor::parse_archive_dirs(const std::string &s) {
+  std::stringstream ss(s);
+  std::string item;
+
+  while (std::getline(ss, item, ';')) {
+    const auto p = item.find(':');
+    if (p != std::string::npos) {
+      auto label = item.substr(0, p);
+      auto dir = item.substr(p + 1);
+      archived_dirs.emplace(label, dir);
+    }
+  }
+}
+
+void Archived_Redo_Log_Monitor::thread_func() {
+  my_thread_init();
+
+  stopped = false;
+  ready = false;
+
+  MYSQL *mysql = xb_mysql_connect();
+
+  char *redo_log_archive_dirs = nullptr;
+  char *server_uuid = nullptr;
+
+  mysql_variable vars[] = {
+      {"innodb_redo_log_archive_dirs", &redo_log_archive_dirs},
+      {"server_uuid", &server_uuid},
+      {nullptr, nullptr}};
+
+  struct {
+    std::string filename;
+    std::string label;
+    std::string dir;
+    std::string subdir;
+  } archive;
+
+  read_mysql_variables(mysql, "SHOW VARIABLES", vars, true);
+
+  if (redo_log_archive_dirs == nullptr || *redo_log_archive_dirs == 0) {
+    msg("xtrabackup: Redo Log Archiving is not set up.\n");
+    free_mysql_variables(vars);
+    mysql_close(mysql);
+    my_thread_end();
+    return;
+  }
+
+  parse_archive_dirs(redo_log_archive_dirs);
+
+  if (archived_dirs.empty()) {
+    msg("xtrabackup: Redo Log Archiving is not set up.\n");
+    free_mysql_variables(vars);
+    mysql_close(mysql);
+    my_thread_end();
+    return;
+  }
+
+  for (const auto &dir : archived_dirs) {
+    /* try to create a directory */
+    using namespace std::chrono;
+    archive.subdir = std::to_string(
+        duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+            .count());
+
+    archive.dir = dir.second;
+    archive.dir.push_back(OS_PATH_SEPARATOR);
+    archive.dir.append(archive.subdir);
+
+    if (mkdirp(archive.dir.c_str(), 0750, MYF(MY_WME)) != 0) {
+      continue;
+    }
+
+    archive.filename = archive.dir;
+    archive.filename.push_back(OS_PATH_SEPARATOR);
+    archive.filename.append("archive.");
+    archive.filename.append(server_uuid);
+    archive.filename.append(".000001.log");
+
+    archive.label = dir.first;
+  }
+
+  if (archive.label.empty()) {
+    msg("xtrabackup: Redo Log Archiving is not used.\n");
+    free_mysql_variables(vars);
+    mysql_close(mysql);
+    my_thread_end();
+    return;
+  }
+
+  free_mysql_variables(vars);
+
+  std::string start_query("select innodb_redo_log_archive_start(");
+
+  start_query.append("'");
+  start_query.append(archive.label);
+  start_query.append("', '");
+  start_query.append(archive.subdir);
+  start_query.append("')");
+
+  auto res = xb_mysql_query(mysql, start_query.c_str(), true, false);
+
+  if (res == nullptr) {
+    msg("xtrabackup: Redo Log Archiving is not used.\n");
+    mysql_close(mysql);
+    my_thread_end();
+    return;
+  }
+
+  mysql_free_result(res);
+
+  msg("xtrabackup: Waiting for archive file '%s'\n", archive.filename.c_str());
+
+  /* wait for archive file to appear */
+  while (!stopped) {
+    bool exists;
+    os_file_type_t type;
+    if (!os_file_status(archive.filename.c_str(), &exists, &type)) {
+      msg("xtrabackup: cannot stat file '%s'\n", archive.filename.c_str());
+      break;
+    }
+    if (exists) {
+      break;
+    }
+    os_event_wait_time_low(event, 100 * 1000, 0);
+    os_event_reset(event);
+  }
+
+  File file{-1};
+  if (!stopped) {
+    file = my_open(archive.filename.c_str(), O_RDONLY, MYF(MY_WME));
+    if (file < 0) {
+      msg("xtrabackup: error: cannot open '%s'\n", archive.filename.c_str());
+      mysql_close(mysql);
+      my_thread_end();
+      return;
+    }
+
+    aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> buf;
+    buf.create(OS_FILE_LOG_BLOCK_SIZE);
+
+    size_t hdr_len = OS_FILE_LOG_BLOCK_SIZE;
+    while (hdr_len > 0 && !stopped) {
+      size_t n_read = my_read(file, buf, hdr_len, MYF(MY_WME));
+      if (n_read == MY_FILE_ERROR) {
+        msg("xtrabackup: cannot read from '%s'\n", archive.filename.c_str());
+        mysql_close(mysql);
+        my_thread_end();
+        return;
+      }
+      os_event_wait_time_low(event, 100 * 1000, 0);
+      os_event_reset(event);
+      hdr_len -= n_read;
+    }
+
+    first_log_block_no = log_block_get_hdr_no(buf);
+    first_log_block_checksum = log_block_get_checksum(buf);
+    ready = true;
+  }
+
+  if (ready && !stopped) {
+    msg("xtrabackup: Redo Log Archive '%s' found. First log block is "
+        "%lu, checksum is %lu.\n",
+        archive.filename.c_str(), static_cast<ulong>(first_log_block_no),
+        static_cast<ulong>(first_log_block_checksum));
+    reader.set_fd(file);
+  }
+
+  while (!stopped) {
+    os_event_wait_time_low(event, 100 * 1000, 0);
+    os_event_reset(event);
+  }
+
+  xb_mysql_query(mysql, "SELECT innodb_redo_log_archive_stop()", false);
+  unlink(archive.filename.c_str());
+  rmdir(archive.subdir.c_str());
+  mysql_close(mysql);
+  my_thread_end();
+}
+
+static dberr_t open_or_create_log_file(bool *log_file_created, ulint i,
+                                       fil_space_t **log_space) {
+  bool ret;
+  os_offset_t size;
+  char name[10000];
+  ulint dirnamelen;
+
+  *log_file_created = false;
+
+  Fil_path::normalize(srv_log_group_home_dir);
+
+  dirnamelen = strlen(srv_log_group_home_dir);
+  ut_a(dirnamelen < (sizeof name) - 10 - sizeof "ib_logfile");
+  memcpy(name, srv_log_group_home_dir, dirnamelen);
+
+  /* Add a path separator if needed. */
+  if (dirnamelen && name[dirnamelen - 1] != OS_PATH_SEPARATOR) {
+    name[dirnamelen++] = OS_PATH_SEPARATOR;
+  }
+
+  sprintf(name + dirnamelen, "%s%ld", "ib_logfile", i);
+
+  pfs_os_file_t file = os_file_create(0, name, OS_FILE_OPEN, OS_FILE_NORMAL,
+                                      OS_LOG_FILE, true, &ret);
+  if (!ret) {
+    msg("xtrabackup: error in opening %s\n", name);
+
+    return (DB_ERROR);
+  }
+
+  size = os_file_get_size(file);
+
+  if (size != srv_log_file_size) {
+    msg("xtrabackup: Error: log file %s is of different size " UINT64PF
+        " bytes than specified in the .cnf file %llu bytes!\n",
+        name, size, srv_log_file_size * UNIV_PAGE_SIZE);
+
+    return (DB_ERROR);
+  }
+
+  ret = os_file_close(file);
+  ut_a(ret);
+
+  if (i == 0) {
+    /* Create in memory the file space object
+    which is for this log group */
+
+    *log_space = fil_space_create(name, dict_sys_t::s_log_space_first_id,
+                                  fsp_flags_set_page_size(0, univ_page_size),
+                                  FIL_TYPE_LOG);
+  }
+
+  ut_a(*log_space != NULL);
+  ut_ad(fil_validate());
+
+  ut_a(fil_node_create(name, srv_log_file_size / univ_page_size.physical(),
+                       *log_space, false, false) != NULL);
+
+  return (DB_SUCCESS);
+}
+
+bool Redo_Log_Data_Manager::init() {
+  error = true;
+  event = os_event_create("log_copying_stop");
+
+  thread = os_thread_create(PFS_NOT_INSTRUMENTED, [this] { copy_func(); });
+
+  if (!log_sys_init(srv_n_log_files, srv_log_file_size,
+                    dict_sys_t::s_log_space_first_id)) {
+    return (false);
+  }
+
+  recv_sys_create();
+  recv_sys_init(buf_pool_get_curr_size());
+
+  ut_a(srv_n_log_files > 0);
+
+  bool log_file_created = false;
+  bool log_created = false;
+  bool log_opened = false;
+  fil_space_t *log_space = nullptr;
+
+  for (ulong i = 0; i < srv_n_log_files; i++) {
+    dberr_t err = open_or_create_log_file(&log_file_created, i, &log_space);
+    if (err != DB_SUCCESS) {
+      return (false);
+    }
+
+    if (log_file_created) {
+      log_created = true;
+    } else {
+      log_opened = true;
+    }
+    if ((log_opened && log_created)) {
+      msg("xtrabackup: Error: all log files must be created at the same time.\n"
+          "xtrabackup: All log files must be created also in database "
+          "creation.\n"
+          "xtrabackup: If you want bigger or smaller log files, shut down the\n"
+          "xtrabackup: database and make sure there were no errors in "
+          "shutdown.\n"
+          "xtrabackup: Then delete the existing log files. Edit the .cnf file\n"
+          "xtrabackup: and start the database again.\n");
+
+      return (false);
+    }
+  }
+
+  /* log_file_created must not be TRUE, if online */
+  if (log_file_created) {
+    msg("xtrabackup: Something wrong with source files...\n");
+    exit(EXIT_FAILURE);
+  }
+
+  ut_a(log_space != nullptr);
+
+  log_read_encryption();
+
+  archived_log_state = ARCHIVED_LOG_NONE;
+  archived_log_monitor.start();
+
+  error = false;
+
+  return (true);
+}
+
+bool Redo_Log_Data_Manager::start() {
+  error = true;
+
+  if (!reader.find_start_checkpoint_lsn()) {
+    return (false);
+  }
+
+  if (!writer.create_logfile(XB_LOG_FILENAME)) {
+    return (false);
+  }
+
+  if (!writer.write_header(reader.get_header())) {
+    return (false);
+  }
+
+  start_checkpoint_lsn = reader.get_start_checkpoint_lsn();
+  last_checkpoint_lsn = start_checkpoint_lsn;
+  stop_lsn = 0;
+
+  bool finished = false;
+  while (!finished) {
+    if (!copy_once(false, &finished)) {
+      return (false);
+    }
+  }
+
+  thread.start();
+
+  error = false;
+
+  return (true);
+}
+
+void Redo_Log_Data_Manager::track_archived_log(lsn_t start_lsn, const byte *buf,
+                                               size_t len) {
+  if (!archived_log_monitor.is_ready() ||
+      archived_log_state == ARCHIVED_LOG_MATCHED) {
+    return;
+  }
+
+  if (archived_log_state == ARCHIVED_LOG_NONE) {
+    for (auto ptr = buf; ptr < buf + len;
+         ptr += OS_FILE_LOG_BLOCK_SIZE, start_lsn += OS_FILE_LOG_BLOCK_SIZE) {
+      auto no = log_block_get_hdr_no(ptr);
+      auto checksum = log_block_get_checksum(ptr);
+      if (no == archived_log_monitor.get_first_log_block_no() &&
+          checksum == archived_log_monitor.get_first_log_block_checksum()) {
+        msg("xtrabackup: Switched to archived redo log starting with "
+            "LSN: " LSN_PF "\n",
+            start_lsn);
+        archived_log_monitor.get_reader().set_start_lsn(start_lsn);
+        archived_log_state = ARCHIVED_LOG_MATCHED;
+      }
+    }
+  }
+
+  if (archived_log_state == ARCHIVED_LOG_MATCHED) {
+    if (archived_log_monitor.get_reader().seek_logfile(
+            reader.get_contiguous_lsn())) {
+      archived_log_state = ARCHIVED_LOG_POSITIONED;
+    }
+  }
+}
+
+bool Redo_Log_Data_Manager::copy_once(bool is_last, bool *finished) {
+  auto start_lsn = reader.get_contiguous_lsn();
+
+  if (archived_log_state == ARCHIVED_LOG_POSITIONED) {
+    auto &archive_reader = archived_log_monitor.get_reader();
+
+    if (archive_reader.seek_logfile(start_lsn)) {
+      auto len = archive_reader.read_logfile(finished);
+
+      if (len < 0) {
+        return (false);
+      }
+
+      if (len > 0) {
+        if (!parser.parse_log(archive_reader.get_buffer(), len, start_lsn,
+                              reader.get_start_checkpoint_lsn())) {
+          return (false);
+        }
+
+        if (!writer.write_buffer(archive_reader.get_buffer(), len)) {
+          return (false);
+        }
+
+        reader.seek_logfile(archive_reader.get_contiguous_lsn());
+
+        return (true);
+      }
+
+      if (stop_lsn == 0 || archive_reader.get_contiguous_lsn() >= stop_lsn) {
+        return (true);
+      }
+    }
+  }
+
+  auto len = reader.read_logfile(is_last, finished);
+  if (len <= 0) {
+    return (len == 0);
+  }
+
+  track_archived_log(start_lsn, reader.get_buffer(), len);
+
+  if (!parser.parse_log(reader.get_buffer(), len, start_lsn,
+                        reader.get_start_checkpoint_lsn())) {
+    return (false);
+  }
+
+  if (!writer.write_buffer(reader.get_buffer(), len)) {
+    return (false);
+  }
+
+  return (true);
+}
+
+void Redo_Log_Data_Manager::copy_func() {
+  my_thread_init();
+
+  aborted = false;
+
+  bool finished;
+  while (!aborted && (stop_lsn == 0 || stop_lsn > reader.get_scanned_lsn())) {
+    xtrabackup_io_throttling();
+
+    if (!copy_once(false, &finished)) {
+      error = true;
+      return;
+    }
+
+    if (finished) {
+      msg_ts(">> log scanned up to (" LSN_PF ")\n", reader.get_scanned_lsn());
+
+      debug_sync_point("xtrabackup_copy_logfile_pause");
+
+      os_event_reset(event);
+      os_event_wait_time_low(event, copy_interval * 1000UL, 0);
+    }
+  }
+
+  if (!aborted && !copy_once(true, &finished)) {
+    error = true;
+  }
+
+  my_thread_end();
+}
+
+lsn_t Redo_Log_Data_Manager::get_last_checkpoint_lsn() const {
+  return (last_checkpoint_lsn);
+}
+
+lsn_t Redo_Log_Data_Manager::get_stop_lsn() const { return (stop_lsn); }
+
+lsn_t Redo_Log_Data_Manager::get_start_checkpoint_lsn() const {
+  return (start_checkpoint_lsn);
+}
+
+lsn_t Redo_Log_Data_Manager::get_scanned_lsn() const { return (scanned_lsn); }
+
+void Redo_Log_Data_Manager::set_copy_interval(ulint interval) {
+  copy_interval = interval;
+}
+
+void Redo_Log_Data_Manager::abort() {
+  aborted = true;
+  os_event_set(event);
+  thread.join();
+  archived_log_monitor.stop();
+}
+
+bool Redo_Log_Data_Manager::is_error() const { return (error); }
+
+Redo_Log_Data_Manager::~Redo_Log_Data_Manager() { os_event_destroy(event); }
+
+bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
+  if (reader.find_last_checkpoint_lsn(&last_checkpoint_lsn)) {
+    msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
+        last_checkpoint_lsn);
+  }
+  msg("xtrabackup: Stopping log copying thread at LSN " LSN_PF ".\n", lsn);
+
+  stop_lsn = lsn;
+  os_event_set(event);
+  thread.join();
+
+  archived_log_monitor.stop();
+
+  scanned_lsn = reader.get_scanned_lsn();
+
+  if (last_checkpoint_lsn > scanned_lsn) {
+    msg("xtrabackup: error: last checkpoint LSN (" LSN_PF
+        ") is larger than last copied LSN (" LSN_PF ").\n",
+        last_checkpoint_lsn, scanned_lsn);
+    return (false);
+  }
+
+  if (!writer.close_logfile()) {
+    return (false);
+  }
+
+  return (true);
+}
+
+void Redo_Log_Data_Manager::close() { log_sys_close(); }

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -1,0 +1,357 @@
+/******************************************************
+Copyright (c) 2019 Percona LLC and/or its affiliates.
+
+Data sink interface.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef XB_REDO_LOG_H
+#define XB_REDO_LOG_H
+
+#include <log0log.h>
+#include <log0types.h>
+#include <os0thread-create.h>
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "datasink.h"
+
+#define redo_log_read_buffer_size ((srv_log_buffer_size) / 2)
+
+/** Redo log reader. */
+class Redo_Log_Reader {
+ public:
+  Redo_Log_Reader();
+
+  /** Find start checkpoint lsn.
+  @param[out] lsn               start checkpoint lsn
+  @return true if success. */
+  bool find_start_checkpoint_lsn();
+
+  /** Find last checkpoint lsn.
+  @param[out] lsn               last checkpoint lsn
+  @return true if success. */
+  bool find_last_checkpoint_lsn(lsn_t *lsn);
+
+  /** Get log header. */
+  byte *get_header() const;
+
+  /** Get log buffer. */
+  byte *get_buffer() const;
+
+  /** Get scanned LSN. */
+  lsn_t get_scanned_lsn() const;
+
+  /** Get contiguous LSN. */
+  lsn_t get_contiguous_lsn() const;
+
+  /** Get checkpoint LSN at the backup start. */
+  lsn_t get_start_checkpoint_lsn() const;
+
+  /** Read from logfile into internal buffer
+  @param[in] is_last            true if this is last read
+  @param[in] finished           true if there is no more data to read
+                                for now
+  @return read length or -1 if error. */
+  ssize_t read_logfile(bool is_last, bool *finished);
+
+  /** Seek logfile to specified lsn. */
+  void seek_logfile(lsn_t lsn);
+
+ private:
+  /** log header buffer. */
+  aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> log_hdr_buf;
+
+  /** log read buffer. */
+  aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> log_buf;
+
+  /** Read specified log segment into a buffer.
+  @param[in,out] buf            buffer where to read
+  @param[in]     start_lsn      read area start
+  @param[in]     end_lsn        read area end
+  @param[in,out] contiguous_lsn it is known that log contain
+                                contiguous log data up to this lsn
+  @param[out]    read_upto_lsn  scanning succeeded up to this lsn
+  @param[in]     checkpoint_lsn checkpoint lsn
+  @param[in] finished           true if there is no more data to read
+                                for now
+  @return scanned length or -1 if error. */
+  ssize_t scan_log_recs(byte *buf, bool is_last, lsn_t start_lsn,
+                        lsn_t *contiguous_lsn, lsn_t *read_upto_lsn,
+                        lsn_t checkpoint_lsn, bool *finished);
+
+  /** Read specified log segment into a buffer.
+  @param[in,out] log            redo log
+  @param[in,out] buf            buffer where to read
+  @param[in]     start_lsn      read area start
+  @param[in]     end_lsn        read area end */
+  void read_log_seg(log_t &log, byte *buf, lsn_t start_lsn, lsn_t end_lsn);
+
+  /** checkpoint LSN at the backup start. */
+  lsn_t checkpoint_lsn_start{0};
+
+  /** checkpoint number at the backup start. */
+  lsn_t checkpoint_no_start{0};
+
+  /** last scanned LSN. */
+  lsn_t log_scanned_lsn{0};
+};
+
+/** Redo log parser. */
+class Redo_Log_Parser {
+ public:
+  /** Parse log from given buffer.
+  @param[in] buf                buffer to parse
+  @param[in] len                data length
+  @param[in] start_lsn          start lsn
+  @param[in] checkpoint_lsn     checkpoint lsn
+  @return false if error. */
+  bool parse_log(const byte *buf, size_t len, lsn_t start_lsn,
+                 lsn_t checkpoint_lsn);
+};
+
+/** Redo log writer. */
+class Redo_Log_Writer {
+ public:
+  Redo_Log_Writer();
+
+  /** Create logfile with given path.
+  @param[in] path               log file name and path
+  @return false if error. */
+  bool create_logfile(const char *path);
+
+  /** Write log header.
+  @param[in] buf                buffer where to write from
+  @return false if error. */
+  bool write_header(byte *hdr);
+
+  /** Write buffer contents into logfile.
+  @param[in] buf                buffer where to write from
+  @param[in] len                data length
+  @return false if error. */
+  bool write_buffer(byte *buf, size_t len);
+
+  /** Close logfile.
+  @return false if error. */
+  bool close_logfile();
+
+ private:
+  /** Log file. */
+  ds_file_t *log_file;
+
+  /** Temporary buffer used for encryption. */
+  aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> scratch_buf;
+};
+
+/** Archived redo log reader. */
+class Archived_Redo_Log_Reader {
+ public:
+  Archived_Redo_Log_Reader();
+
+  /** Set file descriptor of the archived log file. */
+  void set_fd(File fd);
+
+  /** Read from logfile into internal buffer
+  @param[in] finished           true if there is no more data to read
+                                for now
+  @return read length or -1 if error. */
+  ssize_t read_logfile(bool *finished);
+
+  /** Seek logfile to specified lsn.
+  @param[in] lsn                desired lsn
+  @return true if success */
+  bool seek_logfile(lsn_t lsn);
+
+  /** Set start lsn of archived log. */
+  void set_start_lsn(lsn_t lsn);
+
+  /** Get log buffer. */
+  byte *get_buffer() const;
+
+  /** Get contiguous LSN. */
+  lsn_t get_contiguous_lsn() const;
+
+ private:
+  /** log file. */
+  File file;
+
+  /** log read buffer. */
+  aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> log_buf;
+
+  /** temporary buffer used for encryption. */
+  aligned_array_pointer<byte, UNIV_PAGE_SIZE_MAX> scratch_buf;
+
+  /** start lsn of archived redo log. */
+  lsn_t archive_start_lsn;
+
+  /** last scanned LSN. */
+  lsn_t log_scanned_lsn;
+};
+
+/** Archived redo monitor. */
+class Archived_Redo_Log_Monitor {
+ public:
+  Archived_Redo_Log_Monitor();
+  ~Archived_Redo_Log_Monitor();
+
+  /** Start log archiving monitor. */
+  void start();
+
+  /** Signal monitor to stop. */
+  void stop();
+
+  /** Get archived log reader. */
+  Archived_Redo_Log_Reader &get_reader();
+
+  /** Whether the archived log is created and readable. */
+  bool is_ready() const;
+
+  /** Get first log block no from the archived redo log. */
+  uint32_t get_first_log_block_no() const;
+
+  /** Get first log block checksum from the archived redo log. */
+  uint32_t get_first_log_block_checksum() const;
+
+ private:
+  /** Parse the value of innodb_redo_log_archive_dirs. */
+  void parse_archive_dirs(const std::string &s);
+
+  /** Start log archiving on server if supported, open archive file,
+      wait for stop signal and remove the archive. */
+  void thread_func();
+
+  /** parsed value of innodb_redo_log_archive_dirs. */
+  std::unordered_map<std::string, std::string> archived_dirs;
+
+  /** monitor thread. */
+  IB_thread thread;
+
+  /** stopped flag. */
+  std::atomic<bool> stopped;
+
+  /** readiness flag. */
+  std::atomic<bool> ready;
+
+  /** first log block no. */
+  uint32_t first_log_block_no;
+
+  /** first log block checksum. */
+  uint32_t first_log_block_checksum;
+
+  /** archived redo log reader. */
+  Archived_Redo_Log_Reader reader;
+
+  /** stop event. */
+  os_event_t event;
+};
+
+class Redo_Log_Data_Manager {
+ public:
+  /** Init data manager. */
+  bool init();
+
+  /** Start log copying. */
+  bool start();
+
+  /** Abort log copying. */
+  void abort();
+
+  /** Stop log copying at specific lsn. */
+  bool stop_at(lsn_t lsn);
+
+  /** Close log file. */
+  void close();
+
+  /** Get checkpoint lsn at the end of the backup. */
+  lsn_t get_last_checkpoint_lsn() const;
+
+  /** Get checkpoint lsn at the beginning of the backup. */
+  lsn_t get_start_checkpoint_lsn() const;
+
+  /** Get backup stop lsn (consistency point). */
+  lsn_t get_stop_lsn() const;
+
+  /** Get last scanned lsn. */
+  lsn_t get_scanned_lsn() const;
+
+  /** Set copy interval. */
+  void set_copy_interval(ulint interval);
+
+  /** Whether there was an error. */
+  bool is_error() const;
+
+  ~Redo_Log_Data_Manager();
+
+ private:
+  /** Log copying func. */
+  void copy_func();
+
+  /** Copy batch of log blocks. */
+  bool copy_once(bool is_last, bool *finished);
+
+  /** Compare archived log block number and lsn with the current lsn
+      and seek archived log if needed. */
+  void track_archived_log(lsn_t start_lsn, const byte *buf, size_t len);
+
+  /** copying thread. */
+  IB_thread thread;
+
+  /** aborted flag. */
+  std::atomic<bool> aborted;
+
+  /** lsn to stop copying at. */
+  std::atomic<lsn_t> stop_lsn;
+
+  /** checkpoint lsn at the end of the backup. */
+  lsn_t last_checkpoint_lsn;
+
+  /** checkpoint lsn at the beginning of the backup. */
+  lsn_t start_checkpoint_lsn;
+
+  /** last scanned lsn. */
+  lsn_t scanned_lsn;
+
+  /** redo log reader. */
+  Redo_Log_Reader reader;
+
+  /** redo log writer. */
+  Redo_Log_Writer writer;
+
+  /** redo log parser. */
+  Redo_Log_Parser parser;
+
+  /** archived log monitor. */
+  Archived_Redo_Log_Monitor archived_log_monitor;
+
+  /** time to sleep in ms between log copying batches. */
+  ulint copy_interval;
+
+  /** stop event. */
+  os_event_t event;
+
+  /** error flag. */
+  std::atomic<bool> error;
+
+  enum {
+    ARCHIVED_LOG_NONE,
+    ARCHIVED_LOG_MATCHED,
+    ARCHIVED_LOG_POSITIONED
+  } archived_log_state;
+};
+
+#endif

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -105,6 +105,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "fil_cur.h"
 #include "keyring_plugins.h"
 #include "read_filt.h"
+#include "redo_log.h"
 #include "space_map.h"
 #include "write_filt.h"
 #include "wsrep.h"
@@ -160,8 +161,6 @@ bool xtrabackup_create_ib_logfile = FALSE;
 long xtrabackup_throttle = 0; /* 0:unlimited */
 lint io_ticket;
 os_event_t wait_throttle = NULL;
-os_event_t log_copying_stop = NULL;
-lsn_t log_copying_stop_lsn = 0;
 
 char *xtrabackup_incremental = NULL;
 lsn_t incremental_lsn;
@@ -206,11 +205,7 @@ struct xb_filter_entry_struct {
 };
 typedef struct xb_filter_entry_struct xb_filter_entry_t;
 
-lsn_t checkpoint_lsn_start;
-lsn_t checkpoint_no_start;
-lsn_t log_copy_scanned_lsn;
-bool log_copying = true;
-bool log_copying_running = false;
+bool io_watching_thread_stop = false;
 bool io_watching_thread_running = false;
 
 bool xtrabackup_logfile_is_renamed = false;
@@ -460,8 +455,8 @@ extern const char *innodb_flush_method_names[];
 /** Enumeration of innodb_flush_method */
 extern TYPELIB innodb_flush_method_typelib;
 
-#include "sslopt-vars.h"
 #include "caching_sha2_passwordopt-vars.h"
+#include "sslopt-vars.h"
 
 extern struct rand_struct sql_rand;
 extern mysql_mutex_t LOCK_sql_rand;
@@ -2936,281 +2931,6 @@ skip:
   return (FALSE);
 }
 
-/*******************************************************/ /**
- Scans log from a buffer and writes new log data to the outpud datasinc.
- @return true if success */
-static bool xtrabackup_scan_log_recs(
-    /*===============*/
-    log_t &log,               /*!< in: redo log */
-    bool is_last,             /*!< in: whether it is last segment
-                              to copy */
-    lsn_t start_lsn,          /*!< in: buffer start lsn */
-    lsn_t *contiguous_lsn,    /*!< in/out: it is known that all log
-                              groups contain contiguous log data up
-                              to this lsn */
-    lsn_t *group_scanned_lsn, /*!< out: scanning succeeded up to
-                            this lsn */
-    lsn_t checkpoint_lsn,     /*!< in: latest checkpoint LSN */
-    bool *finished)           /*!< out: false if is not able to scan
-                              any more in this log group */
-{
-  lsn_t scanned_lsn;
-  ulint data_len;
-  ulint write_size;
-  const byte *log_block;
-  bool more_data = false;
-
-  ulint scanned_checkpoint_no = 0;
-
-  *finished = false;
-  scanned_lsn = start_lsn;
-  log_block = log_sys->buf;
-
-  while (log_block < log_sys->buf + RECV_SCAN_SIZE && !*finished) {
-    ulint no = log_block_get_hdr_no(log_block);
-    ulint scanned_no = log_block_convert_lsn_to_no(scanned_lsn);
-    ibool checksum_is_ok = log_block_checksum_is_ok(log_block);
-
-    if (no != scanned_no && checksum_is_ok) {
-      ulint blocks_in_group;
-
-      blocks_in_group = log_block_convert_lsn_to_no(log.lsn_real_capacity) - 1;
-
-      if ((no < scanned_no && ((scanned_no - no) % blocks_in_group) == 0) ||
-          no == 0 ||
-          /* Log block numbers wrap around at 0x3FFFFFFF */
-          ((scanned_no | 0x40000000UL) - no) % blocks_in_group == 0) {
-        /* old log block, do nothing */
-        *finished = true;
-        break;
-      }
-
-      msg("xtrabackup: error: log block numbers mismatch:\n"
-          "xtrabackup: error: expected log block no. %lu,"
-          " but got no. %lu from the log file.\n",
-          (ulong)scanned_no, (ulong)no);
-
-      if ((no - scanned_no) % blocks_in_group == 0) {
-        msg("xtrabackup: error:"
-            " it looks like InnoDB log has wrapped"
-            " around before xtrabackup could"
-            " process all records due to either"
-            " log copying being too slow, or "
-            " log files being too small.\n");
-      }
-
-      return (false);
-    } else if (!checksum_is_ok) {
-      /* Garbage or an incompletely written log block */
-      msg("xtrabackup: warning: Log block checksum mismatch"
-          " (block no %lu at lsn " LSN_PF
-          "): \n"
-          "expected %lu, calculated checksum %lu\n",
-          (ulong)no, scanned_lsn, (ulong)log_block_get_checksum(log_block),
-          (ulong)log_block_calc_checksum(log_block));
-      msg("xtrabackup: warning: this is possible when the "
-          "log block has not been fully written by the "
-          "server, will retry later.\n");
-      *finished = true;
-      break;
-    }
-
-    if (log_block_get_flush_bit(log_block)) {
-      /* This block was a start of a log flush operation:
-      we know that the previous flush operation must have
-      been completed for all log groups before this block
-      can have been flushed to any of the groups. Therefore,
-      we know that log data is contiguous up to scanned_lsn
-      in all non-corrupt log groups. */
-
-      if (scanned_lsn > *contiguous_lsn) {
-        *contiguous_lsn = scanned_lsn;
-      }
-    }
-
-    data_len = log_block_get_data_len(log_block);
-
-    if ((scanned_checkpoint_no > 0) &&
-        (log_block_get_checkpoint_no(log_block) < scanned_checkpoint_no) &&
-        (scanned_checkpoint_no - log_block_get_checkpoint_no(log_block) >
-         0x80000000UL)) {
-      /* Garbage from a log buffer flush which was made
-      before the most recent database recovery */
-
-      *finished = true;
-      break;
-    }
-
-    if (!recv_sys->parse_start_lsn &&
-        (log_block_get_first_rec_group(log_block) > 0)) {
-      /* We found a point from which to start the parsing
-      of log records */
-
-      recv_sys->parse_start_lsn =
-          scanned_lsn + log_block_get_first_rec_group(log_block);
-      recv_sys->scanned_lsn = recv_sys->parse_start_lsn;
-      recv_sys->recovered_lsn = recv_sys->parse_start_lsn;
-    }
-
-    scanned_lsn = scanned_lsn + data_len;
-    scanned_checkpoint_no = log_block_get_checkpoint_no(log_block);
-
-    if (scanned_lsn > recv_sys->scanned_lsn) {
-      /* We were able to find more log data: add it to the
-      parsing buffer if parse_start_lsn is already
-      non-zero */
-
-      if (recv_sys->len + 4 * OS_FILE_LOG_BLOCK_SIZE >= RECV_PARSING_BUF_SIZE) {
-        ib::error() << "Log parsing buffer overflow. Recovery may have failed!";
-
-        recv_sys->found_corrupt_log = true;
-
-      } else if (!recv_sys->found_corrupt_log) {
-        more_data = recv_sys_add_to_parsing_buf(log_block, scanned_lsn, 0);
-      }
-
-      recv_sys->scanned_lsn = scanned_lsn;
-      recv_sys->scanned_checkpoint_no = log_block_get_checkpoint_no(log_block);
-    }
-
-    if (data_len < OS_FILE_LOG_BLOCK_SIZE) {
-      /* Log data for this group ends here */
-
-      *finished = true;
-    } else {
-      log_block += OS_FILE_LOG_BLOCK_SIZE;
-    }
-  }
-
-  *group_scanned_lsn = scanned_lsn;
-
-  /* ===== write log to 'xtrabackup_logfile' ====== */
-  if (!*finished) {
-    write_size = RECV_SCAN_SIZE;
-  } else {
-    write_size =
-        ut_uint64_align_up(scanned_lsn, OS_FILE_LOG_BLOCK_SIZE) - start_lsn;
-    if (!is_last && scanned_lsn % OS_FILE_LOG_BLOCK_SIZE) {
-      write_size -= OS_FILE_LOG_BLOCK_SIZE;
-    }
-  }
-
-  byte encrypted_buf[4 * UNIV_PAGE_SIZE_MAX];
-  byte *write_buf = log_sys->buf;
-
-  if (srv_redo_log_encrypt) {
-    IORequest req_type(IORequestLogWrite);
-    fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
-    fil_io_set_encryption(req_type, page_id_t(space->id, 0), space);
-    Encryption encryption(req_type.encryption_algorithm());
-    ulint dst_len = write_size;
-    write_buf = encryption.encrypt_log(req_type, log_sys->buf, write_size,
-                                       encrypted_buf, &dst_len);
-    ut_a(write_size == dst_len);
-  }
-
-  if (ds_write(dst_log_file, write_buf, write_size)) {
-    msg("xtrabackup: Error: "
-        "write to logfile failed\n");
-    return (false);
-  }
-
-  if (more_data && !recv_sys->found_corrupt_log) {
-    /* Try to parse more log records */
-
-    recv_parse_log_recs(checkpoint_lsn);
-
-    if (recv_sys->recovered_offset > RECV_PARSING_BUF_SIZE / 4) {
-      /* Move parsing buffer data to the buffer start */
-
-      recv_reset_buffer();
-    }
-  }
-
-  return (true);
-}
-
-static bool xtrabackup_copy_logfile(log_t &log, lsn_t from_lsn, bool is_last) {
-  /* definition from recv_recovery_from_checkpoint_start() */
-  lsn_t scanned_lsn;
-  lsn_t contiguous_lsn;
-
-  ut_a(dst_log_file != NULL);
-
-  /* read from checkpoint_lsn_start to current */
-  contiguous_lsn = ut_uint64_align_down(from_lsn, OS_FILE_LOG_BLOCK_SIZE);
-
-  bool finished;
-  lsn_t start_lsn;
-  lsn_t end_lsn;
-
-  /* reference recv_group_scan_log_recs() */
-  finished = false;
-
-  start_lsn = contiguous_lsn;
-  scanned_lsn = start_lsn;
-
-  while (!finished) {
-    end_lsn = start_lsn + RECV_SCAN_SIZE;
-
-    xtrabackup_io_throttling();
-
-    recv_read_log_seg(log, log.buf, start_lsn, end_lsn);
-
-    if (!xtrabackup_scan_log_recs(log, is_last, start_lsn, &contiguous_lsn,
-                                  &scanned_lsn, from_lsn, &finished)) {
-      goto error;
-    }
-
-    start_lsn = end_lsn;
-  }
-
-  log.scanned_lsn = scanned_lsn;
-
-  msg_ts(">> log scanned up to (" LSN_PF ")\n", log.scanned_lsn);
-
-  /* update global variable*/
-  log_copy_scanned_lsn = scanned_lsn;
-
-  debug_sync_point("xtrabackup_copy_logfile_pause");
-
-  return (FALSE);
-
-error:
-  ds_close(dst_log_file);
-  msg("xtrabackup: Error: xtrabackup_copy_logfile() failed.\n");
-  return (TRUE);
-}
-
-static void log_copying_thread() {
-  /*
-    Initialize mysys thread-specific memory so we can
-    use mysys functions in this thread.
-  */
-  my_thread_init();
-
-  ut_a(dst_log_file != NULL);
-
-  log_copying_running = true;
-
-  while (log_copying || log_copy_scanned_lsn < log_copying_stop_lsn) {
-    os_event_reset(log_copying_stop);
-    os_event_wait_time_low(log_copying_stop,
-                           xtrabackup_log_copy_interval * 1000ULL, 0);
-    if (xtrabackup_copy_logfile(*log_sys, log_copy_scanned_lsn, false)) {
-      exit(EXIT_FAILURE);
-    }
-  }
-
-  /* last copying */
-  if (xtrabackup_copy_logfile(*log_sys, log_copy_scanned_lsn, true)) {
-    exit(EXIT_FAILURE);
-  }
-
-  log_copying_running = false;
-  my_thread_end();
-}
-
 /* io throttle watching (rough) */
 void io_watching_thread() {
   /* currently, for --backup only */
@@ -3218,7 +2938,7 @@ void io_watching_thread() {
 
   io_watching_thread_running = true;
 
-  while (log_copying) {
+  while (!io_watching_thread_stop) {
     os_thread_sleep(1000000); /*1 sec*/
     io_ticket = xtrabackup_throttle;
     os_event_set(wait_throttle);
@@ -3427,10 +3147,10 @@ static void xb_fil_io_init(void)
 /****************************************************************************
 Populates the tablespace memory cache by scanning for and opening data files.
 @returns DB_SUCCESS or error code.*/
-static ulint xb_load_tablespaces(void)
+static dberr_t xb_load_tablespaces(void)
 /*=====================*/
 {
-  ulint err;
+  dberr_t err;
   page_no_t sum_of_new_sizes;
   lsn_t flush_lsn;
 
@@ -3863,88 +3583,6 @@ static void xb_filters_free() {
 }
 
 /*********************************************************************/ /**
- Creates or opens the log files and closes them.
- @return	DB_SUCCESS or error code */
-static ulint open_or_create_log_file(
-    /*====================*/
-    bool create_new_db,            /*!< in: true if we should create a
-                                   new database */
-    bool *log_file_created,        /*!< out: true if new log file
-                                   created */
-    bool log_file_has_been_opened, /*!< in: true if a log file has been
-                                  opened before: then it is an error
-                                  to try to create another log file */
-    ulint k,                       /*!< in: log group number */
-    ulint i,                       /*!< in: log file number in group */
-    fil_space_t **log_space)       /*!< out: log space */
-{
-  bool ret;
-  os_offset_t size;
-  char name[10000];
-  ulint dirnamelen;
-
-  UT_NOT_USED(create_new_db);
-  UT_NOT_USED(log_file_has_been_opened);
-  UT_NOT_USED(k);
-  ut_ad(k == 0);
-
-  *log_file_created = false;
-
-  Fil_path::normalize(srv_log_group_home_dir);
-
-  dirnamelen = strlen(srv_log_group_home_dir);
-  ut_a(dirnamelen < (sizeof name) - 10 - sizeof "ib_logfile");
-  memcpy(name, srv_log_group_home_dir, dirnamelen);
-
-  /* Add a path separator if needed. */
-  if (dirnamelen && name[dirnamelen - 1] != OS_PATH_SEPARATOR) {
-    name[dirnamelen++] = OS_PATH_SEPARATOR;
-  }
-
-  sprintf(name + dirnamelen, "%s%lu", "ib_logfile", (ulong)i);
-
-  pfs_os_file_t file = os_file_create(0, name, OS_FILE_OPEN, OS_FILE_NORMAL,
-                                      OS_LOG_FILE, true, &ret);
-  if (!ret) {
-    fprintf(stderr, "InnoDB: Error in opening %s\n", name);
-
-    return (DB_ERROR);
-  }
-
-  size = os_file_get_size(file);
-
-  if (size != srv_log_file_size) {
-    fprintf(stderr,
-            "InnoDB: Error: log file %s is of different size " UINT64PF
-            " bytes\n"
-            "InnoDB: than specified in the .cnf file %llu bytes!\n",
-            name, size, srv_log_file_size * UNIV_PAGE_SIZE);
-
-    return (DB_ERROR);
-  }
-
-  ret = os_file_close(file);
-  ut_a(ret);
-
-  if (i == 0) {
-    /* Create in memory the file space object
-    which is for this log group */
-
-    *log_space = fil_space_create(
-        name, 2 * k + dict_sys_t::s_log_space_first_id,
-        fsp_flags_set_page_size(0, univ_page_size), FIL_TYPE_LOG);
-  }
-
-  ut_a(*log_space != NULL);
-  ut_ad(fil_validate());
-
-  ut_a(fil_node_create(name, srv_log_file_size / univ_page_size.physical(),
-                       *log_space, false, false) != NULL);
-
-  return (DB_SUCCESS);
-}
-
-/*********************************************************************/ /**
  Normalizes init parameter values to use units we use inside InnoDB.
  @return	DB_SUCCESS or error code */
 static void xb_normalize_init_values(void)
@@ -4087,7 +3725,6 @@ static void cleanup_mysql_environment() {
 
 void xtrabackup_backup_func(void) {
   MY_STAT stat_info;
-  lsn_t latest_cp;
   uint i;
   uint count;
   ib_mutex_t count_mutex;
@@ -4193,77 +3830,26 @@ void xtrabackup_backup_func(void) {
     xb_tables_compatibility_check();
   }
 
-  {
-    bool log_file_created = false;
-    bool log_created = false;
-    bool log_opened = false;
-    ulint err;
-    ulint i;
-    fil_space_t *log_space = nullptr;
+  srv_is_being_started = true;
 
-    srv_is_being_started = true;
+  os_create_block_cache();
 
-    os_create_block_cache();
+  xb_fil_io_init();
 
-    xb_fil_io_init();
+  Redo_Log_Data_Manager redo_mgr;
 
-    dict_persist_init();
+  dict_persist_init();
 
-    srv_n_log_files = (ulint)innobase_log_files_in_group;
-    srv_log_file_size = (ulint)innobase_log_file_size;
+  srv_n_log_files = (ulint)innobase_log_files_in_group;
+  srv_log_file_size = (ulint)innobase_log_file_size;
 
-    if (!log_sys_init(srv_n_log_files, srv_log_file_size,
-                      dict_sys_t::s_log_space_first_id)) {
-      exit(EXIT_FAILURE);
-    }
+  clone_init();
 
-    recv_sys_create();
-    recv_sys_init(buf_pool_get_curr_size());
+  lock_sys_create(srv_lock_table_size);
 
-    clone_init();
-
-    lock_sys_create(srv_lock_table_size);
-
-    ut_a(srv_n_log_files > 0);
-
-    for (i = 0; i < srv_n_log_files; i++) {
-      err = open_or_create_log_file(false, &log_file_created, log_opened, 0, i,
-                                    &log_space);
-      if (err != DB_SUCCESS) {
-        exit(EXIT_FAILURE);
-      }
-
-      if (log_file_created) {
-        log_created = TRUE;
-      } else {
-        log_opened = TRUE;
-      }
-      if ((log_opened && log_created)) {
-        msg("xtrabackup: Error: all log files must be created at the same "
-            "time.\n"
-            "xtrabackup: All log files must be created also in database "
-            "creation.\n"
-            "xtrabackup: If you want bigger or smaller log files, shut down "
-            "the\n"
-            "xtrabackup: database and make sure there were no errors in "
-            "shutdown.\n"
-            "xtrabackup: Then delete the existing log files. Edit the .cnf "
-            "file\n"
-            "xtrabackup: and start the database again.\n");
-
-        exit(EXIT_FAILURE);
-      }
-    }
-
-    /* log_file_created must not be TRUE, if online */
-    if (log_file_created) {
-      msg("xtrabackup: Something wrong with source files...\n");
-      exit(EXIT_FAILURE);
-    }
-
-    ut_a(log_space != nullptr);
-
-    log_read_encryption();
+  redo_mgr.set_copy_interval(xtrabackup_log_copy_interval);
+  if (!redo_mgr.init()) {
+    exit(EXIT_FAILURE);
   }
 
   /* create extra LSN dir if it does not exist. */
@@ -4283,198 +3869,110 @@ void xtrabackup_backup_func(void) {
     exit(EXIT_FAILURE);
   }
 
-  {
-    /* definition from recv_recovery_from_checkpoint_start() */
-    ulint max_cp_field;
-    byte *buf;
-    byte *log_hdr_buf_;
-    byte *log_hdr_buf;
-    ulint err;
+  xtrabackup_init_datasinks();
 
-    /* start back ground thread to copy newer log */
-    datafiles_iter_t *it;
+  if (!select_history()) {
+    exit(EXIT_FAILURE);
+  }
 
-    log_hdr_buf_ = static_cast<byte *>(
-        ut_malloc_nokey(LOG_FILE_HDR_SIZE + UNIV_PAGE_SIZE_MAX));
-    log_hdr_buf =
-        static_cast<byte *>(ut_align(log_hdr_buf_, UNIV_PAGE_SIZE_MAX));
+  io_ticket = xtrabackup_throttle;
+  wait_throttle = os_event_create("wait_throttle");
+  os_thread_create(PFS_NOT_INSTRUMENTED, io_watching_thread).start();
 
-    /* get current checkpoint_lsn */
-    /* Look for the latest checkpoint from any of the log groups */
+  if (!redo_mgr.start()) {
+    exit(EXIT_FAILURE);
+  }
 
-    err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
+  Tablespace_map::instance().scan(mysql_connection);
 
-    if (err != DB_SUCCESS) {
-      ut_free(log_hdr_buf_);
-      exit(EXIT_FAILURE);
+  /* Populate fil_system with tablespaces to copy */
+  dberr_t err = xb_load_tablespaces();
+  if (err != DB_SUCCESS) {
+    msg("xtrabackup: error: xb_load_tablespaces() failed with error code "
+        "%u\n",
+        err);
+    exit(EXIT_FAILURE);
+  }
+
+  /* FLUSH CHANGED_PAGE_BITMAPS call */
+  if (!flush_changed_page_bitmaps()) {
+    exit(EXIT_FAILURE);
+  }
+  debug_sync_point("xtrabackup_suspend_at_start");
+
+  if (xtrabackup_incremental) {
+    if (!xtrabackup_incremental_force_scan && have_changed_page_bitmaps) {
+      changed_page_bitmap =
+          xb_page_bitmap_init(redo_mgr.get_start_checkpoint_lsn());
     }
-
-    log_files_header_read(*log_sys, max_cp_field);
-    buf = log_sys->checkpoint_buf;
-
-    checkpoint_lsn_start = mach_read_from_8(buf + LOG_CHECKPOINT_LSN);
-    checkpoint_no_start = mach_read_from_8(buf + LOG_CHECKPOINT_NO);
-
-  reread_log_header:
-    err = fil_io(IORequest(IORequest::READ), true,
-                 page_id_t(log_sys->files_space_id, 0), univ_page_size, 0,
-                 LOG_FILE_HDR_SIZE, log_hdr_buf, nullptr);
-
-    if (err != DB_SUCCESS) {
-      ut_free(log_hdr_buf_);
-      exit(EXIT_FAILURE);
+    if (!changed_page_bitmap) {
+      msg("xtrabackup: using the full scan for incremental backup\n");
+    } else if (incremental_lsn != redo_mgr.get_start_checkpoint_lsn()) {
+      /* Do not print that bitmaps are used when dummy bitmap
+      is build for an empty LSN range. */
+      msg("xtrabackup: using the changed page bitmap\n");
     }
+  }
 
-    /* check consistency of log file header to copy */
+  ut_a(xtrabackup_parallel > 0);
 
-    err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
+  if (xtrabackup_parallel > 1) {
+    msg("xtrabackup: Starting %u threads for parallel data files transfer\n",
+        xtrabackup_parallel);
+  }
 
-    if (err != DB_SUCCESS) {
-      ut_free(log_hdr_buf_);
-      exit(EXIT_FAILURE);
-    }
+  if (opt_lock_ddl_per_table) {
+    mdl_lock_init();
+  }
 
-    log_files_header_read(*log_sys, max_cp_field);
-    buf = log_sys->checkpoint_buf;
+  auto it = datafiles_iter_new();
+  if (it == NULL) {
+    msg("xtrabackup: Error: datafiles_iter_new() failed.\n");
+    exit(EXIT_FAILURE);
+  }
 
-    if (checkpoint_no_start != mach_read_from_8(buf + LOG_CHECKPOINT_NO)) {
-      checkpoint_lsn_start = mach_read_from_8(buf + LOG_CHECKPOINT_LSN);
-      checkpoint_no_start = mach_read_from_8(buf + LOG_CHECKPOINT_NO);
-      goto reread_log_header;
-    }
+  /* Create data copying threads */
+  data_threads = (data_thread_ctxt_t *)ut_malloc_nokey(
+      sizeof(data_thread_ctxt_t) * xtrabackup_parallel);
+  count = xtrabackup_parallel;
+  mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &count_mutex);
 
-    xtrabackup_init_datasinks();
+  for (i = 0; i < (uint)xtrabackup_parallel; i++) {
+    data_threads[i].it = it;
+    data_threads[i].num = i + 1;
+    data_threads[i].count = &count;
+    data_threads[i].count_mutex = &count_mutex;
+    data_threads[i].error = &data_copying_error;
+    os_thread_create(PFS_NOT_INSTRUMENTED, data_copy_thread_func,
+                     data_threads + i)
+        .start();
+  }
 
-    if (!select_history()) {
-      exit(EXIT_FAILURE);
-    }
-
-    /* open the log file */
-    memset(&stat_info, 0, sizeof(MY_STAT));
-    dst_log_file = ds_open(ds_redo, XB_LOG_FILENAME, &stat_info);
-    if (dst_log_file == NULL) {
-      msg("xtrabackup: error: failed to open the target stream for '%s'.\n",
-          XB_LOG_FILENAME);
-      ut_free(log_hdr_buf_);
-      exit(EXIT_FAILURE);
-    }
-
-    /* label it */
-    strcpy((char *)log_hdr_buf + LOG_HEADER_CREATOR, "xtrabkup ");
-    ut_sprintf_timestamp((char *)log_hdr_buf +
-                         (LOG_HEADER_CREATOR + (sizeof "xtrabkup ") - 1));
-
-    if (ds_write(dst_log_file, log_hdr_buf, LOG_FILE_HDR_SIZE)) {
-      msg("xtrabackup: error: write to logfile failed\n");
-      ut_free(log_hdr_buf_);
-      exit(EXIT_FAILURE);
-    }
-
-    ut_free(log_hdr_buf_);
-
-    /* start flag */
-    log_copying = TRUE;
-
-    /* start io throttle */
-    if (xtrabackup_throttle) {
-      io_ticket = xtrabackup_throttle;
-      wait_throttle = os_event_create("wait_throttle");
-
-      os_thread_create(PFS_NOT_INSTRUMENTED, io_watching_thread).start();
-    }
-
-    /* copy log file by current position */
-    if (xtrabackup_copy_logfile(*log_sys, checkpoint_lsn_start, FALSE))
-      exit(EXIT_FAILURE);
-
-    log_copying_stop = os_event_create("log_copying_stop");
-    os_thread_create(PFS_NOT_INSTRUMENTED, log_copying_thread).start();
-
-    Tablespace_map::instance().scan(mysql_connection);
-
-    /* Populate fil_system with tablespaces to copy */
-    err = xb_load_tablespaces();
-    if (err != DB_SUCCESS) {
-      msg("xtrabackup: error: xb_load_tablespaces() failed with error code "
-          "%lu\n",
-          err);
-      exit(EXIT_FAILURE);
-    }
-
-    /* FLUSH CHANGED_PAGE_BITMAPS call */
-    if (!flush_changed_page_bitmaps()) {
-      exit(EXIT_FAILURE);
-    }
-    debug_sync_point("xtrabackup_suspend_at_start");
-
-    if (xtrabackup_incremental) {
-      if (!xtrabackup_incremental_force_scan && have_changed_page_bitmaps) {
-        changed_page_bitmap = xb_page_bitmap_init();
-      }
-      if (!changed_page_bitmap) {
-        msg("xtrabackup: using the full scan for incremental backup\n");
-      } else if (incremental_lsn != checkpoint_lsn_start) {
-        /* Do not print that bitmaps are used when dummy bitmap
-        is build for an empty LSN range. */
-        msg("xtrabackup: using the changed page bitmap\n");
-      }
-    }
-
-    ut_a(xtrabackup_parallel > 0);
-
-    if (xtrabackup_parallel > 1) {
-      msg("xtrabackup: Starting %u threads for parallel data files transfer\n",
-          xtrabackup_parallel);
-    }
-
-    if (opt_lock_ddl_per_table) {
-      mdl_lock_init();
-    }
-
-    it = datafiles_iter_new();
-    if (it == NULL) {
-      msg("xtrabackup: Error: datafiles_iter_new() failed.\n");
-      exit(EXIT_FAILURE);
-    }
-
-    /* Create data copying threads */
-    data_threads = (data_thread_ctxt_t *)ut_malloc_nokey(
-        sizeof(data_thread_ctxt_t) * xtrabackup_parallel);
-    count = xtrabackup_parallel;
-    mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &count_mutex);
-
-    for (i = 0; i < (uint)xtrabackup_parallel; i++) {
-      data_threads[i].it = it;
-      data_threads[i].num = i + 1;
-      data_threads[i].count = &count;
-      data_threads[i].count_mutex = &count_mutex;
-      data_threads[i].error = &data_copying_error;
-      os_thread_create(PFS_NOT_INSTRUMENTED, data_copy_thread_func,
-                       data_threads + i).start();
-    }
-
-    /* Wait for threads to exit */
-    while (1) {
-      os_thread_sleep(1000000);
-      mutex_enter(&count_mutex);
-      if (count == 0) {
-        mutex_exit(&count_mutex);
-        break;
-      }
+  /* Wait for threads to exit */
+  while (1) {
+    os_thread_sleep(1000000);
+    mutex_enter(&count_mutex);
+    if (count == 0) {
       mutex_exit(&count_mutex);
+      break;
     }
-
-    mutex_free(&count_mutex);
-    ut_free(data_threads);
-    datafiles_iter_free(it);
-
-    if (data_copying_error) {
+    if (redo_mgr.is_error()) {
+      msg("xtrabackup: error: log copyiing failed.\n");
       exit(EXIT_FAILURE);
     }
+    mutex_exit(&count_mutex);
+  }
 
-    if (changed_page_bitmap) {
-      xb_page_bitmap_deinit(changed_page_bitmap);
-    }
+  mutex_free(&count_mutex);
+  ut_free(data_threads);
+  datafiles_iter_free(it);
+
+  if (data_copying_error) {
+    exit(EXIT_FAILURE);
+  }
+
+  if (changed_page_bitmap) {
+    xb_page_bitmap_deinit(changed_page_bitmap);
   }
 
   Backup_context backup_ctxt;
@@ -4482,43 +3980,16 @@ void xtrabackup_backup_func(void) {
     exit(EXIT_FAILURE);
   }
 
-  /* read the latest checkpoint lsn */
-  latest_cp = 0;
-  {
-    ulint max_cp_field;
-    ulint err;
-
-    err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
-
-    if (err != DB_SUCCESS) {
-      msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
-      goto skip_last_cp;
-    }
-
-    log_files_header_read(*log_sys, max_cp_field);
-
-    latest_cp = mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_LSN);
-
-    msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
-        latest_cp);
+  if (!redo_mgr.stop_at(backup_ctxt.log_status.lsn)) {
+    exit(EXIT_FAILURE);
   }
-skip_last_cp:
-  /* stop log_copying_thread */
-  log_copying = FALSE;
-  log_copying_stop_lsn = backup_ctxt.log_status.lsn;
-  os_event_set(log_copying_stop);
-  msg("xtrabackup: Stopping log copying thread at LSN " LSN_PF ".\n",
-      backup_ctxt.log_status.lsn);
-  while (log_copying_running) {
-    msg(".");
-    os_thread_sleep(200000); /*0.2 sec*/
+  if (redo_mgr.is_error()) {
+    msg("xtrabackup: error: log copyiing failed.\n");
+    exit(EXIT_FAILURE);
   }
   msg("\n");
 
-  os_event_destroy(log_copying_stop);
-  if (ds_close(dst_log_file)) {
-    exit(EXIT_FAILURE);
-  }
+  io_watching_thread_stop = true;
 
   if (!xtrabackup_incremental) {
     strcpy(metadata_type_str, "full-backuped");
@@ -4527,8 +3998,8 @@ skip_last_cp:
     strcpy(metadata_type_str, "incremental");
     metadata_from_lsn = incremental_lsn;
   }
-  metadata_to_lsn = latest_cp;
-  metadata_last_lsn = log_copying_stop_lsn;
+  metadata_to_lsn = redo_mgr.get_last_checkpoint_lsn();
+  metadata_last_lsn = redo_mgr.get_stop_lsn();
 
   if (!xtrabackup_stream_metadata(ds_meta)) {
     msg("xtrabackup: Error: failed to stream metadata.\n");
@@ -4586,7 +4057,8 @@ skip_last_cp:
 
   msg("xtrabackup: Transaction log of lsn (" LSN_PF ") to (" LSN_PF
       ") was copied.\n",
-      checkpoint_lsn_start, log_copy_scanned_lsn);
+      redo_mgr.get_start_checkpoint_lsn(), redo_mgr.get_scanned_lsn());
+
   xb_filters_free();
 
   xb_data_files_close();
@@ -4605,7 +4077,7 @@ skip_last_cp:
 
   row_mysql_close();
 
-  log_sys_close();
+  redo_mgr.close();
 
   dict_persist_close();
 
@@ -4614,14 +4086,6 @@ skip_last_cp:
   xb_keyring_shutdown();
 
   cleanup_mysql_environment();
-
-  /* Make sure that the latest checkpoint made it to xtrabackup_logfile */
-  if (latest_cp > log_copy_scanned_lsn) {
-    msg("xtrabackup: error: last checkpoint LSN (" LSN_PF
-        ") is larger than last copied LSN (" LSN_PF ").\n",
-        latest_cp, log_copy_scanned_lsn);
-    exit(EXIT_FAILURE);
-  }
 }
 
 /* ================= stats ================= */
@@ -5706,8 +5170,7 @@ found:
   /* open the file and return it's handle */
 
   file = os_file_create_simple_no_error_handling(
-      0, real_name, create_option, OS_FILE_READ_WRITE,
-      srv_read_only_mode, &ok);
+      0, real_name, create_option, OS_FILE_READ_WRITE, srv_read_only_mode, &ok);
 
   if (ok) {
     *success = true;
@@ -6473,9 +5936,8 @@ xb_export_cfg_write_header(
  Write MySQL 5.6-style meta data config file.
  @return true in case of success otherwise false. */
 static bool xb_export_cfg_write(
-    const fil_node_t *node,
-    const dict_table_t *table) /*!< in: write the meta data for
-                               this table */
+    const fil_node_t *node, const dict_table_t *table) /*!< in: write the meta
+                                                       data for this table */
 {
   char file_path[FN_REFLEN];
   FILE *file;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -71,9 +71,6 @@ extern ds_ctxt_t *ds_meta;
 extern ds_ctxt_t *ds_data;
 extern ds_ctxt_t *ds_uncompressed_data;
 
-/* The last checkpoint LSN at the backup startup time */
-extern lsn_t checkpoint_lsn_start;
-
 extern xb_page_bitmap *changed_page_bitmap;
 
 extern ulint xtrabackup_rebuild_threads;

--- a/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
+++ b/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
@@ -1,0 +1,40 @@
+#
+# common test for log archiving
+#
+
+mysql -e "set global innodb_redo_log_archive_dirs='b:$TEST_VAR_ROOT/dir_b;a:$TEST_VAR_ROOT/dir_a'"
+
+load_sakila
+
+mysql -e "create table t (a int)" test
+
+mysql -e "insert into t (a) values (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+mysql -e "insert into t select * from t" test
+
+while true ; do
+      mysql -e "insert into t select * from t" test >/dev/null 2>/dev/null
+done &
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+
+xtrabackup --prepare --target-dir=$topdir/backup \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+start_server
+
+mysql -e "CHECKSUM TABLE t" test

--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -49,6 +49,7 @@ Usage: $0 [-f] [-g] [-h] [-s suite] [-t test_name] [-d mysql_basedir] [-c build_
 -j N        Run tests in N parallel processes.
 -T seconds  Test timeout (default is $TEST_TIMEOUT seconds).
 -x options  Extra options to pass to xtrabackup
+-X options  Extra options to pass to mysqld
 -r path     Use specified path as root directory for test workers.
 EOF
 }
@@ -751,7 +752,7 @@ SUBUNIT_OUT=test_results.subunit
 NWORKERS=
 DEBUG_WORKER=""
 
-while getopts "fgh?:t:s:d:c:j:T:x:i:r:" options; do
+while getopts "fgh?:t:s:d:c:j:T:x:X:i:r:" options; do
         case $options in
             f ) force="yes";;
             t )
@@ -791,6 +792,10 @@ recognized for compatibility";;
 
             x )
                 XB_EXTRA_MY_CNF_OPTS="$OPTARG"
+                ;;
+
+            X )
+                MYSQLD_EXTRA_MY_CNF_OPTS="$OPTARG"
                 ;;
 
             r )

--- a/storage/innobase/xtrabackup/test/t/xb_log_archiving.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_archiving.sh
@@ -1,0 +1,16 @@
+#
+# Basic test for using redo log archiving for backups
+#
+
+require_server_version_higher_than 8.0.16
+
+if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
+then
+    skip_test "Incompatible with AddressSanitizer"
+fi
+
+. inc/keyring_file.sh
+
+start_server
+
+. inc/xb_log_archiving.sh

--- a/storage/innobase/xtrabackup/test/t/xb_log_archiving_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_archiving_encrypt.sh
@@ -1,0 +1,20 @@
+#
+# Basic test for using redo log archiving for backups (encrypted)
+#
+
+require_server_version_higher_than 8.0.16
+
+if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
+then
+    skip_test "Incompatible with AddressSanitizer"
+fi
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_redo_log_encrypt
+"
+
+. inc/keyring_file.sh
+
+start_server
+
+. inc/xb_log_archiving.sh


### PR DESCRIPTION
When innodb_redo_log_archive_dirs is set, xtrabackup will try to
enable redo log archiving at the beginning of the backup. Once archived
log is cought up with the current LSN, xtrabackup will switch to
copying/streaming redo log records from the archive instead of the live
redo log. This will improve the case when backup destination is slower
than redo log storage.

If xtrabackup is unable to create or read redo log archive, it will log
error message and continue the backup using live redo logs.

Redo copying refactored:

- redo_log_data_manager to coordinate redo log copying
- redo_log_reader to read redo logs
- redo_log_writer to write redo logs
- redo_log_parser to parse redo logs

Log archiving:

- archived_redo_log_monitor to create and open redo log archive file
- archived_redo_log_read to read redo log from archive file

Added -X parameter to run.sh to pass additional options for MySQL server
when running the test suite