### PR TITLE
PXB-2155 : If redo logs are encrypted, xtrabackup --backup --compress=lz4 creates corrupt redo logs

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
@@ -221,7 +221,10 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len) {
 
     if (error) continue;
 
-    if (thd.to_len > 0) {
+    /* Compressing encrypted or already compressed
+    data the length of compression should exceed, in such case
+    skip the compression */
+    if (thd.to_len > 0 && thd.to_len < COMPRESS_CHUNK_SIZE) {
       /* compressed block length */
       if (write_uint32_le(dest_file, thd.to_len)) {
         error = true;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3108,17 +3108,23 @@ static void xtrabackup_init_datasinks(void) {
                        : DS_TYPE_COMPRESS_QUICKLZ);
     xtrabackup_add_datasink(ds);
     ds_set_pipe(ds, ds_data);
-    if (ds_data != ds_redo) {
+
+    /* disable redo compression if redo log is encrypt */
+    if (srv_redo_log_encrypt) {
       ds_data = ds;
-      ds = ds_create(xtrabackup_target_dir,
-                     xtrabackup_compress == XTRABACKUP_COMPRESS_LZ4
-                         ? DS_TYPE_COMPRESS_LZ4
-                         : DS_TYPE_COMPRESS_QUICKLZ);
-      xtrabackup_add_datasink(ds);
-      ds_set_pipe(ds, ds_redo);
-      ds_redo = ds;
     } else {
-      ds_redo = ds_data = ds;
+      if (ds_data != ds_redo) {
+        ds_data = ds;
+        ds = ds_create(xtrabackup_target_dir,
+                       xtrabackup_compress == XTRABACKUP_COMPRESS_LZ4
+                           ? DS_TYPE_COMPRESS_LZ4
+                           : DS_TYPE_COMPRESS_QUICKLZ);
+        xtrabackup_add_datasink(ds);
+        ds_set_pipe(ds, ds_redo);
+        ds_redo = ds;
+      } else {
+        ds_redo = ds_data = ds;
+      }
     }
   }
 }

--- a/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_redo_log_encrypt.sh
@@ -35,6 +35,14 @@ function test_do() {
 	job=$!
 
 	xtrabackup --backup --target-dir=$topdir/backup ${xtra_backup_args}
+
+	# for compressed backup xtrabackup_logfile should not be compressed since redo log is encrypted
+	if [[ $1 == *"compress"* ]]; then
+		test -f $topdir/backup/xtrabackup_logfile || die "xtrabackup_logfile file not found"
+		test -f $topdir/backup/undo_001 || die "undo_001 not found"
+		xtrabackup --decompress --target-dir=$topdir/backup
+	fi
+
 	xtrabackup --prepare --target-dir=$topdir/backup ${xtra_prepare_args}
 
 	record_db_state sakila
@@ -58,3 +66,4 @@ function test_do() {
 
 test_do "" "--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}" ""
 test_do "--transition-key=123_" "--transition-key=123_" "--transition-key=123_ --generate-new-key"
+test_do "--compress=lz4" "--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}" ""


### PR DESCRIPTION
Problem:
-------
If redo logs are encrypted, xtrabackup --backup --compress=lz4  creates
 corrupt redo logs

Analysis:
--------
when we compress the encrypted block, the size of the compressed block can be
greater than the original block. In such cases, we should skip the compression
of the block and write an uncompressed block to the stream otherwise
decompression would complain about this bigger size.

Fix:
---
It involves two fixes.
Disable the compression for the encrypted redo logs.
If the size of the lz4 compressed block is greater than the uncompressed,
skip the compression for that block and write an uncompressed block