### PR TITLE
PXB-2152 new master key in written in standard error output

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2026,8 +2026,7 @@ copy_back(int argc, char **argv)
 					   &master_key,
 					   &version);
 
-		msg_ts("Generated new master key with ID '%s-%lu'.\n",
-		       server_uuid, master_key_id);
+		msg_ts("Generated new master key");
 
 	        my_free(master_key);
 


### PR DESCRIPTION
Problem:
with generate-new-master-key, copy-back is printing the new
encryption-key

Fix
remove the printing of key in error messages