### PR TITLE
PXB-2242 Prevent back up if Source system (DB) version is higher the…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -390,6 +390,7 @@ bool opt_force_non_empty_dirs = FALSE;
 #ifdef HAVE_VERSION_CHECK
 bool opt_noversioncheck = FALSE;
 #endif
+bool opt_no_server_version_check = FALSE;
 bool opt_no_backup_locks = FALSE;
 bool opt_decompress = FALSE;
 bool opt_remove_original = FALSE;
@@ -650,6 +651,7 @@ enum options_xtrabackup {
   OPT_FORCE_NON_EMPTY_DIRS,
 #ifdef HAVE_VERSION_CHECK
   OPT_NO_VERSION_CHECK,
+  OPT_NO_SERVER_VERSION_CHECK,
 #endif
   OPT_NO_BACKUP_LOCKS,
   OPT_ROLLBACK_PREPARED_TRX,
@@ -1019,6 +1021,13 @@ struct my_option xb_client_options[] = {
      "directory, it will still fail with an error.",
      (uchar *)&opt_force_non_empty_dirs, (uchar *)&opt_force_non_empty_dirs, 0,
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+    {"no-server-version-check", OPT_NO_SERVER_VERSION_CHECK,
+     "This option allow backup to proceed"
+     "when server version is greater (newer) than the PXB version",
+     (uchar *)&opt_no_server_version_check,
+     (uchar *)&opt_no_server_version_check, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0,
+     0},
 
 #ifdef HAVE_VERSION_CHECK
     {"no-version-check", OPT_NO_VERSION_CHECK,

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1023,7 +1023,7 @@ struct my_option xb_client_options[] = {
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
     {"no-server-version-check", OPT_NO_SERVER_VERSION_CHECK,
-     "This option allow backup to proceed"
+     "This option allows backup to proceed"
      "when server version is greater (newer) than the PXB version",
      (uchar *)&opt_no_server_version_check,
      (uchar *)&opt_no_server_version_check, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0,

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -792,6 +792,16 @@ function require_server_version_higher_than()
         skip_test "Requires server version higher than $1"
 }
 
+#########################################################################
+# Requires debug pxb version
+########################################################################
+function require_debug_pxb_version()
+{
+    if ! $XB_BIN --help 2>&1 | grep -q debug.=name; then
+        skip_test "Requires debug build"
+    fi
+}
+
 ########################################################################
 # Return 0 if the server version is lower than the first argument
 #########################################################################

--- a/storage/innobase/xtrabackup/test/t/simulate_lower_version.sh
+++ b/storage/innobase/xtrabackup/test/t/simulate_lower_version.sh
@@ -1,0 +1,16 @@
+########################################################################
+# PXB should error out with upper version of MySQL or PS
+########################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+
+start_server
+
+vlog "case#1 backup should fail with lower version"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --debug=d,simulate_lower_version --target-dir=$topdir/backup
+
+vlog "case#2 backup should succesful with no-server-version-check lower version"
+xtrabackup --backup --debug=d,simulate_lower_version --no-server-version-check --target-dir=$topdir/backup
+rm -r $topdir/backup

--- a/storage/innobase/xtrabackup/test/t/version_check.sh
+++ b/storage/innobase/xtrabackup/test/t/version_check.sh
@@ -10,6 +10,10 @@
 
 start_server
 
+#test server version check
+xtrabackup --backup --no-server-version-check --target-dir=$topdir/backup1
+rm -r $topdir/backup1
+
 # Override the directory where percona-version-check is created to make the test
 # stable
 


### PR DESCRIPTION
…n current PXB version

Add a configuration parameter --no-server-version-check to allow override
of the check process.  The default is override is off (must turn on override) 
If same base upstream/Percona version and PXB version - allow back up to proceed
If base upsteam/Percona version is less then PXB version - allow back up
to proceed
If base upstream/Percona version is greater (newer) then PXB version and
no-server-version-check is  set to allow backup - allow back up to proceed 
If base upstream/Percona version is greater (newer) then PXB version and
no-server-version-check is NOT set to allow back up - prevent back from
occurring - provide compete notification 