### PR TITLE
8.0 Fixed PXB-2313 (bootstrap unset not a valid identifier)

### DIFF
--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -85,7 +85,7 @@ main () {
             fallback_url="https://downloads.mysql.com/archives/get/p/23/file"
             tarball="mysql-${VERSION}-linux-glibc2.12-${arch}.tar.gz"
                 if ! wget --spider "${url}/${tarball}" 2>/dev/null; then
-                    unset $url
+                    unset url
                     url=${fallback_url}
                 fi
             ;;
@@ -94,7 +94,7 @@ main () {
             fallback_url="https://downloads.mysql.com/archives/get/p/23/file"
             tarball="mysql-${VERSION}-linux-glibc2.12-${arch}.tar.gz"
                 if ! wget --spider "${url}/${tarball}" 2>/dev/null; then
-                    unset $url
+                    unset url
                     url=${fallback_url}
                 fi
             ;;


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2313

Unset should not be using $ as prefix for the variable.