### PR TITLE
PXB-1818 Provide a new flag --max-memory to improve performance by au…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -156,7 +156,10 @@ bool xtrabackup_print_param = FALSE;
 bool xtrabackup_export = FALSE;
 bool xtrabackup_apply_log_only = FALSE;
 
+
 longlong xtrabackup_use_memory = 100 * 1024 * 1024L;
+/* default value max memory is 50% of availabe memory */
+longlong xtrabackup_free_memory_per = 50;
 bool xtrabackup_create_ib_logfile = FALSE;
 
 long xtrabackup_throttle = 0; /* 0:unlimited */
@@ -543,6 +546,7 @@ enum options_xtrabackup {
   OPT_XTRA_APPLY_LOG_ONLY,
   OPT_XTRA_PRINT_PARAM,
   OPT_XTRA_USE_MEMORY,
+  OPT_XTRA_MAX_MEMORY,
   OPT_XTRA_THROTTLE,
   OPT_XTRA_LOG_COPY_INTERVAL,
   OPT_XTRA_INCREMENTAL,
@@ -731,6 +735,10 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_use_memory, (G_PTR *)&xtrabackup_use_memory, 0,
      GET_LL, REQUIRED_ARG, 100 * 1024 * 1024L, 1024 * 1024L, LLONG_MAX, 0,
      1024 * 1024L, 0},
+    {"max-free-memory-per", OPT_XTRA_MAX_MEMORY,
+     "Maximum free memory percentage of server can be used during prepare ",
+     (G_PTR *)&xtrabackup_free_memory_per, (G_PTR *)&xtrabackup_free_memory_per,
+     0, GET_LL, REQUIRED_ARG, 50, 0, LONG_MAX, 0, 1, 0},
     {"throttle", OPT_XTRA_THROTTLE,
      "limit count of IO operations (pairs of read&write) per second to IOS "
      "values (for '--backup')",
@@ -7246,6 +7254,7 @@ static void handle_options(int argc, char **argv, int *argc_client,
     opt_transition_key = get_tty_password("Enter transition key: ");
   }
 }
+
 
 void setup_error_messages() {
   my_default_lc_messages = &my_locale_en_US;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -132,6 +132,7 @@ extern ulint xtrabackup_log_copy_interval;
 extern char *xtrabackup_stream_str;
 extern long xtrabackup_throttle;
 extern longlong xtrabackup_use_memory;
+extern longlong xtrabackup_free_memory_per;
 
 extern bool opt_galera_info;
 extern bool opt_slave_info;


### PR DESCRIPTION
…to-tuning the value for --use-memory

Performance in PXB is heavily impacted by the memory provided to InnoDB during
"prepare" stages. If memory is less backup may have to swap pages multiple
 times between buffer pool and disk which increases io and slow down prepare.

The new flag "--max-free-memory-per" would allow backup to take up to that
percentage of free memory and allocate it to XtraBackup.
By default, it will auto-scale up to 50% of available memory.
Xtrabackup will start with default memory and based on the processing
it will increase the memory. Maximum free memory used depends on
"--max-free-memory-per" and server available memory.
If the user wants a fixed amount of memory it can be done by providing
"use-memory"