### PR TITLE
2.4 Implemented PXB-2254 (Redesign --lock-ddl-per-table)

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -35,6 +35,7 @@ extern bool innodb_log_checksum_algorithm_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern my_bool opt_lock_ddl_per_table;
+extern bool mdl_taken;
 
 extern bool use_dumped_tablespace_keys;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1793,7 +1793,7 @@ recv_parse_or_apply_log_rec_body(
 		of offline backup and continue.
 		*/
 		if (!recv_recovery_on) {
-			if (!opt_lock_ddl_per_table) {
+			if (mdl_taken) {
 				if (backup_redo_log_flushed_lsn
 				    < recv_sys->recovered_lsn) {
 					ib::info() << "Last flushed lsn: "

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -104,11 +104,44 @@ write_slave_info(MYSQL *connection);
 void
 parse_show_engine_innodb_status(MYSQL *connection);
 
+/**************************************************************//**
+Acquire MDL lock on all tables*/
 void
-mdl_lock_init();
+mdl_lock_tables();
 
+/**************************************************************//**
+Identifies if tablespace is a Full Text Index
+@return TRUE if is a FTS, or FALSE otherwise */
+bool
+is_fts_index(
+	const std::string &tablespace 	/*!< in: tablespace */
+);
+
+/**************************************************************//**
+Identifies if tablespace is a temporary table (#sql-)
+@return TRUE if is a temporary table, or FALSE otherwise */
+bool
+is_tmp_table(
+	const std::string &tablespace 	/*!< in: tablespace */
+);
+
+/**************************************************************//**
+Runs a regexp against a table name
+@return TRUE if there is a match, or FALSE otherwise */
+bool
+check_regexp_table_name(
+	std::string tablespace,	/*!< in: tablespace */
+	const char* error_context,	/*!< in: error to be return in case of errors */
+	const char* pattern	/*!< in: regexp pattern to try a match */
+);
+
+/**************************************************************//**
+Extract the table name from a full qualified `db`.`table` string 
+removing escape string. Replace the name inplace `*/
 void
-mdl_lock_table(ulint space_id);
+get_table_name_from_tablespace(
+	std::string &tablespace 	/*!< in/out: tablespace */
+);
 
 void
 mdl_unlock_all();

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xbstream.h"
 #include "changed_page_bitmap.h"
 #include "xtrabackup_config.h"
+#include "xb_regex.h"
 
 #ifdef __WIN__
 #define XB_FILE_UNDEFINED { NULL };
@@ -205,6 +206,11 @@ enum binlog_info_enum { BINLOG_INFO_OFF, BINLOG_INFO_LOCKLESS, BINLOG_INFO_ON,
 			BINLOG_INFO_AUTO};
 
 extern ulong opt_binlog_info;
+extern
+bool compile_regex(
+	const char* regex_string,
+	const char* error_context,
+	xb_regex_t* compiled_re);
 
 void xtrabackup_io_throttling(void);
 my_bool xb_write_delta_metadata(const char *filename,

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -112,11 +112,8 @@ heavy_index_rotation &
 job_id=$!
 
 while [ `mysql test -Ne "SELECT val FROM rcount"` -lt "3" ] ; do
-	sleep 1
+	sleep 0.1
 done
-
-xtrabackup --backup --lock-ddl-per-table --target-dir=$topdir/backup5
-xtrabackup --prepare --target-dir=$topdir/backup5
 
 if has_backup_locks ;
 then
@@ -130,4 +127,76 @@ run_cmd_expect_failure grep 'failed to execute query SELECT \* FROM test.t_hello
 kill -USR1 $job_id
 wait $job_id
 
+################################################################################
+# Create database x (this will be the last to be locked) and a table on it.
+# Lock x.tb1 for write (This will block pxb MDL thread).
+# wait for 2 seconds and unlock the table
+# Create a table test.bulk_index (it wont have MDL protection)
+# Add an index (it should generate MLOG_INDEX_LOAD event)
+################################################################################
+function add_index_without_mdl_protection()
+{
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE DATABASE IF NOT EXISTS x;
+CREATE TABLE x.tb1 (ID INT);
+LOCK TABLE x.tb1 WRITE;
+SELECT SLEEP(2);
+UNLOCK TABLES;
+EOF
+  run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE bulk_index (val INT, c2 char(10));
+INSERT INTO bulk_index VALUES (1, 'aaaaaaaa');
+SELECT SLEEP(2);
+EOF
+  mysql test -Ne "CREATE INDEX bindex ON bulk_index(c2);"
+}
+
+add_index_without_mdl_protection &
+run_cmd_expect_failure \
+$XB_BIN $XB_ARGS --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup7
+
+mysql -e "DROP INDEX bindex ON bulk_index" test
+
+################################################################################
+# Wait for 2 seconds to allow PXB to take MDL on all known tables
+# Add index on a continious way. It should wait on MDL
+################################################################################
+function add_index_with_mdl_protection()
+{
+  sleep 2;
+  trap "finish=true" SIGUSR1
+	finish="false"
+  index_id=1
+	while [ $finish != "true" ] ; do
+		mysql -ce "CREATE INDEX bindex_${index_id} ON bulk_index(c2);" test;
+		((index_id=index_id+1));
+	done
+}
+function check_for_mdl_lock()
+{
+  trap "finish=true" SIGUSR1
+	finish="false"
+	while [ $finish != "true" ] ; do
+		mysql -e 'SHOW PROCESSLIST';
+		sleep 0.1;
+	done
+}
+
+add_index_with_mdl_protection &
+job_id_indx=$!
+check_for_mdl_lock &
+job_id_check=$!
+xtrabackup --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup8
+kill -USR1 $job_id_indx
+wait $job_id_indx
+kill -USR1 $job_id_check
+wait $job_id_check
+xtrabackup --prepare --target-dir=$topdir/backup8
+
+if ! grep -q "bindex_" | grep -qi "Waiting for table metadata lock" $OUTFILE
+then
+    die "Cannot find  bindex waiting for table metadata lock message on xtrabackup log"
+fi
 stop_server


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2254

The current implementation of --lock-ddl-per-table works as follow:

 - Creates a dedicated mysql connection for MDL and start a transaction.
 - Start to scan directories (databases) looking for .ibd files.
 - For each .ibd file it tries to transalate the space id recorded on
the file header to a table (or tables in case of shared tablespace).
 - If it finds a table associate with the .ibd (or tables) it executes a
SELECT * FROM table LIMIT 1 using the dedicated connection for MDL.
 - From this point forward, the table is locked and new DDL will be
blocked until the MDL connection commits.
 - With this, it has been assumed that if a MLOG_LOAD_INDEX event has
been generated (https://dev.mysql.com/worklog/task/?id=7277) it's safe
to continue since we have taken MDL on the table we are copying.

This design has a few flaws:

 1. FTS have their own tablespace, which is been copied without
MDL protection.
 2. Ongoing DDL that generate temporary table (#sql...) are copied
without MDL protection.
 3. When creating FTS for the first time, MySQL will have to create a
tmp table (Item 2) and FTS files (Item 1) are pointing to temp table.
 4. Table space IDs for FTS or regular tables will change if you
DROP and then CREATE the same FTS/TABLE. MDL lock query will fail to
find the corresponding table but file will exist, thus will be copied
without MDL protection.
 5. If a table is created after xtrabackup has gathered the list of
.ibd's to copy and before the backup has finished, this particular
table will be part of the backup as it will be contained within the
redo log. However, if a bulk index load operations have been performed
( MLOG_INDEX_LOAD has been written to the redo log), this change to the
data file will not be tracked and will be missed from the backup.

This commit changes to:

1. MDL is taken at the beginning of backup for all know tables at
that time, before we start to copy individual .ibd files.
2. A new flag controls whatever MDL step has been completed or not.
3. Before MDL from step 1 is completed, redo follow thread accept
parsing MLOG_INDEX_LOAD. At this point is still safe to accept it since
we have not started to copy .ibd files. After MDL part is completed,
mdl_taken changes to true and parsing a MLOG_INDEX_LOAD causes the
backup to abort.
4. Before we execute the MDL query for a specific entry from
INNODB_SYS_TABLES, we validate it against a regexp for a FTS file name,
if we are manipulating a FTS index, we translate it to the corresponding
table name.
5. If for any reason we cannot execute the MDL lock query (for example,
a DDL is ongoing and we are manipulating a file starting with #sql-)
we do not abort the backup. We will only abort if a subsequent
MLOG_INDEX_LOAD is found by the redo follow thread during the backup.
6. We identify temporary tables (#sql-) and skip trying to lock them.
No reason to attempt to query it as it will always result in an error.
6. MDL query changed to not bring any row back. This is enough for
taking a MDL while saving the server from bringing any row back.