### PR TITLE
PXB-2252 : Introduce debug option to print redo log records scanned a…

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2427,6 +2427,8 @@ recv_recover_page_func(
 #endif /* !UNIV_HOTBACKUP */
 	buf_block_t*	block)	/*!< in/out: buffer block */
 {
+	DBUG_ENTER("recv_recover_page_func");
+
 	page_t*		page;
 	page_zip_des_t*	page_zip;
 	recv_addr_t*	recv_addr;
@@ -2447,7 +2449,7 @@ recv_recover_page_func(
 
 		mutex_exit(&(recv_sys->mutex));
 
-		return;
+		DBUG_VOID_RETURN;
 	}
 
 	recv_addr = recv_get_fil_addr_struct(block->page.id.space(),
@@ -2462,7 +2464,7 @@ recv_recover_page_func(
 
 		mutex_exit(&(recv_sys->mutex));
 
-		return;
+		DBUG_VOID_RETURN;
 	}
 
 #ifndef UNIV_HOTBACKUP
@@ -2671,7 +2673,7 @@ recv_recover_page_func(
 	recv_sys->n_addrs--;
 
 	mutex_exit(&(recv_sys->mutex));
-
+	DBUG_VOID_RETURN;
 }
 
 #ifndef UNIV_HOTBACKUP

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -326,6 +326,7 @@ ibool srv_compact_backup = FALSE;
 ibool srv_rebuild_indexes = FALSE;
 
 static char *xtrabackup_debug_sync = NULL;
+static const char* dbug_setting = NULL;
 
 my_bool xtrabackup_compact = FALSE;
 my_bool xtrabackup_rebuild_indexes = FALSE;
@@ -1360,6 +1361,13 @@ Disable with --skip-innodb-doublewrite.", (G_PTR*) &innobase_use_doublewrite,
    0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #endif
 
+#ifndef DBUG_OFF
+  {"debug", '#', "Output debug log. Default all ib_log output to stderr."
+   " To redirect all ib_log output to separate file, use "
+   "--debug=d,ib_log:o,/tmp/xtrabackup.trace", &dbug_setting,
+   &dbug_setting, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+#endif /* !DBUG_OFF */
+
   {"innodb_checksum_algorithm", OPT_INNODB_CHECKSUM_ALGORITHM,
   "The algorithm InnoDB uses for page checksumming. [CRC32, STRICT_CRC32, "
    "INNODB, STRICT_INNODB, NONE, STRICT_NONE]", &srv_checksum_algorithm,
@@ -1555,6 +1563,11 @@ xb_get_one_option(int optid,
   }
   param_str << " ";
   switch(optid) {
+  case '#':
+    dbug_setting = argument ? argument : "d,ib_log";
+    DBUG_SET_INITIAL(dbug_setting);
+    break;
+
   case 'h':
     strmake(mysql_real_data_home,argument, FN_REFLEN - 1);
     mysql_data_home= mysql_real_data_home;


### PR DESCRIPTION
…nd applied

Server can print the redo log records scanned and applied using the DBUG framework.
The messages are via DBUG_PRINT.

Although PXB uses the same recovery functions, the DBUG framework is not activated.
It is really useful to have these messages and makes debugging easy

NOTE: this is debug build only option

Just pass --debug to xtrabackup --prepare and it would print messages like this
It can be used to --backup as well and when pxb parses redo log records during
backup phase, it will print them

To redirect all ib_log output to file --debug=d,ib_log:o,/tmp/xtrabackup.trace

Format: Function name : ib_log: Phase (scan or apply) LSN: redo record category, redo record type, len, page (space_id:page_number)

recv_group_scan_log_recs: ib_log: scan 1374877: multi-log rec MLOG_2BYTES len 7 page 0:193
recv_group_scan_log_recs: ib_log: scan 1374877: multi-log rec MLOG_4BYTES len 11 page 0:320
recv_group_scan_log_recs: ib_log: scan 1374877: multi-log rec MLOG_2BYTES len 7 page 0:320

recv_recover_page_func: ib_log: Applying log to page 0:7
recv_recover_page_func: ib_log: apply 1363504: MLOG_8BYTES len 7 page 0:7
recv_recover_page_func: ib_log: Applying log to page 0:2
recv_recover_page_func: ib_log: apply 1370307: MLOG_4BYTES len 4 page 0:2