### PR TITLE
PXB-2255 crash in pxb due to undo truncation

### DIFF
--- a/storage/innobase/xtrabackup/test/t/undo_truncation.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_truncation.sh
@@ -1,0 +1,22 @@
+########################################################################
+# Test support for separate UNDO tablespace
+########################################################################
+
+. inc/common.sh
+
+require_server_version_higher_than 8.0.20
+
+vlog "case #1: block parallel truncation during backup"
+
+start_server
+for i in {1..100} ; do
+    mysql -e "CREATE UNDO TABLESPACE UNDO_$i ADD DATAFILE 'undo_$i.ibu'"
+done;
+
+for i in {1..100} ; do
+    mysql -e "ALTER UNDO TABLESPACE UNDO_$i SET INACTIVE"
+done &
+
+sleep 1s
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup
+


### PR DESCRIPTION
PXB-2255 crash in pxb due to undo truncations happens during backup
    Problem:
    PXB crashes if undo tablespaces are truncated concurrently during backup
    Analysis:
    Backup was applying MLOG_DELETE_FILE generated by undo truncation
    during backup. This redo delete the existing undo files which results
    issue during later stage of backup
    Fix:
    Error out if undo truncation happens during backup since
    dropping and recreating table-space can create issue for file copy
    during backup