### PR TITLE
PXB-2112 xbcloud: Add support for S3 storage classes

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/xbcloud/xbcloud.rst
+++ b/storage/innobase/xtrabackup/doc/source/xbcloud/xbcloud.rst
@@ -101,9 +101,13 @@ The following options are available when using |s3|:
    * - --s3-bucket-lookup = <AUTO|PATH|DNS>
      - Specify whether to use **bucket.endpoint.com** or *endpoint.com/bucket**
        style requests. The default value is AUTO. In this case, |xbcloud| will probe.
+   * - --s3-storage-class = <STANDARD|STANDARD_IA|GLACIER|...>
+     - Specify the S3 storage class to use when uploading objects. By default,
+       the storage class not specified by the client, so on Amazon S3 it
+       defaults to STANDARD.
 
 Creating a full backup with |minio|
-	    
+
 .. code-block:: bash
 
    $ xtrabackup --backup --stream=xbstream --extra-lsndir=/tmp --target-dir=/tmp | \
@@ -128,7 +132,7 @@ compatible with |s3|.
       https://cloud.google.com/storage/docs/interoperability
 
 .. code-block:: bash
-		
+
    $ xtrabackup --backup --stream=xbstream --extra-lsndir=/tmp --target-dir=/tmp | \
    xbcloud put --storage=google \
    --google-endpoint=`storage.googleapis.com` \
@@ -381,9 +385,9 @@ database you can specify only the tables you want to restore:
    --swift-auth-url=http://127.0.0.1:35357/ full_backup \
    ibdata1 sakila/payment.ibd \
    > /storage/partial/partial.xbs
- 
+
    $ xbstream -xv -C /storage/partial < /storage/partial/partial.xbs
- 
+
 This command will download just ``ibdata1`` and ``sakila/payment.ibd`` table
 from the full backup.
 

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define AWS_DATE_HEADER "X-Amz-Date"
 #define AWS_CONTENT_SHA256_HEADER "X-Amz-Content-SHA256"
 #define AWS_SESSION_TOKEN_HEADER "X-Amz-Security-Token"
