### PR TITLE
PXB-1954: PXB gets stuck in prepare of full backup for encrypted tabl…

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -9317,14 +9317,6 @@ static void fil_tablespace_encryption_init(const fil_space_t *space) {
       ib::error(ER_IB_MSG_343) << "Can't set encryption information"
                                << " for tablespace" << space->name << "!";
     }
-
-    ut_free(key.iv);
-    ut_free(key.ptr);
-
-    key.iv = nullptr;
-    key.ptr = nullptr;
-
-    key.space_id = std::numeric_limits<space_id_t>::max();
   }
 }
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1954.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1954.sh
@@ -1,0 +1,37 @@
+#
+# PXB-1954: PXB gets stuck in prepare of full backup for encrypted tablespace
+#
+
+. inc/keyring_file.sh
+
+start_server
+
+mysql test <<EOF
+CREATE TABLE t (a INT) ENCRYPTION='y';
+EOF
+
+mysql -e "INSERT INTO t (a) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9)" test
+
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+
+( while true ; do
+      mysql -e "ALTER TABLE t ROW_FORMAT=COMPRESSED;" test
+      mysql -e "ALTER TABLE t ROW_FORMAT=DYNAMIC;" test
+      mysql -e "ALTER TABLE t ROW_FORMAT=COMPACT;" test
+      mysql -e "ALTER TABLE t ROW_FORMAT=REDUNDANT;" test
+  done ) >/dev/null 2>/dev/null &
+
+xtrabackup --lock-ddl --backup --target-dir=$topdir/backup \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+xtrabackup --prepare --target-dir=$topdir/backup \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}


### PR DESCRIPTION
…espace

Problem:

When tablespace has just been created its encryption info is not yet written
to the first page. In this case page will be still considered valid when
tablespace is opened for recovery. Encryption key will be read and set from
the redo log using fil_tablespace_encryption_init.

It is possible however that during apply log phase tablespace with the same id
is opened multiple times. Problem is that fil_tablespace_encryption_init erases
the key which it used once and next time tablespace is opened, the key is no
longer in the recv_sys->keys list.

Fix:

Do not erase the key from recv_sys->keys list after it has been used in
fil_tablespace_encryption_init.