### PR TITLE
PXB-2229 Error out backup if redo logging is disabled

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -10867,7 +10867,7 @@ ER_XPLUGIN_FAILED_TO_BIND_INTERFACE_ADDRESS
   eng "Value '%s' set to `Mysqlx_bind_address`, X Plugin can't bind to it. Skipping this value."
 
 ER_IB_ERR_RECOVERY_REDO_DISABLED
-  eng "Server was killed when InnoDB redo logging was disabled. Data files could be corrupt. You can try to restart the database with innodb_force_recovery=6"
+  eng "Redo logging is disabled, cannot take consistent backup"
 
 ER_IB_WRN_FAST_SHUTDOWN_REDO_DISABLED
   eng "InnoDB cannot do cold shutdown 'innodb_fast_shutdown = 2' and is forcing 'innodb_fast_shutdown = 1' as redo logging is disabled. InnoDB would flush all dirty pages to ensure physical data consistency."

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1110,7 +1110,8 @@ bool Redo_Log_Data_Manager::is_error() const { return (error); }
 Redo_Log_Data_Manager::~Redo_Log_Data_Manager() { os_event_destroy(event); }
 
 bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
-  if (reader.find_last_checkpoint_lsn(&last_checkpoint_lsn)) {
+  bool last_checkpoint = reader.find_last_checkpoint_lsn(&last_checkpoint_lsn);
+  if (last_checkpoint) {
     msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
         last_checkpoint_lsn);
   }
@@ -1135,7 +1136,7 @@ bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
     return (false);
   }
 
-  return (true);
+  return last_checkpoint;
 }
 
 void Redo_Log_Data_Manager::close() {

--- a/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
+++ b/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
@@ -1,0 +1,129 @@
+########################################################################
+#test redo enable/disable feature with backup and incremental backup	
+########################################################################
+. inc/common.sh
+require_server_version_higher_than 8.0.20
+start_server
+
+vlog '### create a table and keep on inserting records'
+mysql -e "CREATE TABLE t (a INT)" test
+mysql -e "INSERT INTO t VALUES (1), (2), (3), (4)" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+mysql -e "INSERT INTO t SELECT * FROM t" test
+
+while true ; do
+    mysql -e "INSERT INTO t SELECT * FROM t limit 100" test 2>/dev/null >/dev/null
+done &
+
+
+
+vlog "### case #1 check when redo log is disabled ###"
+mysql -e "alter instance disable innodb redo_log"
+run_cmd_expect_failure xtrabackup --backup \
+        --target-dir=$topdir/backup  2>&1 \
+        | tee $topdir/pxb.log
+grep "Redo logging is disabled, cannot take consistent backup" $topdir/pxb.log || die "missing error message"
+mysql -e "alter instance enable innodb redo_log"
+
+vlog "### case #2 check redo log is disabled before incremental backup ###"
+run_cmd xtrabackup --backup --target-dir=$topdir/full
+mysql -e "alter instance disable innodb redo_log"
+run_cmd_expect_failure xtrabackup --backup --target-dir=$topdir/inc \
+	--incremental-basedir=$topdir/full 2>&1 \
+	| tee $topdir/inc.log
+grep "Redo logging is disabled, cannot take consistent backup" $topdir/inc.log || die "missing error message"
+rm -r $topdir/inc
+rm -r $topdir/full
+rm  $topdir/inc.log
+mysql -e "alter instance enable innodb redo_log"
+
+vlog "### case #3 check when redo log is disabled after backup is started ###"
+run_cmd_expect_failure xtrabackup  --backup \
+        --target-dir=$topdir/full   \
+	--debug-sync="data_copy_thread_func" 2>&1 \
+        | tee $topdir/full.log &
+job_pid=$!
+pid_file=$topdir/full/xtrabackup_debug_sync
+# Wait for xtrabackup to suspend
+i=0
+while [ ! -r "$pid_file" ]
+do
+    sleep 1
+    i=$((i+1))
+    echo "Waited $i seconds for $pid_file to be created"
+done
+mysql -e "alter instance disable innodb redo_log"
+xb_pid=`cat $pid_file`
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+grep "Redo logging is disabled, cannot take consistent backup" $topdir/full.log || die "missing error message"
+rm -r $topdir/full
+rm $topdir/full.log
+mysql -e "alter instance enable innodb redo_log"
+
+vlog "### case #4 check redo log is disabled during incremental backup ###"
+run_cmd xtrabackup --backup --target-dir=$topdir/full
+run_cmd_expect_failure xtrabackup --backup --target-dir=$topdir/inc \
+	--incremental-basedir=$topdir/full \
+	--debug-sync="data_copy_thread_func" 2>&1 \
+	| tee $topdir/inc.log &
+job_pid=$!
+pid_file=$topdir/inc/xtrabackup_debug_sync
+# Wait for xtrabackup to suspend
+i=0
+while [ ! -r "$pid_file" ]
+do
+    sleep 1
+    i=$((i+1))
+    echo "Waited $i seconds for $pid_file to be created"
+done
+mysql -e "alter instance disable innodb redo_log"
+xb_pid=`cat $pid_file`
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+grep "Redo logging is disabled, cannot take consistent backup" $topdir/inc.log || die "missing error message"
+rm -r $topdir/inc
+rm -r $topdir/full
+rm  $topdir/inc.log
+mysql -e "alter instance enable innodb redo_log"
+
+vlog "case #5 disable disable/enable before normal backup"
+mysql -e "alter instance disable innodb redo_log"
+load_sakila
+mysql -e "alter instance enable innodb redo_log"
+xtrabackup --backup --target-dir=$topdir/full
+record_db_state sakila
+stop_server
+rm -r $mysql_datadir
+xtrabackup --prepare --target-dir=$topdir/full
+xtrabackup --copy-back --target-dir=$topdir/full
+start_server
+verify_db_state sakila
+stop_server
+rm -r $mysql_datadir
+rm -r $topdir/full
+start_server
+
+vlog "case #6 run normal backup and disable/enable before incremental"
+xtrabackup --backup --target-dir=$topdir/full
+mysql -e "alter instance disable innodb redo_log"
+load_sakila
+mysql -e "alter instance enable innodb redo_log"
+xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
+record_db_state sakila
+stop_server
+rm -r $mysql_datadir
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+xtrabackup --copy-back --target-dir=$topdir/full
+start_server
+verify_db_state sakila
+stop_server
+rm -r $mysql_datadir
+rm -r $topdir/full
+rm -r $topdir/inc


### PR DESCRIPTION
Problem:
--------
From MySQL 8.0.21 release, redo logs can be disabled and enabled dynamically
using ALTER INSTANCE [ENABLE/DISABLE] REDO_LOG. (This is meant only for initial
data loading stages)

PXB relies on replaying redo logs to get consistent backups.

Fix:
----
Detect whether REDOLOG is disabled or not and error out as follows

1. Redo is disabled before backup                              : Backup failure
2. Redo is disabled and enabled before backup                  : Successful backup
3. Redo is enabled at start of backup, but disabled before end
of backup (applies to both full and incremental backups)     : Backup failure
4. Redo is disabled and enabled again between Full and
Incremental backup                                            : Successful backup

Special case:
-------------

If redo is enabled at startup of backup but during the process of backup it is
disabled and enabled before the backup completes, it will result in inconsistent
backups. PXB may not error out in this scenario.

Users are advised to use --lock-ddl=ON with PXB to avoid users disabling and
enabling redo logs "during the backups"