+#define AWS_STORAGE_CLASS_HEADER "X-Amz-Storage-Class"
 #define AWS_SIGNATURE_ALGORITHM "AWS4-HMAC-SHA256"
 
 namespace xbcloud {
@@ -594,6 +595,9 @@ bool S3_client::async_upload_object(
     return false;
   }
   req->add_header("Content-Type", "application/octet-stream");
+  if (!storage_class.empty()) {
+    req->add_header(AWS_STORAGE_CLASS_HEADER, storage_class);
+  }
   for (const auto &h : extra_http_headers) {
     req->add_header(h.first, h.second);
   }

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -126,6 +126,7 @@ class S3_client {
   std::string access_key;
   std::string secret_key;
   std::string session_token;
+  std::string storage_class;
 
   s3_bucket_lookup_t bucket_lookup{LOOKUP_AUTO};
 
@@ -194,6 +195,8 @@ class S3_client {
 
   void set_api_version(s3_api_version_t version) { api_version = version; }
 
+  void set_storage_class(const std::string &sc) { storage_class = sc; }
+
   bool probe_api_version_and_lookup(const std::string &bucket);
 
   bool delete_object(const std::string &bucket, const std::string &name);
@@ -239,10 +242,12 @@ class S3_object_store : public Object_store {
                   const std::string &session_token,
                   const std::string &endpoint = std::string(),
                   s3_bucket_lookup_t bucket_lookup = LOOKUP_DNS,
-                  s3_api_version_t api_version = S3_V_AUTO)
+                  s3_api_version_t api_version = S3_V_AUTO,
+                  const std::string &storage_class = std::string())
       : s3_client{client, region, access_key, secret_key} {
     if (!session_token.empty()) s3_client.set_session_token(session_token);
     if (!endpoint.empty()) s3_client.set_endpoint(endpoint);
+    if (!storage_class.empty()) s3_client.set_storage_class(storage_class);
     s3_client.set_bucket_lookup(bucket_lookup);
     s3_client.set_api_version(api_version);
   }

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -87,6 +87,7 @@ static char *opt_s3_access_key = nullptr;
 static char *opt_s3_secret_key = nullptr;
 static char *opt_s3_session_token = nullptr;
 static char *opt_s3_bucket = nullptr;
+static char *opt_s3_storage_class = nullptr;
 static ulong opt_s3_bucket_lookup;
 static ulong opt_s3_api_version = 0;
 
@@ -148,6 +149,7 @@ enum {
   OPT_S3_BUCKET,
   OPT_S3_BUCKET_LOOKUP,
   OPT_S3_API_VERSION,
+  OPT_S3_STORAGE_CLASS,
 
   OPT_GOOGLE_REGION,
   OPT_GOOGLE_ENDPOINT,
@@ -279,6 +281,10 @@ static struct my_option my_long_options[] = {
     {"s3-api-version", OPT_S3_API_VERSION, "S3 API version.",
      &opt_s3_api_version, &opt_s3_api_version, &s3_api_version_typelib,
      GET_ENUM, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
+    {"s3-storage-class", OPT_S3_STORAGE_CLASS, "S3 storage class.",
+     &opt_s3_storage_class, &opt_s3_storage_class, 0, GET_STR_ALLOC,
+     REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
     {"google-region", OPT_GOOGLE_REGION, "Google cloud storage region.",
      &opt_google_region, &opt_google_region, 0, GET_STR_ALLOC, REQUIRED_ARG, 0,
@@ -418,6 +424,7 @@ static void get_env_args() {
   get_env_value(opt_s3_region, "S3_DEFAULT_REGION");
   get_env_value(opt_cacert, "S3_CA_BUNDLE");
   get_env_value(opt_s3_endpoint, "S3_ENDPOINT");
+  get_env_value(opt_s3_storage_class, "S3_STORAGE_CLASS");
 
   get_env_value(opt_s3_access_key, "AWS_ACCESS_KEY_ID");
   get_env_value(opt_s3_secret_key, "AWS_SECRET_ACCESS_KEY");
@@ -425,11 +432,13 @@ static void get_env_args() {
   get_env_value(opt_s3_region, "AWS_DEFAULT_REGION");
   get_env_value(opt_cacert, "AWS_CA_BUNDLE");
   get_env_value(opt_s3_endpoint, "AWS_ENDPOINT");
+  get_env_value(opt_s3_storage_class, "AWS_STORAGE_CLASS");
 
   get_env_value(opt_s3_access_key, "ACCESS_KEY_ID");
   get_env_value(opt_s3_secret_key, "SECRET_ACCESS_KEY");
   get_env_value(opt_s3_region, "DEFAULT_REGION");
   get_env_value(opt_s3_endpoint, "ENDPOINT");
+  get_env_value(opt_s3_storage_class, "STORAGE_CLASS");
 
   get_env_value(opt_google_access_key, "ACCESS_KEY_ID");
   get_env_value(opt_google_secret_key, "SECRET_ACCESS_KEY");
@@ -1083,7 +1092,8 @@ int main(int argc, char **argv) {
         &http_client, region, access_key, secret_key, session_token,
         opt_s3_endpoint != nullptr ? opt_s3_endpoint : "",
         static_cast<s3_bucket_lookup_t>(opt_s3_bucket_lookup),
-        static_cast<s3_api_version_t>(opt_s3_api_version)));
+        static_cast<s3_api_version_t>(opt_s3_api_version),
+        opt_s3_storage_class != nullptr ? opt_s3_storage_class : ""));
 
     if (opt_s3_bucket == nullptr) {
       msg_ts("%s: S3 bucket is not specified.\n", my_progname);


### PR DESCRIPTION
Add `--s3-storage-class` option to specify the S3 storage class object should
be uploaded in, instead of the `STANDARD` default.

Closes https://jira.percona.com/browse/PXB-2112

Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>