### PR TITLE
8.0 Fixed PXB-1462 (long gtid_executed breaks --history functionality)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1867,7 +1867,7 @@ write_xtrabackup_info(MYSQL *connection)
 		"start_time TIMESTAMP NULL DEFAULT NULL,"
 		"end_time TIMESTAMP NULL DEFAULT NULL,"
 		"lock_time BIGINT UNSIGNED DEFAULT NULL,"
-		"binlog_pos VARCHAR(128) DEFAULT NULL,"
+		"binlog_pos TEXT DEFAULT NULL,"
 		"innodb_from_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"innodb_to_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"partial ENUM('Y', 'N') DEFAULT NULL,"

--- a/storage/innobase/xtrabackup/test/t/history_on_server.sh
+++ b/storage/innobase/xtrabackup/test/t/history_on_server.sh
@@ -220,3 +220,26 @@ run_cmd_expect_failure $IB_BIN $IB_ARGS --incremental \
 vlog "Testing bad --incremental-history-uuid"
 run_cmd_expect_failure $IB_BIN $IB_ARGS --incremental \
 --incremental-history-uuid=foo --stream=tar $backup_dir > /dev/null
+
+
+
+###############################################################################
+# PXB-1462 - long gtid_executed breaks --history functionality
+. inc/common.sh
+if is_server_version_higher_than 5.6.0
+then
+  stop_server
+  start_server --server-id=1 --enforce-gtid-consistency --gtid-mode=ON --log-bin
+  ${MYSQL} ${MYSQL_ARGS} -Ns -e "RESET MASTER"
+  ${MYSQL} ${MYSQL_ARGS} -Ns -e "SET GLOBAL gtid_purged='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaab:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaac:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaad:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaae:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaf:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa0:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa2:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa3:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa4:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa5:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa6:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa7:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa8:1,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa9:1'"
+  ${MYSQL} ${MYSQL_ARGS} -Ns -e "DROP TABLE IF EXISTS PERCONA_SCHEMA.xtrabackup_history"
+  xtrabackup --backup --history --target-dir=$topdir/backup0
+  val=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM PERCONA_SCHEMA.xtrabackup_history"`
+  if [ -z "$val" ] || [ "$val" != "1" ]
+  then
+      vlog "Error inserting data into xtrabackup_history table"
+      exit 1
+  fi
+else
+  vlog "Server does not support GTID"
+fi


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-1462

xtrabackup_history table has a limited length for binlog_pos.
gtid_executed field can grown in case of gaps of multi source
replication making it not fit the current 128 char long field.

Fix
Change binlog_pos to use TEXT fild type.