### PR TITLE
2.4 PXB-2112 xbcloud: Add support for S3 storage classes

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define AWS_CONTENT_SHA256_HEADER "X-Amz-Content-SHA256"
 #define AWS_SESSION_TOKEN_HEADER "X-Amz-Security-Token"
 #define AWS_SIGNATURE_ALGORITHM "AWS4-HMAC-SHA256"
+#define AWS_STORAGE_CLASS_HEADER "X-Amz-Storage-Class"
 
 namespace xbcloud {
 
@@ -186,6 +187,9 @@ void S3_signerV4::sign_request(const std::string &hostname,
     req.add_header(AWS_SESSION_TOKEN_HEADER, session_token);
   }
 
+  if (!storage_class.empty()) {
+    req.add_header(AWS_STORAGE_CLASS_HEADER, storage_class);
+  }
   std::string signed_headers;
   auto string_to_sign = build_string_to_sign(req, signed_headers);
 
@@ -441,8 +445,9 @@ bool S3_client::probe_api_version_and_lookup(const std::string &bucket) {
         signer = std::unique_ptr<S3_signer>(
             new S3_signerV2(lookup, region, access_key, secret_key));
       } else {
-        signer = std::unique_ptr<S3_signer>(new S3_signerV4(
-            lookup, region, access_key, secret_key, session_token));
+        signer = std::unique_ptr<S3_signer>(
+            new S3_signerV4(lookup, region, access_key, secret_key,
+                            session_token, storage_class));
       }
       auto tmp_lookup = bucket_lookup;
       auto tmp_version = api_version;

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -61,6 +61,7 @@ class S3_signerV4 : public S3_signer {
   std::string access_key;
   std::string secret_key;
   std::string session_token;
+  std::string storage_class;
 
   static std::string aws_date_format(time_t t);
 
@@ -73,12 +74,14 @@ class S3_signerV4 : public S3_signer {
  public:
   S3_signerV4(s3_bucket_lookup_t lookup, const std::string &region,
               const std::string &access_key, const std::string &secret_key,
-              const std::string &session_token = std::string())
+              const std::string &session_token = std::string(),
+              const std::string &storage_class = std::string())
       : lookup(lookup),
         region(region),
         access_key(access_key),
         secret_key(secret_key),
-        session_token(session_token) {}
+        session_token(session_token),
+        storage_class(storage_class) {}
 
   void sign_request(const std::string &hostname, const std::string &bucket,
                     Http_request &req, time_t t);
@@ -126,6 +129,7 @@ class S3_client {
   std::string access_key;
   std::string secret_key;
   std::string session_token;
+  std::string storage_class;
 
   s3_bucket_lookup_t bucket_lookup{LOOKUP_AUTO};
 
@@ -171,6 +175,7 @@ class S3_client {
     protocol = Http_request::HTTPS;
     rtrim_slashes(host);
     session_token = "";
+    storage_class = "";
   }
 
   void set_endpoint(const std::string &ep) {
@@ -187,10 +192,10 @@ class S3_client {
     }
     rtrim_slashes(host);
   }
-  
-  void set_session_token(const std::string &st) {
-    session_token = st;
-  }
+
+  void set_session_token(const std::string &st) { session_token = st; }
+
+  void set_storage_class(const std::string &sc) { storage_class = sc; }
 
   void set_bucket_lookup(s3_bucket_lookup_t val) { bucket_lookup = val; }
 
@@ -239,11 +244,13 @@ class S3_object_store : public Object_store {
   S3_object_store(const Http_client *client, std::string &region,
                   const std::string &access_key, const std::string &secret_key,
                   const std::string &session_token,
+                  const std::string &storage_class,
                   const std::string &endpoint = std::string(),
                   s3_bucket_lookup_t bucket_lookup = LOOKUP_DNS,
                   s3_api_version_t api_version = S3_V_AUTO)
       : s3_client{client, region, access_key, secret_key} {
-    if (!session_token.empty()) s3_client.set_session_token(session_token);      
+    if (!session_token.empty()) s3_client.set_session_token(session_token);
+    if (!storage_class.empty()) s3_client.set_storage_class(storage_class);
     if (!endpoint.empty()) s3_client.set_endpoint(endpoint);
     s3_client.set_bucket_lookup(bucket_lookup);
     s3_client.set_api_version(api_version);

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
@@ -214,6 +214,28 @@ TEST(s3v4_signer, sessionToken) {
                "e");
 }
 
+TEST(s3v4_signer, storageClass) {
+  Http_request req(Http_request::GET, Http_request::HTTPS, "hyhost",
+                   "mybucket/myobject/");
+  req.add_header("Content-Length", "4");
+  req.add_header("Content-Type", "application/octet-stream");
+  req.append_payload("test", 4);
+
+  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key",
+                     "session_token", "storage_class");
+
+  signer.sign_request("myhost", "mybucket", req, 1555892546);
+
+  ASSERT_STREQ(req.headers().at("Authorization").c_str(),
+               "AWS4-HMAC-SHA256 "
+               "Credential=access_key/20190422/example-region/s3/aws4_request, "
+               "SignedHeaders=content-length;content-type;host;x-amz-content-"
+               "sha256;x-amz-date;x-amz-security-token;x-amz-storage-class, "
+               "Signature="
+               "891034a3bd13729689a54d363380ad1849b26bf2b9e461d4c2bdeeca32e0c1c"
+               "e");
+}
+
 TEST(s3v2_signer, basicDNS) {
   Http_request req(Http_request::GET, Http_request::HTTPS, "mybucket.hyhost",
                    "myobject/");

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -84,6 +84,7 @@ static char *opt_s3_endpoint = nullptr;
 static char *opt_s3_access_key = nullptr;
 static char *opt_s3_secret_key = nullptr;
 static char *opt_s3_session_token = nullptr;
+static char *opt_s3_storage_class = nullptr;
 static char *opt_s3_bucket = nullptr;
 static ulong opt_s3_bucket_lookup;
 static ulong opt_s3_api_version = 0;
@@ -93,6 +94,7 @@ static char *opt_google_endpoint = nullptr;
 static char *opt_google_access_key = nullptr;
 static char *opt_google_secret_key = nullptr;
 static char *opt_google_session_token = nullptr;
+static char *opt_google_storage_class = nullptr;
 static char *opt_google_bucket = nullptr;
 
 static std::string backup_name;
@@ -143,6 +145,7 @@ enum {
   OPT_S3_ACCESS_KEY,
   OPT_S3_SECRET_KEY,
   OPT_S3_SESSION_TOKEN,
+  OPT_S3_STORAGE_CLASS,
   OPT_S3_BUCKET,
   OPT_S3_BUCKET_LOOKUP,
   OPT_S3_API_VERSION,
@@ -152,6 +155,7 @@ enum {
   OPT_GOOGLE_ACCESS_KEY,
   OPT_GOOGLE_SECRET_KEY,
   OPT_GOOGLE_SESSION_TOKEN,
+  OPT_GOOGLE_STORAGE_CLASS,
   OPT_GOOGLE_BUCKET,
 
   OPT_PARALLEL,
@@ -267,6 +271,14 @@ static struct my_option my_long_options[] = {
      &opt_s3_session_token, &opt_s3_session_token, 0, GET_STR_ALLOC,
      REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
+    {"s3-storage-class", OPT_S3_STORAGE_CLASS,
+     "S3 storage class. STANDARD|STANDARD_IA|GLACIER|...     "
+     "... is meant for passing "
+     "custom storage class names provided by other S3 implementations such as "
+     "MinIO CephRadosGW, etc.",
+     &opt_s3_storage_class, &opt_s3_storage_class, 0, GET_STR_ALLOC,
+     REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
     {"s3-bucket", OPT_S3_BUCKET, "S3 bucket.", &opt_s3_bucket, &opt_s3_bucket,
      0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
@@ -298,6 +310,11 @@ static struct my_option my_long_options[] = {
      "Goolge cloud storage session token.", &opt_google_session_token,
      &opt_google_session_token, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0,
      0},
+
+    {"google-storage-class", OPT_GOOGLE_STORAGE_CLASS,
+     "Goolge cloud storage class. STANDARD|NEARLINE|COLDLINE|ARCHIVE",
+     &opt_google_storage_class, &opt_google_storage_class, 0, GET_STR_ALLOC,
+     REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
     {"google-bucket", OPT_GOOGLE_BUCKET, "Goolge cloud storage bucket.",
      &opt_google_bucket, &opt_google_bucket, 0, GET_STR_ALLOC, REQUIRED_ARG, 0,
@@ -414,6 +431,7 @@ static void get_env_args() {
   get_env_value(opt_s3_access_key, "S3_ACCESS_KEY_ID");
   get_env_value(opt_s3_secret_key, "S3_SECRET_ACCESS_KEY");
   get_env_value(opt_s3_session_token, "S3_SESSION_TOKEN");
+  get_env_value(opt_s3_storage_class, "S3_STORAGE_CLASS");
   get_env_value(opt_s3_region, "S3_DEFAULT_REGION");
   get_env_value(opt_cacert, "S3_CA_BUNDLE");
   get_env_value(opt_s3_endpoint, "S3_ENDPOINT");
@@ -421,6 +439,7 @@ static void get_env_args() {
   get_env_value(opt_s3_access_key, "AWS_ACCESS_KEY_ID");
   get_env_value(opt_s3_secret_key, "AWS_SECRET_ACCESS_KEY");
   get_env_value(opt_s3_session_token, "AWS_SESSION_TOKEN");
+  get_env_value(opt_s3_storage_class, "AWS_STORAGE_CLASS");
   get_env_value(opt_s3_region, "AWS_DEFAULT_REGION");
   get_env_value(opt_cacert, "AWS_CA_BUNDLE");
   get_env_value(opt_s3_endpoint, "AWS_ENDPOINT");
@@ -1093,9 +1112,11 @@ int main(int argc, char **argv) {
         opt_s3_secret_key != nullptr ? opt_s3_secret_key : "";
     std::string session_token =
         opt_s3_session_token != nullptr ? opt_s3_session_token : "";
+    std::string storage_class =
+        opt_s3_storage_class != nullptr ? opt_s3_storage_class : "";
     object_store = std::unique_ptr<Object_store>(new S3_object_store(
         &http_client, region, access_key, secret_key, session_token,
-        opt_s3_endpoint != nullptr ? opt_s3_endpoint : "",
+        storage_class, opt_s3_endpoint != nullptr ? opt_s3_endpoint : "",
         static_cast<s3_bucket_lookup_t>(opt_s3_bucket_lookup),
         static_cast<s3_api_version_t>(opt_s3_api_version)));
 
@@ -1122,11 +1143,15 @@ int main(int argc, char **argv) {
         opt_google_secret_key != nullptr ? opt_google_secret_key : "";
     std::string session_token =
         opt_google_session_token != nullptr ? opt_google_session_token : "";
+    std::string storage_class =
+        opt_google_storage_class != nullptr ? opt_google_storage_class : "";
+
     object_store = std::unique_ptr<Object_store>(new S3_object_store(
         &http_client, region, access_key, secret_key, session_token,
+        storage_class,
         opt_google_endpoint != nullptr ? opt_google_endpoint
                                        : "https://storage.googleapis.com/",
-        LOOKUP_DNS, S3_V2));
+        LOOKUP_DNS, S3_V4));
 
     if (opt_google_bucket == nullptr) {
       msg_ts("%s: Google bucket is not specified.\n", my_progname);


### PR DESCRIPTION
Introduce new storage class support for xbcloud.

Instead of the using "STANDARD" option for S3 storage, we will now support multiple
storage class types.

Introduced --s3-storage-class option which accepts STANDARD|STANDARD_IA|GLACIER|
Introduced --google-storage-class option which accepts STANDARD|NEARLINE|COLDLINE|ARCHIVE

Thanks to Benoît Knecht <bknecht@protonmail.ch> for providing the patch