### PR TITLE
PXB-1937: xtrabackup --move-back is failing due to encrypted binlog file

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1601,8 +1601,10 @@ struct binlog_file_location {
           r.path = buf + suffix;
         }
       } else {
+        char buf[FN_REFLEN];
+        fn_format(buf, name.c_str(), datadir.c_str(), "", MY_UNPACK_FILENAME);
         r.name = name;
-        r.path = path;
+        r.path = buf;
       }
     }
 
@@ -2255,6 +2257,7 @@ bool copy_back(int argc, char **argv) {
       if (!ret) {
         msg("xtrabackup: Error: failed to reencrypt binary log file "
             "header.\n");
+        goto cleanup;
       }
       /* make sure we don't copy binary log and .index files twice */
       skip_copy_back_list.insert(binlog.name.c_str());

--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -845,6 +845,10 @@ bool xb_binlog_password_reencrypt(const char *binlog_file_path) {
 
   auto header = binlog_header_read(binlog_file_path);
 
+  if (header == nullptr) {
+    return (false);
+  }
+
   Key_string file_password(key, ENCRYPTION_KEY_LEN);
   header->encrypt_file_password(file_password);
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1937.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1937.sh
@@ -1,0 +1,29 @@
+#
+# PXB-1937: xtrabackup --move-back is failing due to encrypted binlog file
+#
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+binlog-encryption
+log-bin=binlog
+"
+
+. inc/keyring_file.sh
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup --transition-key=123
+
+xtrabackup --prepare --target-dir=$topdir/backup --transition-key=123
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --no-defaults --datadir=$mysql_datadir \
+           --move-back --target-dir=$topdir/backup \
+           --generate-new-master-key \
+           --transition-key=123 \
+           --xtrabackup-plugin-dir=${plugin_dir} \
+           ${keyring_args}
+
+start_server


### PR DESCRIPTION
Problem:

When log-bin variable was set to default value, xtrabackup did not
properly expand the destination directory for the binary log file.

Fix:

1. Apply target datadir for the binary log path when performing
   copy-back/move-back and log-bin is not set
2. Check the return value of the binlog_header_read and exit gracefully
   in case of error