### PR TITLE
PXB-2215 Importing tablespace where character set of table is specifi…

### DIFF
--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -679,9 +679,10 @@ dict_table_t *dd_table_create_on_dd_obj(const dd::Table *dd_table,
 
     long_true_varchar = 0;
     if (field_type == MYSQL_TYPE_VARCHAR) {
-      col_len -= HA_VARCHAR_PACKLENGTH(field_length);
+      byte pack_length = HA_VARCHAR_PACKLENGTH(dd_col->char_length());
+      col_len -= pack_length;
 
-      if (HA_VARCHAR_PACKLENGTH(field_length) == 2) {
+      if (pack_length == 2) {
         long_true_varchar = DATA_LONG_TRUE_VARCHAR;
       }
     }

--- a/storage/innobase/xtrabackup/test/t/xb_export.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_export.sh
@@ -113,7 +113,8 @@ insert_data incremental_sample test2 $indices_count $rows_count
 mysql -e 'create table test4(col1 bool, col2 int, col3 float, col4 double,
 col5 timestamp, col6 long, col7 date, col8 time, col9 datetime, col10 year,
 col11 varchar(20), col12 bit ,col13 decimal, col14 blob, col16 json,
-col17 mediumtext, col18 enum("01","2"),col19 SET("0","1","2") )' incremental_sample;
+col17 mediumtext, col18 enum("01","2"), col19 SET("0","1","2"),
+col20 varchar(255) character set latin1 )' incremental_sample;
 
 checksum_1=`checksum_table incremental_sample test`
 rowsnum_1=`${MYSQL} ${MYSQL_ARGS} -Ns -e "select count(*) from test" incremental_sample`
@@ -135,7 +136,8 @@ init_schema incremental_sample test3 $indices_count "y"
 mysql -e 'create table test4(col1 bool, col2 int, col3 float, col4 double,
 col5 timestamp, col6 long, col7 date, col8 time, col9 datetime, col10 year,
 col11 varchar(20), col12 bit ,col13 decimal, col14 blob, col16 json,
-col17 mediumtext, col18 enum("01","2"),col19 SET("0","1","2") )' incremental_sample;
+col17 mediumtext, col18 enum("01","2"), col19 SET("0","1","2"),
+col20 varchar(255) character set latin1 )' incremental_sample;
 vlog "Database was re-initialized"
 
 mysql -e "alter table test discard tablespace;" incremental_sample


### PR DESCRIPTION
…ed fails with (Column x precise type mismatch.)

Problem:
--------
PXB doesn't calculate pack length of the varchar columns correctly. This is
because it relies on TABLE*->field->field_length. PXB can rely only on dd::Table* 
(created by SDI to dd::Table* conversion) and doesn't have TABLE* initialized.
So TABLE*->field->field_length would give wrong values

Fix:
---
calculate the pack_length based on dd::Column* field length

Thanks to luqun@fb.com for providing this patch