### PR TITLE
PXB-1915: MyRocks backups feature - renewing checkpoints

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -444,6 +444,9 @@ uint opt_read_buffer_size = 0;
 char *opt_rocksdb_datadir = nullptr;
 char *opt_rocksdb_wal_dir = nullptr;
 
+int opt_rocksdb_checkpoint_max_age = 0;
+int opt_rocksdb_checkpoint_max_count = 0;
+
 /** Possible values for system variable "innodb_checksum_algorithm". */
 extern const char *innodb_checksum_algorithm_names[];
 
@@ -627,6 +630,8 @@ enum options_xtrabackup {
 
   OPT_ROCKSDB_DATADIR,
   OPT_ROCKSDB_WAL_DIR,
+  OPT_ROCKSDB_CHECKPOINT_MAX_AGE,
+  OPT_ROCKSDB_CHECKPOINT_MAX_COUNT,
 
   OPT_COPY_BACK,
   OPT_MOVE_BACK,
@@ -1236,6 +1241,16 @@ struct my_option xb_client_options[] = {
     {"strict", OPT_XTRA_STRICT,
      "Fail with error when invalid arguments were passed to the xtrabackup.",
      (uchar *)&opt_strict, (uchar *)&opt_strict, 0, GET_BOOL, NO_ARG, 0, 0, 0,
+     0, 0, 0},
+
+    {"rocksdb-checkpoint-max-age", OPT_ROCKSDB_CHECKPOINT_MAX_AGE,
+     "Maximum ROCKSB checkpoint age in seconds.",
+     &opt_rocksdb_checkpoint_max_age, &opt_rocksdb_checkpoint_max_age, 0,
+     GET_INT, REQUIRED_ARG, 0, 0, INT_MAX, 0, 0, 0},
+
+    {"rocksdb-checkpoint-max-count", OPT_ROCKSDB_CHECKPOINT_MAX_COUNT,
+     "Maximum count of ROCKSB checkpoints.", &opt_rocksdb_checkpoint_max_count,
+     &opt_rocksdb_checkpoint_max_count, 0, GET_INT, REQUIRED_ARG, 0, 0, INT_MAX,
      0, 0, 0},
 
     {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}};

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -160,6 +160,8 @@ extern char *opt_binlog_index_name;
 
 extern char *opt_rocksdb_datadir;
 extern char *opt_rocksdb_wal_dir;
+extern int opt_rocksdb_checkpoint_max_age;
+extern int opt_rocksdb_checkpoint_max_count;
 
 extern const char *query_type_names[];
 

--- a/storage/innobase/xtrabackup/test/t/rocksdb_local_max_age.sh
+++ b/storage/innobase/xtrabackup/test/t/rocksdb_local_max_age.sh
@@ -1,0 +1,40 @@
+#
+# basic rocksdb backup test
+#
+
+require_rocksdb
+
+start_server
+
+FULL_BACKUP_CMD="xtrabackup
+    --backup
+    --target-dir=$topdir/backup
+    --parallel=10
+    --rocksdb-checkpoint-max-age=1
+    --rocksdb-checkpoint-max-count=10"
+
+INC_BACKUP_CMD="xtrabackup
+    --backup
+    --target-dir=$topdir/inc
+    --incremental-basedir=$topdir/backup
+    --parallel=10"
+
+FULL_PREPARE_CMD="xtrabackup
+    --prepare
+    --apply-log-only
+    --target-dir=$topdir/backup"
+
+INC_PREPARE_CMD="xtrabackup
+    --prepare
+    --target-dir=$topdir/backup
+    --incremental-dir=$topdir/inc
+    --parallel=10"
+
+CLEANUP_CMD="rm -rf $mysql_datadir"
+
+RESTORE_CMD="xtrabackup
+    --copy-back
+    --target-dir=$topdir/backup
+    --parallel=10"
+
+. inc/rocksdb_basic.sh


### PR DESCRIPTION
When backing up MyRocks datadir, xtrabackup creates checkpoint, captures
binlog coordinates and then copies the .SST files into the
backup. Copying may take a while. Then, if one want to setup new slave
or just apply binary logs on top of the backup, the size of binary logs
may become large.

This feature provides a way to minimize the size of binary logs and to
move binary coordinates closer to the moment when file copying
completes.

The idea is to create the checkpoint and copy .SST files. If copy took a
while, create next checkpoint and copy only new .SST files, second copy
should take less time. Repeat the process until copy time fall within
acceptable range.

Two xtrabackup parameters added:

- rocksdb-checkpoint-max-age - checkpoint shall not be older than this
  number of seconds when backup completes

- rocksdb-checkpoint-max-count - complete backup even if checkpoint age
  requirement has not been met after this number of checkpoints