### PR TITLE
PXB-1942: Backup fails when database is on a fast storage with redo a…

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -227,6 +227,9 @@ class Archived_Redo_Log_Monitor {
   /** Get first log block checksum from the archived redo log. */
   uint32_t get_first_log_block_checksum() const;
 
+  /** Read archived log until the given log block. */
+  void skip_for_block(lsn_t lsn, uint32_t no, uint32_t checksum);
+
  private:
   /** Parse the value of innodb_redo_log_archive_dirs. */
   void parse_archive_dirs(const std::string &s);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -258,8 +258,6 @@ lsn_t metadata_from_lsn = 0;
 lsn_t metadata_to_lsn = 0;
 lsn_t metadata_last_lsn = 0;
 
-#define XB_LOG_FILENAME "xtrabackup_logfile"
-
 ds_file_t *dst_log_file = NULL;
 
 static char mysql_data_home_buff[2];
@@ -3885,6 +3883,8 @@ void xtrabackup_backup_func(void) {
   if (!redo_mgr.init()) {
     exit(EXIT_FAILURE);
   }
+
+  debug_sync_point("after_redo_log_manager_init");
 
   /* create extra LSN dir if it does not exist. */
   if (xtrabackup_extra_lsndir &&

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -27,6 +27,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xbstream.h"
 #include "xtrabackup_config.h"
 
+#define XB_LOG_FILENAME "xtrabackup_logfile"
+
 #ifdef __WIN__
 #define XB_FILE_UNDEFINED {NULL};
 #else

--- a/storage/innobase/xtrabackup/test/t/pxb-1942.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1942.sh
@@ -1,0 +1,50 @@
+#
+# PXB-1942: Backup fails when database is on a fast storage with redo archive logs enabled
+#
+
+require_server_version_higher_than 8.0.16
+
+mkdir $TEST_VAR_ROOT/b
+
+start_server --innodb-redo-log-archive-dirs=":$TEST_VAR_ROOT/b"
+
+mysql -e "CREATE TABLE t (a INT)" test
+mysql -e "INSERT INTO t VALUES (1), (2), (3), (4)" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+
+mkdir $topdir/backup
+
+xtrabackup --backup --target-dir=$topdir/backup \
+           --debug-sync="after_redo_log_manager_init" \
+           2> >(tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+
+while true ; do
+    mysql -e "INSERT INTO t SELECT * FROM t" test 2>/dev/null >/dev/null
+done &
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+if ! grep -q "Archived redo log has caught up" $topdir/backup.log ; then
+    if ! grep -q "Switched to archived redo log starting with LSN" $topdir/backup.log ; then
+        die "Archived logs were not used"
+    fi
+fi


### PR DESCRIPTION
…rchive logs enabled

Problem:

It is possible that when archived redo log monitor has read the first
log block from the archive, the main redo log copying thread has ran
forward and in this case we need to pause log copying and wait for
archived log to catch up.

Fix:

When first log block number in the archive is lower than the current log
block number, pause log copying and wait for archived redo log to catch
up.