### PR TITLE
2.4 Fixed PXB-1462 (long gtid_executed breaks --history functionality)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1867,7 +1867,7 @@ write_xtrabackup_info(MYSQL *connection)
 		"start_time TIMESTAMP NULL DEFAULT NULL,"
 		"end_time TIMESTAMP NULL DEFAULT NULL,"
 		"lock_time BIGINT UNSIGNED DEFAULT NULL,"
-		"binlog_pos VARCHAR(128) DEFAULT NULL,"
+		"binlog_pos TEXT DEFAULT NULL,"
 		"innodb_from_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"innodb_to_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"partial ENUM('Y', 'N') DEFAULT NULL,"


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-1462

xtrabackup_history table has a limited length for binlog_pos.
gtid_executed field can grown in case of gaps of multi source
replication making it not fit the current 128 char long field.

Fix
Change binlog_pos to use TEXT fild type.