### PR TITLE
Fixed PXB-2343 (New unneeded files for packaging appeared)

### DIFF
--- a/libmysql/CMakeLists.txt
+++ b/libmysql/CMakeLists.txt
@@ -262,7 +262,7 @@ IF(WIN32)
 ENDIF()
   
 # Merge several convenience libraries into one big mysqlclient
-MERGE_CONVENIENCE_LIBRARIES(mysqlclient ${LIBS_TO_MERGE} COMPONENT Development)
+MERGE_CONVENIENCE_LIBRARIES(mysqlclient ${LIBS_TO_MERGE} COMPONENT Development SKIP_INSTALL)
 TARGET_LINK_LIBRARIES(mysqlclient ${LIBS_TO_LINK})
 
 # Visual Studio users need debug  static library for debug projects
@@ -308,7 +308,7 @@ IF(NOT DISABLE_SHARED)
   # and link them together into shared library.
   MERGE_LIBRARIES_SHARED(libmysql ${LIBS_TO_MERGE}
     EXPORTS ${CLIENT_API_FUNCTIONS} ${CLIENT_API_FUNCTIONS_UNDOCUMENTED}
-    COMPONENT SharedLibraries)
+    COMPONENT SharedLibraries SKIP_INSTALL)
   TARGET_LINK_LIBRARIES(libmysql ${LIBS_TO_LINK})
   IF(UNIX)
     # libtool compatability

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -161,19 +161,6 @@ IF(UNIX)
 )
 ENDIF()
 
-IF(NOT WITHOUT_SERVER)
-  INSTALL(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/mysql_system_tables.sql
-    ${CMAKE_CURRENT_SOURCE_DIR}/mysql_system_tables_data.sql
-    ${CMAKE_CURRENT_SOURCE_DIR}/fill_help_tables.sql
-    ${CMAKE_CURRENT_SOURCE_DIR}/mysql_sys_schema.sql
-    ${CMAKE_CURRENT_SOURCE_DIR}/mysql_test_data_timezone.sql
-    ${CMAKE_CURRENT_SOURCE_DIR}/mysql_security_commands.sql
-    ${FIX_PRIVILEGES_SQL}
-    DESTINATION ${INSTALL_MYSQLSHAREDIR} COMPONENT Server
-  )
-ENDIF()
-
 SET(COMPILE_DEFINITIONS_WHITELIST
 )
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2343

Issue:
During 5.7.32 merge, libmysql/CMakeLists.txt and scripts/CMakeLists.txt
got overwritten making libmysqlclient and a few share/.sql files to be
generated as part of the build.

Fix:
Added proper CMAKE flags to skip those files (same behavior as on
previous versions).