### PR TITLE
Increase biglog_pos variable-length to accomodate lengthy filename and GTID definitions

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1867,7 +1867,7 @@ write_xtrabackup_info(MYSQL *connection)
 		"start_time TIMESTAMP NULL DEFAULT NULL,"
 		"end_time TIMESTAMP NULL DEFAULT NULL,"
 		"lock_time BIGINT UNSIGNED DEFAULT NULL,"
-		"binlog_pos VARCHAR(128) DEFAULT NULL,"
+		"binlog_pos VARCHAR(256) DEFAULT NULL,"
 		"innodb_from_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"innodb_to_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"partial ENUM('Y', 'N') DEFAULT NULL,"


### PR DESCRIPTION
PXB in conjunction with MySQL Community 5.7.30, configured with GTID replication, sees the `--history` flag fail to create an entry in the `PERCONA_SCHEMA.xtrabackup_history` table.  This is due to the result exceeding the 128 character limit on the binlog_pos table.

A standard 160 character example that fails to insert: 

`binlog_pos: filename 'mysql-bin.000005', position '7995', GTID of the last change '49f6e2b4-540e-11ea-a79d-525400fb8fc1:1-16,
4d7eb16b-540e-11ea-ae55-525400fe033a:1-229248'`

This commit increases the limit and sees a successful transaction. 

This may be related to `PXB-1462` and should probably be cherry-picked into the `8.0` branch.