### PR TITLE
PXB-2202 Xbcloud does not display an error when xtrabackup fails to c…

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -696,20 +696,32 @@ bool xbcloud_put(Object_store *store, const std::string &container,
 
   xb_stream_read_done(stream);
 
-  bool ret = (res != XB_STREAM_READ_ERROR) && (!has_errors);
 
-  if (ret && upload_md5) {
-    msg_ts("%s: Uploading md5\n", my_progname);
-    ret = store->upload_object(container, backup_name + ".md5", buf_md5);
-  }
-
-  if (!ret) {
+  // check if backup directory exists and it has some files
+  if (res == XB_STREAM_READ_ERROR || has_errors ||
+      !store->list_objects_in_directory(container, backup_name, object_list) ||
+      object_list.size() == 0) {
     msg_ts("%s: Upload failed.\n", my_progname);
-  } else {
-    msg_ts("%s: Upload completed.\n", my_progname);
+    return false;
   }
 
-  return ret;
+  // check if xtrabackup_info, almost the last file exists in backup
+  if (std::count(object_list.begin(), object_list.end(),
+                 backup_name + "/xtrabackup_info.00000000000000000000") == 0) {
+    msg_ts("%s: Upload failed: backup is incomplete.\n", my_progname);
+    return false;
+  }
+
+  if (upload_md5) {
+    msg_ts("%s: Uploading md5\n", my_progname);
+    if (!store->upload_object(container, backup_name + ".md5", buf_md5)) {
+      msg_ts("%s: Upload failed: Error uploading md5.\n", my_progname);
+      return false;
+    }
+  }
+
+  msg_ts("%s: Upload completed.\n", my_progname);
+  return true;
 }
 
 bool chunk_name_to_file_name(const std::string &chunk_name,

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -122,9 +122,22 @@ fi
 #PXB-2198 xbcloud doesn't return the error on delete if the backup doesn't exist in s3 bucket
 xbcloud --defaults-file=$topdir/xbcloud.cnf delete somedummyjunkbackup 2>$topdir/pxb-2198.log
 
-if ! grep -q failed $topdir/pxb-2198.log ; then
+if ! grep -q "error: backup" $topdir/pxb-2198.log ; then
     die 'xbcloud did not exit with error on delete'
 fi
+
+#PXB-2202 Xbcloud does not display an error when xtrabackup fails to create a backup
+xtrabackup --backup --stream=xbstream --extra-lsndir=$full_backup_dir \
+	   --target-dir=/some/unknown/dir | \
+    run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+	    --parallel=4 \
+	    somedummyjunkbackup 2>$topdir/pxb-2202.log
+
+
+if ! grep -q "Upload failed" $topdir/pxb-2202.log ; then
+    die 'xbcloud did not exit with error on upload'
+fi
+
 # cleanup
 run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf delete \
 	${full_backup_name} --parallel=4


### PR DESCRIPTION
…reate a backup

Problem:
When xtrabackup fails to create a backup, xbcloud connects to cloud
and displays that the upload is completed.

Analysis:
Xtrabackup doesn't check if backup is sucessful or not.

Fix:
Check if backup is uploaded successfuly else error out.
Now PXB checks if backup folder is created and it has backup files in it