### PR TITLE
Adding location constraint to the request body when creating a bucket

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -402,6 +402,9 @@ bool S3_client::create_bucket(const std::string &name) {
   Http_request req(Http_request::PUT, protocol, hostname(name),
                    bucketname(name) + "/");
   signer->sign_request(hostname(name), name, req, time(0));
+  req.append_payload("<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><LocationConstraint>");
+  req.append_payload(region);
+  req.append_payload("</LocationConstraint></CreateBucketConfiguration>");
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -401,11 +401,10 @@ Http_buffer S3_client::download_object(const std::string &bucket,
 bool S3_client::create_bucket(const std::string &name) {
   Http_request req(Http_request::PUT, protocol, hostname(name),
                    bucketname(name) + "/");
-  signer->sign_request(hostname(name), name, req, time(0));
   req.append_payload("<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><LocationConstraint>");
   req.append_payload(region);
   req.append_payload("</LocationConstraint></CreateBucketConfiguration>");
-
+  signer->sign_request(hostname(name), name, req, time(0));
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
     return false;


### PR DESCRIPTION
### Issue
When using a regional endpoint for S3 (specified with --s3-endpoint=...) and non-default region (--s3-region=...), the bucket will fail to be created due to AWS S3's location constraint missing from the request. See S3 API documents [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#API_CreateBucket_RequestBody).

Example error output:

```
200610 23:55:43 xbcloud_real: Successfully connected. 
200610 23:55:43 xbcloud_real: Failed to create bucket. Error message: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.
```