### PR TITLE
PXB-2099 additional Undo files are not copied back

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1,6 +1,6 @@
 /******************************************************
 hot backup tool for InnoDB
-(c) 2009-2015 Percona LLC and/or its affiliates
+(c) 2009-2020 Percona LLC and/or its affiliates
 Originally Created 3/3/2009 Yasufumi Kinoshita
 Written by Alexey Kopytov, Aleksandr Kuzminsky, Stewart Smith, Vadim Tkachenko,
 Yasufumi Kinoshita, Ignacio Nin and Baron Schwartz.
@@ -1988,8 +1988,12 @@ static void copy_back_thread_func(datadir_thread_ctxt_t *ctx) {
 
     std::string dst_path = entry.rel_path;
 
-    if (file_purpose == FILE_PURPOSE_DATAFILE ||
-        file_purpose == FILE_PURPOSE_UNDO_LOG) {
+    if (file_purpose == FILE_PURPOSE_UNDO_LOG) {
+      /* undo tablespace can only be in undo_dir or data dir */
+      std::string dst_dir =
+          (srv_undo_dir && *srv_undo_dir) ? srv_undo_dir : mysql_data_home;
+      dst_path = dst_dir + "/" + dst_path;
+    } else if (file_purpose == FILE_PURPOSE_DATAFILE) {
       std::string tablespace_name = entry.path;
       /* Remove starting ./ and trailing .ibd/.ibu from tablespace name */
       tablespace_name = tablespace_name.substr(2, tablespace_name.length() - 6);

--- a/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
@@ -79,10 +79,163 @@ xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
 xtrabackup --copy-back --target-dir=$topdir/backup
 
 
-for file in $undo_directory_ext/undo1.ibu $undo_directory_ext/undo2.ibu \
-        $undo_directory/undo1.ibu $undo_directory/undo2.ibu \
-        $undo_directory_ext/undo3.ibu $undo_directory_ext/undo4.ibu \
+for file in $undo_directory/undo1.ibu $undo_directory/undo2.ibu \
         $undo_directory/undo3.ibu $undo_directory/undo4.ibu ; do
+    if [ ! -f $file ] ; then
+        vlog "Tablepace $file is missing!"
+        exit -1
+    fi
+done
+
+start_server
+
+# Check that the uncommitted transaction has been rolled back
+
+checksum2=`checksum_table sakila payment`
+test -n "$checksum2" || die "Failed to checksum table sakila.payment"
+
+vlog "Old checksum: $checksum1"
+vlog "New checksum: $checksum2"
+
+if [ "$checksum1" != "$checksum2"  ]
+then
+    vlog "Checksums do not match"
+    exit -1
+fi
+
+#start new test to see if undo_tablespace are moved in datadir if undo_tablespace is not specified
+
+stop_server
+
+rm -rf $MYSQLD_DATADIR/*
+rm -rf $undo_directory_ext/*
+rm -rf $topdir/*
+
+mkdir -p $undo_directory_ext
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_file_per_table=1
+innodb_undo_tablespaces=4
+innodb_directories=$undo_directory_ext
+"
+
+start_server
+# create some undo tablespaces
+mysql -e "CREATE UNDO TABLESPACE undo1 ADD DATAFILE '$undo_directory_ext/undo1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo2 ADD DATAFILE '$undo_directory_ext/undo2.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo3 ADD DATAFILE 'undo3.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo4 ADD DATAFILE 'undo4.ibu'"
+
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_001 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_002 SET INACTIVE"
+
+load_sakila
+
+checksum1=`checksum_table sakila payment`
+test -n "$checksum1" || die "Failed to checksum table sakila.payment"
+
+ls -al $undo_directory_ext
+# Start a transaction, modify some data and keep it uncommitted for the backup
+# stage. InnoDB avoids using the rollback segment in the system tablespace, if
+# separate undo tablespaces are used, so the test would fail if we did not
+# handle separate undo tablespaces correctly.
+start_uncomitted_transaction &
+job_master=$!
+
+xtrabackup --backup --target-dir=$topdir/backup
+kill -SIGKILL $job_master
+stop_server
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+data_dir=$topdir/restore
+MYSQLD_EXTRA_MY_CNF_OPTS="
+datadir=$data_dir
+"
+xtrabackup --copy-back --target-dir=$topdir/backup --datadir=$data_dir
+
+for file in $data_dir/undo1.ibu $data_dir/undo2.ibu \
+        $data_dir/undo3.ibu $data_dir/undo4.ibu ; do
+    if [ ! -f $file ] ; then
+        vlog "Tablepace $file is missing!"
+        exit -1
+    fi
+done
+
+start_server
+
+# Check that the uncommitted transaction has been rolled back
+
+checksum2=`checksum_table sakila payment`
+test -n "$checksum2" || die "Failed to checksum table sakila.payment"
+
+vlog "Old checksum: $checksum1"
+vlog "New checksum: $checksum2"
+
+if [ "$checksum1" != "$checksum2"  ]
+then
+    vlog "Checksums do not match"
+    exit -1
+fi
+
+#start new test to see if undo_tablespace are moved to  undo_directory if specified
+
+stop_server
+
+rm -rf $MYSQLD_DATADIR/*
+rm -rf $undo_directory_ext/*
+rm -rf $topdir/*
+rm -rf $undo_directory
+
+mkdir -p $undo_directory
+mkdir -p $undo_directory_ext
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_file_per_table=1
+innodb_undo_directory=$undo_directory
+innodb_undo_tablespaces=4
+innodb_directories=$undo_directory_ext
+"
+start_server
+
+# create some undo tablespaces
+mysql -e "CREATE UNDO TABLESPACE undo1 ADD DATAFILE '$undo_directory_ext/undo1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo2 ADD DATAFILE '$undo_directory_ext/undo2.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo3 ADD DATAFILE 'undo3.ibu'"
+mysql -e "CREATE UNDO TABLESPACE undo4 ADD DATAFILE 'undo4.ibu'"
+
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_001 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_002 SET INACTIVE"
+
+load_sakila
+
+checksum1=`checksum_table sakila payment`
+test -n "$checksum1" || die "Failed to checksum table sakila.payment"
+
+ls -al $undo_directory_ext
+ls -al $undo_directory
+# Start a transaction, modify some data and keep it uncommitted for the backup
+# stage. InnoDB avoids using the rollback segment in the system tablespace, if
+# separate undo tablespaces are used, so the test would fail if we did not
+# handle separate undo tablespaces correctly.
+start_uncomitted_transaction &
+job_master=$!
+
+xtrabackup --backup --target-dir=$topdir/backup
+kill -SIGKILL $job_master
+stop_server
+
+xtrabackup --prepare --target-dir=$topdir/backup
+data_dir=$topdir/restore
+undo_dir=$topdir/undo
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_undo_directory=$undo_dir
+datadir=$data_dir
+"
+xtrabackup --copy-back --target-dir=$topdir/backup --datadir=$data_dir --innodb_undo_directory=$undo_dir
+
+for file in $undo_dir/undo1.ibu $undo_dir/undo2.ibu \
+        $undo_dir/undo3.ibu $undo_dir/undo4.ibu ; do
     if [ ! -f $file ] ; then
         vlog "Tablepace $file is missing!"
         exit -1


### PR DESCRIPTION
Problem:
Undo files created with "Create Undo tablespace"
are not copied back to new data-directory/undo-directory.

Analysis:
Additional undo files are being considered as external files.
and backup tries to move them to its original location.

Fix:
Move additional undo files ending with .ibut to undo_directory or data directory