### PR TITLE
PXB-1979 Enable --lock-ddl by default

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1377,12 +1377,6 @@ static bool backup_rocksdb_checkpoint(Backup_context &context, bool final) {
 @return true if success. */
 bool backup_start(Backup_context &context) {
   if (!opt_no_lock) {
-    if (opt_safe_slave_backup) {
-      if (!wait_for_safe_slave(mysql_connection)) {
-        return (false);
-      }
-    }
-
     if (!backup_files(MySQL_datadir_path.path().c_str(), true)) {
       return (false);
     }

--- a/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
+++ b/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
@@ -42,7 +42,7 @@ mysql -e "alter instance enable innodb redo_log"
 
 vlog "### case #3 check when redo log is disabled after backup is started ###"
 run_cmd_expect_failure xtrabackup  --backup \
-        --target-dir=$topdir/full   \
+        --target-dir=$topdir/full --lock-ddl=false   \
 	--debug-sync="data_copy_thread_func" 2>&1 \
         | tee $topdir/full.log &
 job_pid=$!
@@ -67,7 +67,7 @@ mysql -e "alter instance enable innodb redo_log"
 
 vlog "### case #4 check redo log is disabled during incremental backup ###"
 run_cmd xtrabackup --backup --target-dir=$topdir/full
-run_cmd_expect_failure xtrabackup --backup --target-dir=$topdir/inc \
+run_cmd_expect_failure xtrabackup --backup --lock-ddl=false --target-dir=$topdir/inc \
 	--incremental-basedir=$topdir/full \
 	--debug-sync="data_copy_thread_func" 2>&1 \
 	| tee $topdir/inc.log &

--- a/storage/innobase/xtrabackup/test/t/bug1277403.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1277403.sh
@@ -12,7 +12,7 @@ has_backup_locks && skip_test "Requires server without backup locks support"
 
 mysql -e 'CREATE TABLE t1 (a INT) engine=MyISAM' test
 
-xtrabackup --backup --target-dir=$topdir/full_backup
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/full_backup
 
 grep_general_log > $topdir/log1
 

--- a/storage/innobase/xtrabackup/test/t/bug1291299.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1291299.sh
@@ -10,7 +10,7 @@ remote_dir=$TEST_VAR_ROOT/var1/remote_dir
 mkdir -p $remote_dir
 start_server --innodb_directories=$remote_dir
 
-xtrabackup --backup --target-dir=$topdir/backup \
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup \
            --debug-sync="data_copy_thread_func" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/bug1461735.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1461735.sh
@@ -13,7 +13,7 @@ debug-sync=xtrabackup_load_tablespaces_pause
 start_server
 
 function backup_local() {
-	xtrabackup --backup --target-dir=$topdir/backup
+	xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup
 }
 
 function prepare_local() {
@@ -21,7 +21,7 @@ function prepare_local() {
 }
 
 function backup_xbstream() {
-	xtrabackup --backup --stream=xbstream --target-dir=$topdir/backup > $topdir/backup.xbs
+	xtrabackup --backup --lock-ddl=false --stream=xbstream --target-dir=$topdir/backup > $topdir/backup.xbs
 }
 
 function prepare_xbstream() {
@@ -30,7 +30,7 @@ function prepare_xbstream() {
 }
 
 function backup_rsync() {
-	xtrabackup --backup --rsync --target-dir=$topdir/backup
+	xtrabackup --backup --lock-ddl=false --rsync --target-dir=$topdir/backup
 }
 
 function prepare_rsync() {

--- a/storage/innobase/xtrabackup/test/t/create_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/t/create_tablespace.sh
@@ -46,7 +46,7 @@ INSERT INTO test.t2_3 VALUES (1100), (1200), (1300);
 EOF
 
 xtrabackup --backup --target-dir=$topdir/inc \
-	   --incremental-basedir=$topdir/full \
+	   --incremental-basedir=$topdir/full --lock-ddl=false \
 	   --debug-sync="data_copy_thread_func" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/ddl.sh
+++ b/storage/innobase/xtrabackup/test/t/ddl.sh
@@ -45,7 +45,8 @@ start_server
 mkdir -p $topdir/backup
 
 # Backup
-xtrabackup --datadir=$mysql_datadir --backup --target-dir=$topdir/backup \
+xtrabackup --datadir=$mysql_datadir --lock-ddl=false --backup \
+    --target-dir=$topdir/backup \
     --debug-sync="data_copy_thread_func" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_slave_info.sh
@@ -74,7 +74,7 @@ run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --slave-info --no-lock \
   --target-dir=$topdir/backup
 
 vlog "Full backup of the slave server"
-xtrabackup --backup --target-dir=$topdir/backup --slave-info 2>&1 | tee $topdir/pxb.log
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup --slave-info 2>&1 | tee $topdir/pxb.log
 
 grep_general_log > $topdir/log1
 
@@ -108,7 +108,7 @@ mysql -e "TRUNCATE TABLE mysql.general_log;"
 mkdir $topdir/xbstream_backup
 
 vlog "Full backup of the slave server to a xbstream stream"
-xtrabackup --backup --slave-info --stream=xbstream \
+xtrabackup --backup --lock-ddl=false --slave-info --stream=xbstream \
     | xbstream -xv -C $topdir/xbstream_backup
 
 cat $topdir/xbstream_backup/xtrabackup_slave_info
@@ -149,7 +149,7 @@ setup_slave GTID $slave2_id $master_id
 mysql -e "SET GLOBAL general_log=1; SET GLOBAL log_output='TABLE';"
 
 vlog "Full backup of the GTID with AUTO_POSITION slave server"
-xtrabackup --backup --slave-info --target-dir=$topdir/backup
+xtrabackup --backup --lock-ddl=false --slave-info --target-dir=$topdir/backup
 
 grep_general_log > $topdir/log3
 
@@ -180,7 +180,7 @@ start_server_with_id $slave3_id
 setup_slave $slave3_id $master_id
 
 vlog "Full backup of the GTID slave server"
-xtrabackup --backup --slave-info --target-dir=$topdir/backup
+xtrabackup --backup --lock-ddl=false --slave-info --target-dir=$topdir/backup
 
 run_cmd egrep -q "$binlog_slave_info_pattern" \
     $topdir/backup/xtrabackup_slave_info

--- a/storage/innobase/xtrabackup/test/t/keyring_pxb_2275.sh
+++ b/storage/innobase/xtrabackup/test/t/keyring_pxb_2275.sh
@@ -16,7 +16,7 @@ load_dbase_data sakila
 mkdir $topdir/backup
 
 # Test 1 - should fail since we don't have any entry on keyring file yet
-run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --backup \
+run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
 --target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
 
 job_pid=$!
@@ -68,7 +68,7 @@ $MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1" sakila
 
 
 # Test 2 - Should pass as keyring file alwady have encryption information
-run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --backup \
+run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
 --target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/pxb-1679.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1679.sh
@@ -27,7 +27,7 @@ CREATE TABLE test02 (id int auto_increment primary key, a TEXT, b TEXT);
 INSERT INTO test02 SELECT * FROM test01;
 EOF
 
-xtrabackup --backup --target-dir=$topdir/backup 2>&1 | tee /dev/stderr | \
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup 2>&1 | tee /dev/stderr | \
     while read line ; do
         echo $line
         if [ $( echo $line | grep -i -c './test/test01#p#p3.ibd') -eq 1 ]; then

--- a/storage/innobase/xtrabackup/test/t/pxb-1784.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1784.sh
@@ -1,7 +1,8 @@
 #
 # PXB-1784: ALTER UNDO TABLESPACE fails after restore when undo tablespace
 #           state is changed during backup
-#
+# As part of making lock-ddl default it is to check ALTER UNDO TABLESPACE set INACTIVE/ACTIVE
+#should work with both ps and ms
 
 start_server
 
@@ -12,7 +13,7 @@ while true ; do
     mysql -e "ALTER UNDO TABLESPACE undo1 SET ACTIVE"
 done &
 
-xtrabackup --no-backup-locks --lock-ddl --backup --target-dir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/backup
 
 mysql -e "CREATE UNDO TABLESPACE undo2 ADD DATAFILE 'undo2.ibu'"
 
@@ -21,7 +22,7 @@ while true ; do
     mysql -e "ALTER UNDO TABLESPACE undo2 SET ACTIVE"
 done &
 
-xtrabackup --no-backup-locks --lock-ddl --backup --incremental-basedir=$topdir/backup --target-dir=$topdir/inc
+xtrabackup --backup --incremental-basedir=$topdir/backup --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc

--- a/storage/innobase/xtrabackup/test/t/pxb-1870.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1870.sh
@@ -23,5 +23,5 @@ PARTITION BY HASH (uid)
 PARTITIONS 3000;
 EOF
 
-xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/pxb-1914.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1914.sh
@@ -15,12 +15,12 @@ xtrabackup --backup --target-dir=$topdir/bak1 --binlog-info=ON
 
 rm -rf $topdir/bak1
 
-xtrabackup --backup --backup-lock-retry-count=5 --backup-lock-timeout=3 \
+xtrabackup --backup --lock-ddl=false --backup-lock-retry-count=5 --backup-lock-timeout=3 \
 	   --target-dir=$topdir/bak1 --binlog-info=ON
 
 rm -rf $topdir/bak1
 
-xtrabackup --backup --backup-lock-timeout=2 --backup-lock-retry-count=4 \
+xtrabackup --backup --lock-ddl=false --backup-lock-timeout=2 --backup-lock-retry-count=4 \
 	   --no-backup-locks --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1

--- a/storage/innobase/xtrabackup/test/t/pxb-2357.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2357.sh
@@ -12,7 +12,7 @@ start_server --innodb-redo-log-archive-dirs=":$TEST_VAR_ROOT/b"
 
 mkdir $topdir/backup
 
-xtrabackup --backup --target-dir=$topdir/backup \
+xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup \
            --debug-sync="stop_before_redo_archive" \
            2> >(tee $topdir/backup.log)&
 

--- a/storage/innobase/xtrabackup/test/t/undo_truncation.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_truncation.sh
@@ -18,5 +18,5 @@ for i in {1..100} ; do
 done &
 
 sleep 1s
-run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --lock-ddl=false --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
@@ -12,7 +12,7 @@ load_dbase_data sakila
 mkdir $topdir/backup
 
 run_cmd_expect_failure $XB_BIN $XB_ARGS --datadir=$mysql_datadir --backup \
-    --innodb_log_file_size=4M --target-dir=$topdir/backup \
+    --lock-ddl=false --innodb_log_file_size=4M --target-dir=$topdir/backup \
     --debug-sync="xtrabackup_copy_logfile_pause" &
 
 job_pid=$!


### PR DESCRIPTION
Without --lock-ddl(default as OFF), concurrent DDLs can occur and PXB can take
invalid backups. i.e. --backup will succeed but fail at prepare stage.

So if some DDL happened during  backup without
the knowledge of user, he might think the backup succeeded.
The backup taken is corrupted. For example, see bugs: PXB-1974 PXB-1972 PXB-1969.
These are just few bugs with CREATE and TRUNCATE in progress during backup.

If --no-lock or --safe-slave-backup is used, --lock-ddl will be disabled, ie it
will be treated as OFF

--safe-slave-backup now stops SQL thread before starting InnoDB tables
Previously, it was taken after InnoDB file and before non-InnoDB tables