### PR TITLE
PXB-2124 General tablespaces are moved to the data directory after restore

### DIFF
--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -13,7 +13,7 @@ Prepares a server binary directory to be used by run.sh when running XtraBackup
 tests.
 
 If the argument is one of the build targets passed to build.sh
-(i.e. innodb51 innodb55 innodb56 xtradb51 xtradb55) then the
+(i.e. innodb80 innodb57 innodb56 xtradb80 xtradb57) then the
 appropriate Linux tarball is downloaded from a pre-defined location and
 unpacked into the specified installation  directory ('./server' by default).
 
@@ -54,12 +54,12 @@ function ssl_version()
 case "$1" in
     innodb80)
         url="https://dev.mysql.com/get/Downloads/MySQL-8.0"
-        tarball="mysql-8.0.18-linux-glibc2.12-${arch}.tar.xz"
+        tarball="mysql-8.0.19-linux-glibc2.12-${arch}.tar.xz"
         ;;
 
     xtradb80)
-        url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.15-6/binary/tarball"
-        tarball="Percona-Server-8.0.15-6-Linux.${arch}.ssl$(ssl_version).tar.gz"
+        url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.18-9/binary/tarball"
+        tarball="Percona-Server-8.0.18-9-Linux.${arch}.ssl$(ssl_version).tar.gz"
         ;;
 
     *)

--- a/storage/innobase/xtrabackup/test/t/bug1130627.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1130627.sh
@@ -24,31 +24,31 @@ EOF
 force_checkpoint
 
 # Test that specifying partitions with --tables works
-xtrabackup --backup --tables='^test.*#P#p5' --target-dir=$topdir/backup
+xtrabackup --backup --tables='^test.*#p#p5' --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup
 
 file_cnt=`ls $topdir/backup/test | wc -l`
 
 test "$file_cnt" -eq 1
 
-test -f $topdir/backup/test/t_innodb#P#p5.ibd
+test -f $topdir/backup/test/t_innodb#p#p5.ibd
 
 rm -rf $topdir/backup
 
 # Test that specifying partitions with --databases works
 
 xtrabackup --backup \
-    --databases='test.t_innodb#P#p5' --target-dir=$topdir/backup
+    --databases='test.t_innodb#p#p5' --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup
 
 test "$file_cnt" -eq 1
-test -f $topdir/backup/test/t_innodb#P#p5.ibd
+test -f $topdir/backup/test/t_innodb#p#p5.ibd
 
 rm -rf $topdir/backup
 
 # Test that specifying partitions with --tables-file works
 cat >$topdir/tables_file <<EOF
-test.t_innodb#P#p5
+test.t_innodb#p#p5
 EOF
 xtrabackup --backup --tables-file=$topdir/tables_file --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/pxb-1793.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1793.sh
@@ -9,7 +9,7 @@ MYSQLD_EXTRA_MY_CNF_OPTS="
 binlog-encryption
 innodb-undo-log-encrypt
 innodb-redo-log-encrypt
-innodb_encrypt_tables=ON
+default_table_encryption=on
 innodb_encrypt_online_alter_logs=ON
 innodb_temp_tablespace_encrypt=ON
 encrypt-tmp-files

--- a/storage/innobase/xtrabackup/test/t/shared_tablespace_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/shared_tablespace_encryption.sh
@@ -7,7 +7,7 @@ require_server_version_higher_than 8.0.13
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb-sys-tablespace-encrypt
-innodb-encrypt-tables=FORCE
+loose-innodb-default-encryption=on
 "
 
 . inc/keyring_file.sh


### PR DESCRIPTION
Problem:
If a general tablespace has file_name different from the tablespace
name, they are not restored to their original data directory.

Analysis:
Xtrabackup stores tablespace name and file_name path in a map.
While restoring it checks for file_name instead of tablespace name
and tries to find the entry in the map.If filename is different from
the tablespace name, it fails to get entry from the map.

Fix:
Rather storing tablespace_name on the map. save file_name and file_path.