### PR TITLE
2.4 PXB-2279 Xbcloud: Upload failed: backup is incomplete (#960)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -715,7 +715,7 @@ bool xbcloud_put(Object_store *store, const std::string &container,
     for (auto cur_file : object_list) {
       if (cur_file.size() >= last_file_size &&
 	  cur_file.substr(0, last_file_size).compare(last_file_prefix) == 0) {
-	file_found = true;
+	  file_found = true;
         break;
       }
     }

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -705,9 +705,22 @@ bool xbcloud_put(Object_store *store, const std::string &container,
     return false;
   }
 
-  // check if xtrabackup_info, almost the last file exists in backup
-  if (std::count(object_list.begin(), object_list.end(),
-                 backup_name + "/xtrabackup_info.00000000000000000000") == 0) {
+  /* check if the xtrabackup_info.gz.00000000000 or
+  xtrabackup_info.00000000000000000000 is uploaded to cloud storage to
+  determine successful xbcloud "put" operation. */
+  bool file_found = false;
+  if (!object_list.empty()) {
+    std::string last_file_prefix = backup_name + "/xtrabackup_info";
+    auto last_file_size = last_file_prefix.size();
+    for (auto cur_file : object_list) {
+      if (cur_file.size() >= last_file_size &&
+	  cur_file.substr(0, last_file_size).compare(last_file_prefix) == 0) {
+	file_found = true;
+        break;
+      }
+    }
+  }
+  if (!file_found) {
     msg_ts("%s: Upload failed: backup is incomplete.\n", my_progname);
     return false;
   }

--- a/storage/innobase/xtrabackup/test/t/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcloud.sh
@@ -138,6 +138,33 @@ if ! grep -q "Upload failed" $topdir/pxb-2202.log ; then
     die 'xbcloud did not exit with error on upload'
 fi
 
+#PXB-2279 Xbcloud: Upload failed: backup is incomplete
+vlog "take full backup to test compression"
+run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf delete \
+	${full_backup_name} --parallel=4
+rm -r $full_backup_dir
+xtrabackup --backup --stream=xbstream --compress --extra-lsndir=$full_backup_dir \
+	   --target-dir=$full_backup_dir | \
+    run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+	    --parallel=4 \
+	    ${full_backup_name} 2> $topdir/pxb-2279.log
+if  grep -q "Upload failed" $topdir/pxb-2279.log ; then
+    die 'xbcloud exit with error on upload'
+fi
+vlog "take full backup to test encryption"
+run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf delete \
+	${full_backup_name} --parallel=4
+rm -r $full_backup_dir
+xtrabackup --backup --stream=xbstream  --encrypt=AES256 \
+          --encrypt-key="percona_xtrabackup_is_awesome___" --extra-lsndir=$full_backup_dir \
+	   --target-dir=$full_backup_dir | \
+    run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+	    --parallel=4 \
+	    ${full_backup_name} 2> $topdir/pxb-2279.log
+if  grep -q "Upload failed" $topdir/pxb-2279.log ; then
+    die 'xbcloud exit with error on upload'
+fi
+
 # cleanup
 run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf delete \
 	${full_backup_name} --parallel=4


### PR DESCRIPTION
 PXB-2279 Xbcloud: Upload failed: backup is incomplete (#960)

    Problem:
    When backup is a compressed backup, xbcloud "put" operation fails with an error message
    The "put" operation is successful but wrongly throws that it failed

    Analysis:
    To validate that xbcloud put operation is successful, xbcloud looks for the
    presence of ""xtrabackup_info.00000000000000000000" in the list of files
    in cloud storage. In case of compressed backup, the filename is
    "xtrabackup_info.gz.00000000000"

    Because of the extra ".gz" in the filename, it doesn't match with the expected
    name and xbcloud wrongly prints the error message.

    Fix:
    Change the check to file  "xtrabackup_info*" instead of "xtrabackup_info*"
    Look for the prefix "xtrabackup_info" without the extensions