### PR TITLE
8.0 Implemented PXB-2254 (Redesign --lock-ddl-per-table)

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -25,6 +25,7 @@ extern bool innodb_log_checksums_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern bool opt_lock_ddl_per_table;
+extern bool mdl_taken;
 
 extern bool use_dumped_tablespace_keys;
 

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -35,6 +35,7 @@ extern bool innodb_log_checksum_algorithm_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern my_bool opt_lock_ddl_per_table;
+extern bool mdl_taken;
 
 extern bool use_dumped_tablespace_keys;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1655,7 +1655,7 @@ static byte *recv_parse_or_apply_log_rec_body(
       Error out in case of online backup and emit a warning in case
       of offline backup and continue. */
       if (!recv_recovery_on) {
-        if (!opt_lock_ddl_per_table) {
+        if (mdl_taken) {
           if (backup_redo_log_flushed_lsn < recv_sys->recovered_lsn) {
             ib::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
                        << " load_index lsn " << recv_sys->recovered_lsn;

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1793,7 +1793,7 @@ recv_parse_or_apply_log_rec_body(
 		of offline backup and continue.
 		*/
 		if (!recv_recovery_on) {
-			if (!opt_lock_ddl_per_table) {
+			if (mdl_taken) {
 				if (backup_redo_log_flushed_lsn
 				    < recv_sys->recovered_lsn) {
 					ib::info() << "Last flushed lsn: "

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -66,6 +66,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "xtrabackup_version.h"
 
 #include "backup_mysql.h"
+#include "fsp0fsp.h"
+#include "xb_regex.h"
 
 extern uint opt_ssl_mode;
 extern char *opt_ssl_ca;
@@ -1138,11 +1140,6 @@ bool lock_tables_maybe(MYSQL *connection, int timeout, int retry_count) {
  Releases the lock acquired with FTWRL/LOCK TABLES FOR BACKUP, depending on
  the locking strategy being used */
 void unlock_all(MYSQL *connection) {
-  if (opt_debug_sleep_before_unlock) {
-    msg_ts("Debug sleep for %u seconds\n", opt_debug_sleep_before_unlock);
-    os_thread_sleep(opt_debug_sleep_before_unlock * 1000);
-  }
-
   if (instance_locked) {
     msg_ts("Executing UNLOCK INSTANCE\n");
     xb_mysql_query(connection, "UNLOCK INSTANCE", false);
@@ -2155,60 +2152,89 @@ void backup_cleanup() {
   }
 }
 
-static ib_mutex_t mdl_lock_con_mutex;
 static MYSQL *mdl_con = NULL;
-
-void mdl_lock_init() {
-  mutex_create(LATCH_ID_XTRA_DATAFILES_ITER_MUTEX, &mdl_lock_con_mutex);
-
-  mdl_con = xb_mysql_connect();
-
-  if (mdl_con != NULL) {
-    xb_mysql_query(mdl_con, "BEGIN", false, true);
-  }
-}
-
-void mdl_lock_table(ulint space_id) {
+void mdl_lock_tables() {
+  msg_ts("Initializing MDL on all current tables.\n");
   MYSQL_RES *mysql_result = NULL;
   MYSQL_ROW row;
-  char *query;
+  mdl_con = xb_mysql_connect();
+  if (mdl_con != NULL) {
+    xb_mysql_query(mdl_con, "BEGIN", false, true);
+    mysql_result = xb_mysql_query(mdl_con,
+                                  "SELECT NAME, SPACE FROM "
+                                  "INFORMATION_SCHEMA.INNODB_TABLES",
+                                  true, true);
+    while ((row = mysql_fetch_row(mysql_result))) {
+      if (fsp_is_ibd_tablespace(atoi(row[1]))) {
+        char full_table_name[MAX_FULL_NAME_LEN + 1];
+        innobase_format_name(full_table_name, sizeof(full_table_name), row[0]);
+        if (is_fts_index(full_table_name)) {
+          // We will eventually get to the row to lock the main table
+          msg_ts("%s is a Full-Text Index. Skipping\n", full_table_name);
+          continue;
+        } else if (is_tmp_table(full_table_name)) {
+          // We cannot run SELECT ... #sql-; Skipped to avoid invalid query.
+          msg_ts("%s is a temporary table. Skipping\n", full_table_name);
+          continue;
+        }
 
-  mutex_enter(&mdl_lock_con_mutex);
+        msg_ts("Locking MDL for %s\n", full_table_name);
+        char *lock_query;
+        xb_a(
+            asprintf(&lock_query, "SELECT 1 FROM %s LIMIT 0", full_table_name));
 
-  xb_a(asprintf(&query,
-                "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLES "
-                "WHERE SPACE = %lu",
-                space_id));
+        xb_mysql_query(mdl_con, lock_query, false, false);
 
-  mysql_result = xb_mysql_query(mdl_con, query, true);
-
-  while ((row = mysql_fetch_row(mysql_result))) {
-    char *lock_query;
-    char table_name[MAX_FULL_NAME_LEN + 1];
-
-    innobase_format_name(table_name, sizeof(table_name), row[0]);
-
-    msg_ts("Locking MDL for %s\n", table_name);
-
-    xb_a(asprintf(&lock_query, "SELECT * FROM %s LIMIT 1", table_name));
-
-    xb_mysql_query(mdl_con, lock_query, false, false);
-
-    free(lock_query);
+        free(lock_query);
+      }
+    }
+    mysql_free_result(mysql_result);
   }
-
-  mysql_free_result(mysql_result);
-  free(query);
-
-  mutex_exit(&mdl_lock_con_mutex);
 }
 
 void mdl_unlock_all() {
   msg_ts("Unlocking MDL for all tables\n");
+  if (mdl_con != NULL) {
+    xb_mysql_query(mdl_con, "COMMIT", false, true);
+    mysql_close(mdl_con);
+  }
+}
+bool is_fts_index(const std::string &tablespace) {
+  const char *pattern =
+      "^(FTS|fts)_[0-9a-fA-f]{16}_(([0-9a-fA-]{16}_(INDEX|index)_[1-6])|"
+      "DELETED_CACHE|deleted_cache|DELETED|deleted|CONFIG|config|BEING_DELETED|"
+      "being_deleted|BEING_DELETED_CACHE|beign_deleted_cache)$";
+  const char *error_context = "is_fts_index";
+  return check_regexp_table_name(tablespace, error_context, pattern);
+}
 
-  xb_mysql_query(mdl_con, "COMMIT", false, true);
+bool is_tmp_table(const std::string &tablespace) {
+  const char *pattern = "^#sql-";
+  const char *error_context = "is_tmp_table";
+  return check_regexp_table_name(tablespace, error_context, pattern);
+}
 
-  mutex_free(&mdl_lock_con_mutex);
+bool check_regexp_table_name(std::string tablespace, const char *error_context,
+                             const char *pattern) {
+  bool result = false;
+  get_table_name_from_tablespace(tablespace);
+  xb_regex_t preg;
+  size_t nmatch = 1;
+  xb_regmatch_t pmatch[1];
+  compile_regex(pattern, error_context, &preg);
+
+  if (xb_regexec(&preg, tablespace.c_str(), nmatch, pmatch, 0) != REG_NOMATCH) {
+    result = true;
+  }
+  xb_regfree(&preg);
+  return result;
+}
+void get_table_name_from_tablespace(std::string &tablespace) {
+  std::size_t pos = tablespace.find("`.`");  //`db`.`table` separator
+  if (pos != std::string::npos) {
+    tablespace = tablespace.substr(pos + 3);
+    tablespace.erase(tablespace.size() - 1);  // remove leading `
+  }
 }
 
 bool has_innodb_buffer_pool_dump() {

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -220,9 +220,32 @@ bool write_slave_info(MYSQL *connection);
 
 void parse_show_engine_innodb_status(MYSQL *connection);
 
-void mdl_lock_init();
+/** Acquires MDL lock on all tables */
+void mdl_lock_tables();
 
-void mdl_lock_table(ulint space_id);
+/** Identifies if tablespace is a Full Text Index.
+@param[in]	tablespace		tablespace
+@return true if tablespace is FTS. */
+bool is_fts_index(const std::string &tablespace);
+
+/** Identifies if tablespace is a temporary table (#sql-)
+@param[in]	tablespace		tablespace
+@return true if tablespace is temporary table. */
+bool is_tmp_table(const std::string &tablespace);
+
+/** Runs a regexp against a table name
+@param[in]	tablespace		tablespace
+@param[in]	error_context		error to be return in case of errors
+@param[in]	pattern		regexp pattern to try a match
+@return true if there is a match, or false otherwise */
+bool check_regexp_table_name(std::string tablespace, const char *error_context,
+                             const char *pattern);
+
+/** Extract the table name from a full qualified `db`.`table` string
+removing escape string. Replace the name inplace
+@param[in/out]	tablespace		tablespace
+ */
+void get_table_name_from_tablespace(std::string &tablespace);
 
 void mdl_unlock_all();
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -104,11 +104,44 @@ write_slave_info(MYSQL *connection);
 void
 parse_show_engine_innodb_status(MYSQL *connection);
 
+/**************************************************************//**
+Acquire MDL lock on all tables*/
 void
-mdl_lock_init();
+mdl_lock_tables();
 
+/**************************************************************//**
+Identifies if tablespace is a Full Text Index
+@return TRUE if is a FTS, or FALSE otherwise */
+bool
+is_fts_index(
+	const std::string &tablespace 	/*!< in: tablespace */
+);
+
+/**************************************************************//**
+Identifies if tablespace is a temporary table (#sql-)
+@return TRUE if is a temporary table, or FALSE otherwise */
+bool
+is_tmp_table(
+	const std::string &tablespace 	/*!< in: tablespace */
+);
+
+/**************************************************************//**
+Runs a regexp against a table name
+@return TRUE if there is a match, or FALSE otherwise */
+bool
+check_regexp_table_name(
+	std::string tablespace,	/*!< in: tablespace */
+	const char* error_context,	/*!< in: error to be return in case of errors */
+	const char* pattern	/*!< in: regexp pattern to try a match */
+);
+
+/**************************************************************//**
+Extract the table name from a full qualified `db`.`table` string 
+removing escape string. Replace the name inplace `*/
 void
-mdl_lock_table(ulint space_id);
+get_table_name_from_tablespace(
+	std::string &tablespace 	/*!< in/out: tablespace */
+);
 
 void
 mdl_unlock_all();

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_getopt.h>
 #include "changed_page_bitmap.h"
 #include "datasink.h"
+#include "xb_regex.h"
 #include "xbstream.h"
 #include "xtrabackup_config.h"
 
@@ -196,6 +197,8 @@ extern bool opt_generate_new_master_key;
 extern uint opt_dump_innodb_buffer_pool_timeout;
 extern uint opt_dump_innodb_buffer_pool_pct;
 extern bool opt_dump_innodb_buffer_pool;
+extern bool compile_regex(const char *regex_string, const char *error_context,
+                          xb_regex_t *compiled_re);
 
 enum binlog_info_enum {
   BINLOG_INFO_OFF,

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xbstream.h"
 #include "changed_page_bitmap.h"
 #include "xtrabackup_config.h"
+#include "xb_regex.h"
 
 #ifdef __WIN__
 #define XB_FILE_UNDEFINED { NULL };
@@ -205,6 +206,11 @@ enum binlog_info_enum { BINLOG_INFO_OFF, BINLOG_INFO_LOCKLESS, BINLOG_INFO_ON,
 			BINLOG_INFO_AUTO};
 
 extern ulong opt_binlog_info;
+extern
+bool compile_regex(
+	const char* regex_string,
+	const char* error_context,
+	xb_regex_t* compiled_re);
 
 void xtrabackup_io_throttling(void);
 my_bool xb_write_delta_metadata(const char *filename,

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -102,11 +102,9 @@ heavy_index_rotation &
 job_id=$!
 
 while [ `mysql test -Ne "SELECT val FROM rcount"` -lt "3" ] ; do
-	sleep 1
+	sleep 0.1
 done
 
-xtrabackup --backup --lock-ddl-per-table --target-dir=$topdir/backup5
-xtrabackup --prepare --target-dir=$topdir/backup5
 
 if has_backup_locks ;
 then
@@ -120,4 +118,76 @@ run_cmd_expect_failure grep 'failed to execute query SELECT \* FROM test.t_hello
 kill -USR1 $job_id
 wait $job_id
 
+################################################################################
+# Create database x (this will be the last to be locked) and a table on it.
+# Lock x.tb1 for write (This will block pxb MDL thread).
+# wait for 2 seconds and unlock the table
+# Create a table test.bulk_index (it wont have MDL protection)
+# Add an index (it should generate MLOG_INDEX_LOAD event)
+################################################################################
+function add_index_without_mdl_protection()
+{
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE DATABASE IF NOT EXISTS x;
+CREATE TABLE x.tb1 (ID INT);
+LOCK TABLE x.tb1 WRITE;
+SELECT SLEEP(2);
+UNLOCK TABLES;
+EOF
+  run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE bulk_index (val INT, c2 char(10));
+INSERT INTO bulk_index VALUES (1, 'aaaaaaaa');
+SELECT SLEEP(2);
+EOF
+  mysql test -Ne "CREATE INDEX bindex ON bulk_index(c2);"
+}
+
+add_index_without_mdl_protection &
+run_cmd_expect_failure \
+$XB_BIN $XB_ARGS --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup7
+
+mysql -e "DROP INDEX bindex ON bulk_index" test
+
+################################################################################
+# Wait for 2 seconds to allow PXB to take MDL on all known tables
+# Add index on a continious way. It should wait on MDL
+################################################################################
+function add_index_with_mdl_protection()
+{
+  sleep 2;
+  trap "finish=true" SIGUSR1
+	finish="false"
+  index_id=1
+	while [ $finish != "true" ] ; do
+		mysql -ce "CREATE INDEX bindex_${index_id} ON bulk_index(c2);" test;
+		((index_id=index_id+1));
+	done
+}
+function check_for_mdl_lock()
+{
+  trap "finish=true" SIGUSR1
+	finish="false"
+	while [ $finish != "true" ] ; do
+		mysql -e 'SHOW PROCESSLIST';
+		sleep 0.1;
+	done
+}
+
+add_index_with_mdl_protection &
+job_id_indx=$!
+check_for_mdl_lock &
+job_id_check=$!
+xtrabackup --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup8
+kill -USR1 $job_id_indx
+wait $job_id_indx
+kill -USR1 $job_id_check
+wait $job_id_check
+xtrabackup --prepare --target-dir=$topdir/backup8
+
+if ! grep -q "bindex_" | grep -qi "Waiting for table metadata lock" $OUTFILE
+then
+    die "Cannot find  bindex waiting for table metadata lock message on xtrabackup log"
+fi
 stop_server

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -112,11 +112,8 @@ heavy_index_rotation &
 job_id=$!
 
 while [ `mysql test -Ne "SELECT val FROM rcount"` -lt "3" ] ; do
-	sleep 1
+	sleep 0.1
 done
-
-xtrabackup --backup --lock-ddl-per-table --target-dir=$topdir/backup5
-xtrabackup --prepare --target-dir=$topdir/backup5
 
 if has_backup_locks ;
 then
@@ -130,4 +127,76 @@ run_cmd_expect_failure grep 'failed to execute query SELECT \* FROM test.t_hello
 kill -USR1 $job_id
 wait $job_id
 
+################################################################################
+# Create database x (this will be the last to be locked) and a table on it.
+# Lock x.tb1 for write (This will block pxb MDL thread).
+# wait for 2 seconds and unlock the table
+# Create a table test.bulk_index (it wont have MDL protection)
+# Add an index (it should generate MLOG_INDEX_LOAD event)
+################################################################################
+function add_index_without_mdl_protection()
+{
+    run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE DATABASE IF NOT EXISTS x;
+CREATE TABLE x.tb1 (ID INT);
+LOCK TABLE x.tb1 WRITE;
+SELECT SLEEP(2);
+UNLOCK TABLES;
+EOF
+  run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE bulk_index (val INT, c2 char(10));
+INSERT INTO bulk_index VALUES (1, 'aaaaaaaa');
+SELECT SLEEP(2);
+EOF
+  mysql test -Ne "CREATE INDEX bindex ON bulk_index(c2);"
+}
+
+add_index_without_mdl_protection &
+run_cmd_expect_failure \
+$XB_BIN $XB_ARGS --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup7
+
+mysql -e "DROP INDEX bindex ON bulk_index" test
+
+################################################################################
+# Wait for 2 seconds to allow PXB to take MDL on all known tables
+# Add index on a continious way. It should wait on MDL
+################################################################################
+function add_index_with_mdl_protection()
+{
+  sleep 2;
+  trap "finish=true" SIGUSR1
+	finish="false"
+  index_id=1
+	while [ $finish != "true" ] ; do
+		mysql -ce "CREATE INDEX bindex_${index_id} ON bulk_index(c2);" test;
+		((index_id=index_id+1));
+	done
+}
+function check_for_mdl_lock()
+{
+  trap "finish=true" SIGUSR1
+	finish="false"
+	while [ $finish != "true" ] ; do
+		mysql -e 'SHOW PROCESSLIST';
+		sleep 0.1;
+	done
+}
+
+add_index_with_mdl_protection &
+job_id_indx=$!
+check_for_mdl_lock &
+job_id_check=$!
+xtrabackup --backup --lock-ddl-per-table \
+--debug-sleep-before-unlock=3 --target-dir=$topdir/backup8
+kill -USR1 $job_id_indx
+wait $job_id_indx
+kill -USR1 $job_id_check
+wait $job_id_check
+xtrabackup --prepare --target-dir=$topdir/backup8
+
+if ! grep -q "bindex_" | grep -qi "Waiting for table metadata lock" $OUTFILE
+then
+    die "Cannot find  bindex waiting for table metadata lock message on xtrabackup log"
+fi
 stop_server


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2254

The current implementation of --lock-ddl-per-table works as follow:

Creates a dedicated mysql connection for MDL and start a transaction.
Start to scan directories (databases) looking for .ibd files.
For each .ibd file it tries to transalate the space id recorded on
the file header to a table (or tables in case of shared tablespace).
If it finds a table associate with the .ibd (or tables) it executes a
SELECT * FROM table LIMIT 1 using the dedicated connection for MDL.
From this point forward, the table is locked and new DDL will be
blocked until the MDL connection commits.
With this, it has been assumed that if a MLOG_LOAD_INDEX event has
been generated (https://dev.mysql.com/worklog/task/?id=7277) it's safe
to continue since we have taken MDL on the table we are copying.
This design has a few flaws:

FTS have their own tablespace, which is been copied without
MDL protection.
Ongoing DDL that generate temporary table (#sql...) are copied
without MDL protection.
When creating FTS for the first time, MySQL will have to create a
tmp table (Item 2) and FTS files (Item 1) are pointing to temp table.
Table space IDs for FTS or regular tables will change if you
DROP and then CREATE the same FTS/TABLE. MDL lock query will fail to
find the corresponding table but file will exist, thus will be copied
without MDL protection.
If a table is created after xtrabackup has gathered the list of
.ibd's to copy and before the backup has finished, this particular
table will be part of the backup as it will be contained within the
redo log. However, if a bulk index load operations have been performed
( MLOG_INDEX_LOAD has been written to the redo log), this change to the
data file will not be tracked and will be missed from the backup.
This commit changes to:

MDL is taken at the beginning of backup for all know tables at
that time, before we start to copy individual .ibd files.
A new flag controls whatever MDL step has been completed or not.
Before MDL from step 1 is completed, redo follow thread accept
parsing MLOG_INDEX_LOAD. At this point is still safe to accept it since
we have not started to copy .ibd files. After MDL part is completed,
mdl_taken changes to true and parsing a MLOG_INDEX_LOAD causes the
backup to abort.
Before we execute the MDL query for a specific entry from
INNODB_SYS_TABLES, we validate it against a regexp for a FTS file name,
if we are manipulating a FTS index, we translate it to the corresponding
table name.
If for any reason we cannot execute the MDL lock query (for example,
a DDL is ongoing and we are manipulating a file starting with #sql-)
we do not abort the backup. We will only abort if a subsequent
MLOG_INDEX_LOAD is found by the redo follow thread during the backup.
We identify temporary tables (#sql-) and skip trying to lock them.
No reason to attempt to query it as it will always result in an error.
MDL query changed to not bring any row back. This is enough for
taking a MDL while saving the server from bringing any row back.