### PR TITLE
PXB-2152 new master key is written in standard error output

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2153,8 +2153,7 @@ bool copy_back(int argc, char **argv) {
     ulint master_key_id;
     Encryption::get_master_key(&master_key_id, &master_key);
 
-    msg_ts("Generated new master key with ID '%s-%lu'.\n", server_uuid,
-           master_key_id);
+    msg_ts("Generated new master key");
 
     my_free(master_key);
   }


### PR DESCRIPTION
Problem:
with generate-new-master-key, copy-back is printing the new
encryption-key

Fix
remove the printing of key in error messages