### PR TITLE
PXB-1951: PXB crashes when it cannot connect to server

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -642,7 +642,11 @@ void Archived_Redo_Log_Monitor::thread_func() {
   stopped = false;
   ready = false;
 
-  MYSQL *mysql = xb_mysql_connect();
+  auto mysql = xb_mysql_connect();
+  if (mysql == nullptr) {
+    my_thread_end();
+    return;
+  }
 
   char *redo_log_archive_dirs = nullptr;
   char *server_uuid = nullptr;

--- a/storage/innobase/xtrabackup/test/t/pxb-1951.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1951.sh
@@ -1,0 +1,11 @@
+#
+# PXB-1951: PXB crashes when it cannot connect to server
+#
+
+start_server --max-connections=2
+
+mysql -e "select sleep(1000);" &
+
+sleep 2
+
+xtrabackup --backup --target-dir=$topdir/backup


### PR DESCRIPTION
Problem:

When archived redo log monitor is trying to connect to the server,
it doesn't check if connection is successful and xtrabackup
crashes with segfault.

Fix:

When connection was not successful exit the archived redo log
monitor and continue backup without using archived logs.