### PR TITLE
PXB-2127 xbcloud fails to upload backups with empty database to min.io storage

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1397,7 +1397,7 @@ backup_files(const char *from, bool prep_mode)
 			/* backup fake file into empty directory */
 			char path[FN_REFLEN];
 			ut_snprintf(path, sizeof(path),
-					"%s/db.opt", node.filepath);
+					"%sdb.opt", node.filepath);
 			if (!(ret = backup_file_printf(
 					trim_dotslash(path), "%s", ""))) {
 				msg("Failed to create file %s\n", path);


### PR DESCRIPTION
Problem:
Xbcloud fails to upload data in minio with empty database.

Analysis:
xbcloud is placing dummy file /db.opt in an empty directory.
Path becomes /path/to//db.opt instead of /path/to/db.opt
minio assue path of the file as "/db.opt" and throws error
unspported file name.

Fix:
intead of /db.opt use db.opt as output file