### PR TITLE
PXB-1905: Encrypted table is not restored when ADD/DROP INDEX is run …

### DIFF
--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -147,6 +147,7 @@ xb_fil_cur_open(
 	cursor->node = NULL;
 
 	cursor->space_id = node->space->id;
+	cursor->space_flags = node->space->flags;
 	cursor->is_system = !fil_is_user_tablespace_id(node->space->id);
 
 	strncpy(cursor->abs_path, node->name, sizeof(cursor->abs_path));

--- a/storage/innobase/xtrabackup/src/fil_cur.h
+++ b/storage/innobase/xtrabackup/src/fil_cur.h
@@ -64,6 +64,7 @@ struct xb_fil_cur_t {
 					buffer */
 	uint		thread_n;	/*!< thread number for diagnostics */
 	ulint		space_id;	/*!< ID of tablespace */
+	ulint		space_flags;	/*!< tablespace flags */
 	ulint		space_size;	/*!< space size in pages */
 	ulint		block_size;	/*!< FS block size */
 

--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -88,6 +88,7 @@ wf_incremental_init(xb_write_filt_ctxt_t *ctxt, char *dst_name,
 	info.page_size = cursor->page_size;
 	info.zip_size = cursor->zip_size;
 	info.space_id = cursor->space_id;
+	info.space_flags = cursor->space_flags;
 	if (!xb_write_delta_metadata(meta_name, &info)) {
 		msg("[%02u] xtrabackup: Error: "
 		    "failed to write meta info for %s\n",

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2346,6 +2346,7 @@ xb_read_delta_metadata(const char *filepath, xb_delta_info_t *info)
 	info->page_size = ULINT_UNDEFINED;
 	info->zip_size = ULINT_UNDEFINED;
 	info->space_id = ULINT_UNDEFINED;
+	info->space_flags = 0;
 
 	fp = fopen(filepath, "r");
 	if (!fp) {
@@ -2361,6 +2362,8 @@ xb_read_delta_metadata(const char *filepath, xb_delta_info_t *info)
 				info->zip_size = strtoul(value, NULL, 10);
 			} else if (strcmp(key, "space_id") == 0) {
 				info->space_id = strtoul(value, NULL, 10);
+			} else if (strcmp(key, "space_flags") == 0) {
+				info->space_flags = strtoul(value, NULL, 10);
 			}
 		}
 	}
@@ -2387,7 +2390,7 @@ my_bool
 xb_write_delta_metadata(const char *filename, const xb_delta_info_t *info)
 {
 	ds_file_t	*f;
-	char		buf[64];
+	char		buf[200];
 	my_bool		ret;
 	size_t		len;
 	MY_STAT		mystat;
@@ -2395,8 +2398,10 @@ xb_write_delta_metadata(const char *filename, const xb_delta_info_t *info)
 	snprintf(buf, sizeof(buf),
 		 "page_size = %lu\n"
 		 "zip_size = %lu\n"
-		 "space_id = %lu\n",
-		 info->page_size, info->zip_size, info->space_id);
+		 "space_id = %lu\n"
+		 "space_flags = %lu\n",
+		 info->page_size, info->zip_size, info->space_id,
+		 info->space_flags);
 	len = strlen(buf);
 
 	mystat.st_size = len;
@@ -6205,6 +6210,7 @@ xb_delta_open_matching_space(
 	const char*	dbname,		/* in: path to destination database dir */
 	const char*	name,		/* in: name of delta file (without .delta) */
 	ulint		space_id,	/* in: space id of delta file */
+	ulint		space_flags,	/* in: space flags of delta file */
 	ulint		zip_size,	/* in: zip_size of tablespace */
 	char*		real_name,	/* out: full path of destination file */
 	size_t		real_name_len,	/* out: buffer size for real_name */
@@ -6215,7 +6221,6 @@ xb_delta_open_matching_space(
 	bool			ok;
 	fil_space_t*		fil_space;
 	pfs_os_file_t		file	= XB_FILE_UNDEFINED;
-	ulint			tablespace_flags;
 	xb_filter_entry_t*	table;
 
 	*success = false;
@@ -6346,7 +6351,7 @@ xb_delta_open_matching_space(
 
 	/* No matching space found. create the new one.  */
 
-	if (!fil_space_create(dest_space_name, space_id, 0,
+	if (!fil_space_create(dest_space_name, space_id, space_flags,
 			      FIL_TYPE_TABLESPACE)) {
 		msg("xtrabackup: Cannot create tablespace %s\n",
 			dest_space_name);
@@ -6354,19 +6359,16 @@ xb_delta_open_matching_space(
 	}
 
 	/* Calculate correct tablespace flags for compressed tablespaces.  */
-	if (!zip_size || zip_size == ULINT_UNDEFINED) {
-		tablespace_flags = 0;
-	}
-	else {
-		tablespace_flags
-			= (get_bit_shift(zip_size >> PAGE_ZIP_MIN_SIZE_SHIFT
+	if (zip_size != 0 && zip_size != ULINT_UNDEFINED) {
+		space_flags
+			|= (get_bit_shift(zip_size >> PAGE_ZIP_MIN_SIZE_SHIFT
 					 << 1)
 			   << DICT_TF_ZSSIZE_SHIFT)
 			| DICT_TF_COMPACT
 			| (DICT_TF_FORMAT_ZIP << DICT_TF_FORMAT_SHIFT);
-		ut_a(page_size_t(tablespace_flags).physical() == zip_size);
+		ut_a(page_size_t(space_flags).physical() == zip_size);
 	}
-	*success = xb_space_create_file(real_name, space_id, tablespace_flags,
+	*success = xb_space_create_file(real_name, space_id, space_flags,
 					&file);
 	goto exit;
 
@@ -6481,9 +6483,10 @@ xtrabackup_apply_delta(
 
 	os_file_set_nocache(src_file.m_file, src_path, "OPEN");
 
-	dst_file = xb_delta_open_matching_space(
-			dbname, space_name, info.space_id, info.zip_size,
-			dst_path, sizeof(dst_path), &success);
+	dst_file = xb_delta_open_matching_space(dbname, space_name,
+						info.space_id, info.space_flags,
+						info.zip_size, dst_path,
+						sizeof(dst_path), &success);
 	if (!success) {
 		msg("xtrabackup: error: cannot open %s\n", dst_path);
 		goto error;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -43,6 +43,7 @@ typedef struct {
 	ulint	page_size;
 	ulint	zip_size;
 	ulint	space_id;
+	ulint	space_flags;
 } xb_delta_info_t;
 
 /* ======== Datafiles iterator ======== */


### PR DESCRIPTION
…on the table

Problem:

ALTER TABLE ... , ALGORITHM=COPY works as follows:

1. Create temp table
2. Copy data from original table into the temp table
3. Rename original table and temp table

Issue comes when full backup contains an version of the table and
.delta contains new version of the table. Special condition is
that the first page of the new table has not been flushed to the
dist yet.

In this case LSN of the first page in .delta will be 0 and the
page won't be included into .delta. Xtrabackup based in space_id
(stored in .meta) will guess that the table was altered, rename
old table into #xtrabackup_tmp_old_id.ibd and create tablespace
with new ID.

Because .meta does not contain space flags, they will be set as
default, then during apply log phase assertion will fail that
space flags indicate that space is not encrypted while it supposed
to be (encryption info record found).

Fix:

Store space flags into .meta