### PR TITLE
PXB-2127 xbcloud fails to upload backups with empty database to min.i…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1396,6 +1396,9 @@ backup_files(const char *from, bool prep_mode)
 		} else if (!prep_mode) {
 			/* backup fake file into empty directory */
 			char path[FN_REFLEN];
+			/* remove trailing / */
+			if(node.filepath[strlen(node.filepath) -1] == '/')
+				node.filepath[strlen(node.filepath) - 1] = '\0';
 			ut_snprintf(path, sizeof(path),
 					"%s/db.opt", node.filepath);
 			if (!(ret = backup_file_printf(

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -32,6 +32,8 @@ echo ${XBCLOUD_CREDENTIALS} | sed 's/ *--/\'$'\n/g' >> $topdir/xbcloud.cnf
 load_dbase_schema sakila
 load_dbase_data sakila
 
+mysql -e "CREATE database emptydatabas"
+
 now=$(date +%s)
 pwdpart=($(pwd | md5sum))
 


### PR DESCRIPTION
…o storage

Problem:
-----
xbcloud failed to upload backups with an empty database to min.io
It throws an error message: Object name contains unsupported characters.
Analysis:
Xbcloud is placing dummy file db.opt in an empty directory.
Path becomes /path/to//db.opt instead of /path/to/db.opt
minio assume name of the file as “/db.opt” and throws error
unspported file name.
Fix:
Make sure the complete path doesn’t contain // and contains only /.