### PR TITLE
PXB-1936: --prepare cannot decrypt table but "completed ok"

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1692,6 +1692,11 @@ fil_write_encryption_parse(
 		if (!fsp_header_decode_encryption_info(key,
 						       iv,
 						       ptr)) {
+			if (!srv_backup_mode) {
+				ib::error() << "Cannot decode encryption "
+					       "information in the redo log.";
+				exit(EXIT_FAILURE);
+			}
 			return(ptr + len);
 		}
 	} else {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3687,6 +3687,9 @@ xb_load_single_table_tablespace(
 		if (xtrabackup_backup && err != DB_PAGE_IS_BLANK) {
 			exit(EXIT_FAILURE);
 		}
+		if (xtrabackup_prepare) {
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	ut_free(name);

--- a/storage/innobase/xtrabackup/test/t/pxb-1936.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1936.sh
@@ -1,0 +1,48 @@
+#
+# PXB-1936: --prepare cannot decrypt table but "completed ok"
+#
+
+require_server_version_higher_than 5.7.10
+
+. inc/keyring_file.sh
+
+start_server
+
+mysql -e "CREATE TABLE t (a INT) ENCRYPTION='y'" test
+
+mysql -e "INSERT INTO t VALUES (1), (2), (3), (4)" test
+
+( while true ; do
+    mysql -e "INSERT INTO t SELECT a + 10*$i FROM t ORDER BY a LIMIT 4" test
+    mysql -e "ALTER INSTANCE ROTATE INNODB MASTER KEY"
+    sleep 1
+done ) 2>/dev/null &
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --target-dir=$topdir/backup
+
+rm -rf $mysql_datadir
+rm -rf $topdir/backup
+
+start_server
+
+mysql -e "CREATE TABLE t (a INT) ENCRYPTION='y'" test
+
+mysql -e "INSERT INTO t VALUES (1), (2), (3), (4)" test
+
+innodb_wait_for_flush_all
+
+( while true ; do
+    mysql -e "INSERT INTO t SELECT a + 10*$i FROM t ORDER BY a LIMIT 4" test
+    mysql -e "ALTER INSTANCE ROTATE INNODB MASTER KEY"
+    sleep 1
+done ) 2>/dev/null &
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --target-dir=$topdir/backup


### PR DESCRIPTION
Problem:

InnoDB code doesn't make a difference between missing tablespace and the
tablespace which header cannot be decrypted. XtraBackup does not treat
missing tablespace as an error for many reasons.

Fix:

Terminate xtrabackup for two types of errors:

- xtrabackup was unable to open the tablespace at startup in "prepare"
  mode
- xtrabackup was unable to decrypt encrypted tablespace header from the
  redo log record