### PR TITLE
PXB-1982 history table showing wrong value for lock_time

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1574,9 +1574,9 @@ backup_finish()
 	/* release all locks */
 	if (!opt_no_lock) {
 		unlock_all(mysql_connection);
-		history_lock_time = 0;
-	} else {
 		history_lock_time = time(NULL) - history_lock_time;
+	} else {
+		history_lock_time = 0;
 	}
 
 	if (opt_safe_slave_backup && sql_thread_started) {

--- a/storage/innobase/xtrabackup/test/t/history_on_server.sh
+++ b/storage/innobase/xtrabackup/test/t/history_on_server.sh
@@ -85,6 +85,15 @@ do
     check_for_value "$column" "N"
 done
 
+get_one_value "lock_time"
+lock_time_without_lock=$val
+
+if [ $val -lt 0 ];
+then	
+    vlog "Error: lock_time in history record invalid, expected > 0, got \"$val\""
+    exit 1
+fi
+
 check_for_value "format" "tar"
 
 # saving for later
@@ -102,7 +111,7 @@ vlog "Testing incremental based on history name"
 multi_row_insert incremental_sample.test \({101..200},100\)
 
 innobackupex --history=test1 --incremental \
---incremental-history-name=test1 $backup_dir > /dev/null
+--incremental-history-name=test1 --no-lock $backup_dir > /dev/null
 
 # saving for later
 get_one_value "uuid"
@@ -111,6 +120,8 @@ get_one_value "innodb_from_lsn"
 second_from_lsn=$val
 get_one_value "innodb_to_lsn"
 second_to_lsn=$val
+
+check_for_value "lock_time" "0"
 
 check_for_value "format" "file"
 check_for_value "incremental" "Y"


### PR DESCRIPTION
 PXB-1982 history table showing wrong value for lock_time

    In the backup history table, lock_time is shown as 0 when the database
    is locked and junk value when the database is not locked.

    Fix:
    Update lock_time to 0 if the database is not locked and if the database
    is locked then, time in seconds.
    With upstream, lock_time is the time between FTWRL and UNLOCK TABLES.
    With PS, lock_time is the time between LOCK BINLOG FOR BACKUP and UNLOCK TABLES
