### PR TITLE
8.0 Fixed PXB-2275 (PXB crashes during backup if an encrypted table is cr…

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -29,6 +29,8 @@ extern bool mdl_taken;
 
 extern bool use_dumped_tablespace_keys;
 
+extern std::vector<ulint> invalid_encrypted_tablespace_ids;
+
 /** Fetch tablespace key from "xtrabackup_keys".
 @param[in]	space_id	tablespace id
 @param[out]	key		fetched tablespace key

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -38,6 +38,7 @@ extern my_bool opt_lock_ddl_per_table;
 
 extern bool use_dumped_tablespace_keys;
 
+extern std::vector<ulint> invalid_encrypted_tablespace_ids;
 /******************************************************************************
 Callback used in buf_page_io_complete() to detect compacted pages.
 @return TRUE if the page is marked as compacted, FALSE otherwise. */

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -963,6 +963,8 @@ bool Redo_Log_Data_Manager::start() {
    */
   mdl_taken = true;
 
+  debug_sync_point("xtrabackup_pause_after_redo_catchup");
+
   thread.start();
 
   error = false;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -461,6 +461,8 @@ char *opt_server_public_key = NULL;
 static void
 check_all_privileges();
 
+std::vector<ulint> invalid_encrypted_tablespace_ids;
+
 /* Whether xtrabackup_binlog_info should be created on recovery */
 static bool recover_binlog_info;
 
@@ -3598,6 +3600,41 @@ Datafile *xb_new_datafile(
 	}
 }
 
+bool
+validate_missing_encryption_tablespaces()
+{
+	bool ret=true;
+	bool found = false;
+	if (invalid_encrypted_tablespace_ids.size() > 0)
+	{
+		std::vector<ulint>::iterator it;
+		for (it = invalid_encrypted_tablespace_ids.begin();
+		    it != invalid_encrypted_tablespace_ids.end();
+		    it++) {
+			found = false;
+			mutex_enter(&recv_sys->mutex);
+			if (recv_sys->encryption_list != NULL) {
+				encryption_list_t::iterator	it_enc;
+				for (it_enc = recv_sys->encryption_list->begin();
+				     it_enc != recv_sys->encryption_list->end();
+				     it_enc++) {
+					if (it_enc->space_id == (*it)) {
+						found = true;
+						break;
+					}
+				}
+			}
+			mutex_exit(&recv_sys->mutex);
+			if (!found)
+			{
+				msg_ts("xtrabackup: Error: Space ID %lu is missing encryption information.\n", (*it));
+				ret=false;
+			}
+		}
+	}
+	return ret;
+}
+
 void
 xb_load_single_table_tablespace(
 	const char *dirname,
@@ -3695,6 +3732,7 @@ xb_load_single_table_tablespace(
 	} else {
 		/* allow corrupted first page for xtrabackup, it could be just
 		zero-filled page, which we'll restore from redo log later */
+
 		if (xtrabackup_backup && err != DB_PAGE_IS_BLANK) {
 			exit(EXIT_FAILURE);
 		}
@@ -4923,6 +4961,7 @@ reread_log_header:
 
 
 	log_copying_stop = os_event_create("log_copying_stop");
+	debug_sync_point("xtrabackup_pause_after_redo_catchup");
 	os_thread_create(log_copying_thread, NULL, &log_copying_thread_id);
 
 	/* Populate fil_system with tablespaces to copy */
@@ -5060,6 +5099,11 @@ skip_last_cp:
 	if (ds_close(dst_log_file)) {
 		exit(EXIT_FAILURE);
 	}
+
+	if (!validate_missing_encryption_tablespaces()) {
+		exit(EXIT_FAILURE);
+	}
+
 
 	if(!xtrabackup_incremental) {
 		strcpy(metadata_type, "full-backuped");

--- a/storage/innobase/xtrabackup/test/t/keyring_pxb_2275.sh
+++ b/storage/innobase/xtrabackup/test/t/keyring_pxb_2275.sh
@@ -1,0 +1,111 @@
+. inc/common.sh
+. inc/keyring_file.sh
+
+if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
+    skip_test "Requires --debug-sync support"
+fi
+
+if is_server_version_lower_than 5.7.0
+then
+    skip_test "Requires server version 5.7"
+fi
+
+start_server --innodb-log-file-size=8M
+load_dbase_schema sakila
+load_dbase_data sakila
+mkdir $topdir/backup
+
+# Test 1 - should fail since we don't have any entry on keyring file yet
+run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --backup \
+--target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
+
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+# Create some data on Redo
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp1 ENGINE=InnoDB SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+
+
+# Create encrypted table
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp2 (ID INT PRIMARY KEY) ENCRYPTION='Y'" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp2 VALUES (1)" sakila
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+# wait's return code will be the code returned by the background process
+run_cmd wait $job_pid
+rm -rf $topdir/backup
+mkdir $topdir/backup
+
+# Clean-up
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1, tmp2" sakila
+
+# Write data on Redo log so advance checkpoint to after creation of 1st encryption table
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp1 ENGINE=InnoDB SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1" sakila
+
+
+# Test 2 - Should pass as keyring file alwady have encryption information
+run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --backup \
+--target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
+
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+# Create some data on Redo
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp1 ENGINE=InnoDB SELECT * FROM payment" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "DELETE FROM tmp1" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp1 SELECT * FROM payment" sakila
+
+
+# Create encrypted table
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp2 (ID INT PRIMARY KEY) ENCRYPTION='Y'" sakila
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO tmp2 VALUES (1)" sakila
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+# wait's return code will be the code returned by the background process
+run_cmd wait $job_pid
+
+# prepare backup
+run_cmd $XB_BIN $XB_ARGS --xtrabackup-plugin-dir=${plugin_dir} --prepare \
+--target-dir=$topdir/backup ${keyring_args}
+
+# restore
+stop_server
+rm -rf $mysql_datadir
+
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server --innodb-log-file-size=8M
+run_cmd $MYSQL $MYSQL_ARGS -Ns -e "SELECT * FROM tmp2;" sakila


### PR DESCRIPTION
…eated)

https://jira.percona.com/browse/PXB-2275
TDE encryption happens in the phases:

Encryption flag is written to page0 synchronously
Encryption information is written on page0 in memory(buffer pool) and
generates a redo log of type MLOG_WRITE_STRING.
PXB accepts taking a backup if we have a case where tablespace has
encryption flag set but is still missing the encryption information.
It tries to validate if the encryption key having the same tablespace ID
has already been parsed from redo logs by accessing
recv_sys->encryption_list. If it cannot find the key it move forward
anyway on the assumption that the key will eventually be parsed via
redo log follow thread.

Problems:

We are trying to iterate through recv_sys->encryption_list assuming
it has already been populated, however, it can still be a NULL pointer.
The is no guarantee that said redo log will be parsed and and in an
edge case we may finish the backup before the redo event has been parsed
causing the backup to be incomplete.
Fixes:

Validate recv_sys->encryption_list before trying to iterate through.
Create a vector to store tablespace IDs that have a missing key when
we first attempted to open it. At the end of the backup, after we have
already stopped redo follow thread (we won't receive any new redo log
event) we test the list of saved tablespace IDs to validate if the
encryption key has been read via redo log during the backup. In case we
find any missing key, we abort the backup as it means we won't be able
to decrypt this table.