### PR TITLE
PXB-1928: PXB does not use the redo log archiving feature if label is…

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1,7 +1,7 @@
 /******************************************************
 Copyright (c) 2019 Percona LLC and/or its affiliates.
 
-Data sink interface.
+Redo log handling.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -682,14 +682,8 @@ void Archived_Redo_Log_Monitor::thread_func() {
     archive.filename.append(".000001.log");
 
     archive.label = dir.first;
-  }
 
-  if (archive.label.empty()) {
-    msg("xtrabackup: Redo Log Archiving is not used.\n");
-    free_mysql_variables(vars);
-    mysql_close(mysql);
-    my_thread_end();
-    return;
+    break;
   }
 
   free_mysql_variables(vars);
@@ -777,7 +771,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
 
   xb_mysql_query(mysql, "SELECT innodb_redo_log_archive_stop()", false);
   unlink(archive.filename.c_str());
-  rmdir(archive.subdir.c_str());
+  rmdir(archive.dir.c_str());
   mysql_close(mysql);
   my_thread_end();
 }

--- a/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
+++ b/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
@@ -20,7 +20,7 @@ mysql -e "insert into t select * from t" test
 mysql -e "insert into t select * from t" test
 
 while true ; do
-      mysql -e "insert into t select * from t" test >/dev/null 2>/dev/null
+    mysql -e "insert into t select * from t" test >/dev/null 2>/dev/null
 done &
 
 xtrabackup --backup --target-dir=$topdir/backup
@@ -38,3 +38,21 @@ xtrabackup --copy-back --target-dir=$topdir/backup \
 start_server
 
 mysql -e "CHECKSUM TABLE t" test
+
+# PXB-1928: PXB does not use the redo log archiving feature if label is not specified
+
+mysql -e "set global innodb_redo_log_archive_dirs=':$TEST_VAR_ROOT/dir_b'"
+
+xtrabackup --backup --target-dir=$topdir/bakup_pxb_1928 2> >( tee $topdir/pxb-1928 )
+
+if ! grep -q "Waiting for archive file" $topdir/pxb-1928 ; then
+    die "xtrabackup did not use redo log archiving"
+fi
+
+# PXB-1938: PXB leaves empty directories in redo log archive directory after backup
+
+ls $TEST_VAR_ROOT/dir_a
+ls $TEST_VAR_ROOT/dir_b
+
+[ "$( ls -A $TEST_VAR_ROOT/dir_a )" ] && die "directory $TEST_VAR_ROOT/dir_a is not empty" || true
+[ "$( ls -A $TEST_VAR_ROOT/dir_b )" ] && die "directory $TEST_VAR_ROOT/dir_b is not empty" || true


### PR DESCRIPTION
… not specified

Problem:

XtraBackup does not use redo log archiving when label is empty.

Fix:

Remove the check for empty label.

PXB-1938: PXB leaves empty directories in redo log archive directory after backup.

Problem:

When xtrabackup is trying to remove the subdir it uses relative name
which leads to rmdir failure.

Fix:

Call rmdir with absolute path.