### PR TITLE
8.0 Fixed PXB-2272 (Regexp from is_tmp_table doesn't account for all temp…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -2209,7 +2209,7 @@ bool is_fts_index(const std::string &tablespace) {
 }
 
 bool is_tmp_table(const std::string &tablespace) {
-  const char *pattern = "^#sql-";
+  const char *pattern = "^#sql";
   const char *error_context = "is_tmp_table";
   return check_regexp_table_name(tablespace, error_context, pattern);
 }


### PR DESCRIPTION
…orary tables)

https://jira.percona.com/browse/PXB-2272

Fixed regexp to consider all #sql as temporary tables.

(This will be cherry-picked on 8.0).

(cherry picked from commit c66e3a9784282cad28effcc54d4064fe4b1d4069)