### PR TITLE
Fixed PXB-2321 (PXB-8.0 test is not setting xtrabackup PATH properly …

### DIFF
--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -301,6 +301,12 @@ function set_vars()
         PATH="$PWD/../bin:$PATH"
     fi
 
+    # 8.0 branch run test at xtrabackup-test/test folder
+    if test -d $PWD/../../bin
+    then
+        PATH="$PWD/../../bin:$PATH"
+    fi
+
     PATH="${MYSQL_BASEDIR}/bin:$PATH"
 
     if [ -z "${LD_LIBRARY_PATH:-}" ]; then


### PR DESCRIPTION
…in run.sh)

https://jira.percona.com/browse/PXB-2321

Issue:
In 8.0 branch, when running tests manually, you have to run it from xtrabackup-test/test folder and PATH is not properly set.

Fix:
Add PATH variable to 2 levels down (../../bin/)