### PR TITLE
PXB-2179 keyring plugin is not shut down during prepare with generate…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6614,9 +6614,7 @@ skip_check:
     innodb_free_param();
   }
 
-  if (!use_dumped_tablespace_keys) {
-    xb_keyring_shutdown();
-  }
+  xb_keyring_shutdown();
 
   Tablespace_map::instance().serialize();
 
@@ -6628,9 +6626,7 @@ skip_check:
 
 error_cleanup:
 
-  if (!use_dumped_tablespace_keys) {
-    xb_keyring_shutdown();
-  }
+  xb_keyring_shutdown();
 
   xtrabackup_close_temp_log(FALSE);
 


### PR DESCRIPTION
…-transition-key

Problem:
when the backup is prepared with --generate-transition-key.
 It doesn't shut down the keyring plugin.

Fix:
Shutdown the keyring plugin always.
There is no need to check if it is initialized or not.