### PR TITLE
Revert "[WIP]dont run FTWRL unless forced"

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1125,7 +1125,7 @@ bool lock_tables_maybe(MYSQL *connection, int timeout, int retry_count) {
     return (true);
   }
 
-  if (!force_ftwrl) {
+  if (have_backup_locks && !force_ftwrl) {
     return lock_tables_for_backup(connection, timeout, retry_count);
   }
 


### PR DESCRIPTION
Reverts percona/percona-xtrabackup#807

It is breaking the backup of MyISAM tables as they taking the LOCK INSTANCE FOR BACKUP
instead of FTRWL.