### PR TITLE
PXB-2165 : xbcloud cannot store backups using s3 access key parameters if AWS access key env variables are set

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -408,6 +408,16 @@ static void get_env_args() {
   get_env_value(opt_swift_storage_url, "OS_STORAGE_URL");
   get_env_value(opt_cacert, "OS_CACERT");
 
+  /* Below block should always be above AWS_* and should not be moved because
+  the order of prefrence are like S3_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID and
+  ACCESS_KEY  */
+  get_env_value(opt_s3_access_key, "S3_ACCESS_KEY_ID");
+  get_env_value(opt_s3_secret_key, "S3_SECRET_ACCESS_KEY");
+  get_env_value(opt_s3_session_token, "S3_SESSION_TOKEN");
+  get_env_value(opt_s3_region, "S3_DEFAULT_REGION");
+  get_env_value(opt_cacert, "S3_CA_BUNDLE");
+  get_env_value(opt_s3_endpoint, "S3_ENDPOINT");
+
   get_env_value(opt_s3_access_key, "AWS_ACCESS_KEY_ID");
   get_env_value(opt_s3_secret_key, "AWS_SECRET_ACCESS_KEY");
   get_env_value(opt_s3_session_token, "AWS_SESSION_TOKEN");


### PR DESCRIPTION
Problem:
--------
If AWS prefix environment variables were set, then xbcloud didn't pick the
other environment variables. for example, If AWS_ACCESS_KEY_ID is set by
some application it did not pick set by ACCESS_KEY which would end up
using the wrong value for s3-access-key and unable to store the backup in
cloud

Analysis:
--------
These AWS prefix credentials are commonly used by other applications as well.
So If a user had set ACCESS_KEY_ID and another application had set
AWS_ACCESS_KEY_ID then xbcloud was pick AWS_ACCESS_KEY_ID and end up
using the wrong credentials.
PXB was giving preference to AWS prefix over other environment variables.

Fix:
---
Introduced new environment variables Prefix with S3 having high preference than AWS*
S3_ACCESS_KEY_ID,
S3_SECRET_ACCESS_KEY
S3_SESSION_TOKEN
S3_DEFAULT_REGION
S3_CA_BUNDLE
S3_ENDPOINT
like S3_ACCESS_KEY_ID preference would be above AWS_ACCESS_KEY_ID and
ACCESS_KEY_ID.So users can set S3 prefix variables and xbcloud would pick them
instead of the variable prefix with AWS.

order of preference:  higher(1) to lower (4)
1) s3 command line like --s3-access-key
2) S3 ENV
3) AWS ENV
4) ACCESS_KEY*