### PR TITLE
PXB-2249 : xtrabackup sh: perl: command not found

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2337,6 +2337,11 @@ decrypt_decompress()
 void
 version_check()
 {
+	if (system("which perl > /dev/null 2>&1")) {
+		msg("xtrabackup: perl binary not found. Skipping the version check\n");
+		return;
+	}
+
 	if (opt_password != NULL) {
 		setenv("option_mysql_password", opt_password, 1);
 	}


### PR DESCRIPTION
Problem:
--------
xtrabackup does version check by default. To do this it uses perl. Can be
skipped with --no-version-check

On kubernetes pods, perl doesn't exist by default and it prints message
"xtrabackup sh: perl: command not found". Note that backup is successful.

Fix:
----
Check if perl binary exists or not before doing version check