### PR TITLE
PXB-1818 Provide a new flag --max-memory to improve performance by

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -85,6 +85,8 @@ bool meb_replay_file_ops = true;
 #endif /* !UNIV_HOTBACKUP */
 
 std::list<space_id_t> recv_encr_ts_list;
+extern longlong xtrabackup_use_memory;
+extern longlong xtrabackup_free_memory_per;
 
 /** Log records are stored in the hash table in chunks at most of this size;
 this must be less than UNIV_PAGE_SIZE as it is stored in the buffer pool */
@@ -3221,6 +3223,7 @@ automatically when the hash table becomes full.
                                 contiguous log data up to this lsn
 @param[out]	read_upto_lsn	scanning succeeded up to this lsn
 @param[in]  to_lsn LSN to stop scanning at
+@param[in,out]  true if the data is flushed to disk
 @return true if not able to scan any more in this log */
 #ifndef UNIV_HOTBACKUP
 static bool recv_scan_log_recs(log_t &log,
@@ -3230,7 +3233,7 @@ bool meb_scan_log_recs(
                                ulint max_memory, const byte *buf, ulint len,
                                lsn_t checkpoint_lsn, lsn_t start_lsn,
                                lsn_t *contiguous_lsn, lsn_t *read_upto_lsn,
-                               lsn_t to_lsn) {
+                               lsn_t to_lsn, bool *flushed) {
   const byte *log_block = buf;
   lsn_t scanned_lsn = start_lsn;
   bool finished = false;
@@ -3434,7 +3437,10 @@ bool meb_scan_log_recs(
 #ifndef UNIV_HOTBACKUP
     if (recv_heap_used() > max_memory) {
       recv_apply_hashed_log_recs(log, false);
+      ut_ad(*flushed == false);
+      *flushed = true;
     }
+
 #endif /* !UNIV_HOTBACKUP */
 
     if (recv_sys->recovered_offset > recv_sys->buf_len / 4) {
@@ -3627,15 +3633,62 @@ static void recv_recovery_begin(log_t &log, lsn_t *contiguous_lsn,
 
   bool finished = false;
 
+  static int redo_applied = 0;
+  static int redo_applied_total = 0;
+
+
+
   while (!finished) {
     lsn_t end_lsn = start_lsn + RECV_SCAN_SIZE;
 
     recv_read_log_seg(log, log.buf, start_lsn, end_lsn);
 
+    bool flushed = false;
     finished = recv_scan_log_recs(log, max_mem, log.buf, RECV_SCAN_SIZE,
                                   checkpoint_lsn, start_lsn, contiguous_lsn,
-                                  &log.scanned_lsn, to_lsn);
+                                  &log.scanned_lsn, to_lsn, &flushed);
 
+    redo_applied += RECV_SCAN_SIZE;
+    if (flushed) {
+      redo_applied_total += redo_applied;
+
+      auto pct = ((double)redo_applied / srv_log_file_size) * 100;
+      auto total_applied_per =
+          ((double)redo_applied_total / (double)srv_log_file_size) * 100;
+
+      ib::info() << "redo applied in last iteration:" << pct
+                 << "%\n total redo applied:" << total_applied_per << "%";
+
+      /* find availabe free memory */
+      auto free_memory =
+          (ulint)(double(sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE) *
+                         xtrabackup_free_memory_per) /
+                  100);
+
+      ib::info() << "Maximum memory for buffer pool:" << free_memory;
+
+      /* gradually increase the buffer pool until it can processed redo log in
+      one iteration or it hit threshold */
+      if (xtrabackup_use_memory == 100 * 1024 * 1024L &&
+          srv_buf_pool_size <= free_memory &&
+          pct <= (100 - total_applied_per)) {
+        srv_buf_pool_size *= 2;
+
+        if (srv_buf_pool_size > free_memory) srv_buf_pool_size = free_memory;
+        srv_buf_pool_size = buf_pool_size_align(srv_buf_pool_size);
+
+        ib::info() << " increasing the  buffer pool to " << srv_buf_pool_size;
+
+        os_event_set(srv_buf_resize_event);
+        buf_resize_thread();
+
+        max_mem = UNIV_PAGE_SIZE *
+                  (srv_buf_pool_size / UNIV_PAGE_SIZE -
+                   (recv_n_pool_free_frames * srv_buf_pool_instances));
+      }
+
+      redo_applied = 0;
+    }
     start_lsn = end_lsn;
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -157,6 +157,8 @@ bool xtrabackup_export = FALSE;
 bool xtrabackup_apply_log_only = FALSE;
 
 longlong xtrabackup_use_memory = 100 * 1024 * 1024L;
+/* Default free memory percentage used is 50 % of available free memory */
+longlong xtrabackup_free_memory_per = 50;
 bool xtrabackup_create_ib_logfile = FALSE;
 
 long xtrabackup_throttle = 0; /* 0:unlimited */
@@ -543,6 +545,7 @@ enum options_xtrabackup {
   OPT_XTRA_APPLY_LOG_ONLY,
   OPT_XTRA_PRINT_PARAM,
   OPT_XTRA_USE_MEMORY,
+  OPT_XTRA_MAX_MEMORY,
   OPT_XTRA_THROTTLE,
   OPT_XTRA_LOG_COPY_INTERVAL,
   OPT_XTRA_INCREMENTAL,
@@ -731,6 +734,10 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_use_memory, (G_PTR *)&xtrabackup_use_memory, 0,
      GET_LL, REQUIRED_ARG, 100 * 1024 * 1024L, 1024 * 1024L, LLONG_MAX, 0,
      1024 * 1024L, 0},
+    {"use-free-memory-pct", OPT_XTRA_MAX_MEMORY,
+     "Maximum free memory percentage of server can be used during prepare ",
+     (G_PTR *)&xtrabackup_free_memory_per, (G_PTR *)&xtrabackup_free_memory_per,
+     0, GET_LL, REQUIRED_ARG, 50, 0, LONG_MAX, 0, 1, 0},
     {"throttle", OPT_XTRA_THROTTLE,
      "limit count of IO operations (pairs of read&write) per second to IOS "
      "values (for '--backup')",
@@ -7239,6 +7246,7 @@ static void handle_options(int argc, char **argv, int *argc_client,
     opt_transition_key = get_tty_password("Enter transition key: ");
   }
 }
+
 
 void setup_error_messages() {
   my_default_lc_messages = &my_locale_en_US;

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -132,6 +132,7 @@ extern ulint xtrabackup_log_copy_interval;
 extern char *xtrabackup_stream_str;
 extern long xtrabackup_throttle;
 extern longlong xtrabackup_use_memory;
+extern longlong xtrabackup_free_memory_per;
 
 extern bool opt_galera_info;
 extern bool opt_slave_info;


### PR DESCRIPTION
auto-tunning value for --use-memory

Performance in PXB is heavily impacted by the memory provided to InnoDB during
"prepare" stages. If memory is less backup may have to swap pages multiple
 times between buffer pool and disk which increases io and slow down prepare.

The new flag "--use-free-memory-pct" would allow backup to take up to that
percentage of free memory and allocate it to XtraBackup.
By default, it will auto-scale up to 50% of available memory.
Xtrabackup will start with default memory and based on the processing
it will increase the memory. Maximum free memory used depends on
"--use-free-memory-per" and server available memory.
If the user wants a fixed amount of memory it can be done by providing
"use-memory"