### PR TITLE
PXB-1968 support of encryption version 3 of percona-server

### DIFF
--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -317,6 +317,10 @@ static const char ENCRYPTION_KEY_MAGIC_V1[] = "lCA";
 version. */
 static const char ENCRYPTION_KEY_MAGIC_V2[] = "lCB";
 
+/** Encryption magic bytes for 5.7.28+, it's for checking the encryption
+information version. */
+static const char ENCRYPTION_KEY_MAGIC_V3[] = "lCC";
+
 /** Encryption master key prifix */
 static const char ENCRYPTION_MASTER_KEY_PRIFIX[] = "INNODBKey";
 
@@ -365,6 +369,9 @@ struct Encryption {
 
 		/** Version in > 5.7.11 */
 		ENCRYPTION_VERSION_2 = 1,
+
+		/** Version in > 5.7.29 */
+		ENCRYPTION_VERSION_3 = 2,
 	};
 
 	/** Default constructor */
@@ -508,6 +515,10 @@ struct Encryption {
 
 	/** Current uuid of server instance */
 	static char		uuid[ENCRYPTION_SERVER_UUID_LEN + 1];
+
+	/** current maximum version, used to avoid writing V3 encryption on
+	old versions that support only upto V2 header */
+	static Version max_version;
 };
 
 /** Types for AIO operations @{ */

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -8898,6 +8898,9 @@ ulint	Encryption::master_key_id = 0;
 /** Current uuid of server instance */
 char	Encryption::uuid[ENCRYPTION_SERVER_UUID_LEN + 1] = {0};
 
+/** Default max_version */
+Encryption::Version Encryption::max_version = Encryption::ENCRYPTION_VERSION_2;
+
 /** Get current master key and master key id
 @param[in,out]	master_key_id	master key id
 @param[in,out]	master_key	master key
@@ -8914,7 +8917,7 @@ Encryption::get_master_key(ulint* master_key_id,
 	int	ret;
 
 	memset(key_name, 0, ENCRYPTION_KEY_LEN);
-	*version = Encryption::ENCRYPTION_VERSION_2;
+	*version = Encryption::max_version;
 
 	if (Encryption::master_key_id == 0) {
 		/* If m_master_key is 0, means there's no encrypted


### PR DESCRIPTION
Problem:
xtrabackup is not working when using encrypted tablespace
for PS version of 5.7.28-31

Analysis:
Percona server recent change of Encryption version 3
PS-5910 are not implemented in xtrabackup.

Fix:
Incorporate encryption V3 in xtracbackup so it can
backup encrypt tables using V3.

Reviewed by Satya Bodapati <satya.bodapati@percona.com>