### PR TITLE
Fixed PXB-787 (Xtrabackup continues after finding corrupted tablespace)

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2259,7 +2259,9 @@ static void xb_scan_for_tablespaces() {
 
   msg("xtrabackup: Generating a list of tablespaces\n");
 
-  fil_scan_for_tablespaces(true);
+  if (fil_scan_for_tablespaces(true) != DB_SUCCESS) {
+    exit(EXIT_FAILURE);
+  }
 }
 
 static void dict_load_from_spaces_sdi() {

--- a/storage/innobase/xtrabackup/test/t/tablespace_corruption.sh
+++ b/storage/innobase/xtrabackup/test/t/tablespace_corruption.sh
@@ -1,0 +1,17 @@
+# PXB-787 - xtrabackup continues after finding corrupted tablespace.
+. inc/common.sh
+start_server
+mkdir $topdir/backup
+
+
+# Create table and make it corrupted
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE DATABASE percona"
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE percona.t1 (ID INT PRIMARY KEY AUTO_INCREMENT)"
+echo "" > $mysql_datadir/percona/t1.ibd
+
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup
+
+rm -rf $topdir/backup
+$MYSQL $MYSQL_ARGS -Ns -e "DROP DATABASE percona"
+


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-787

Problem:
Tablespace_dirs::scan was calling Tablespace_dirs::open_ibd passing
result variable as copy instead of by reference, as a result, changes
made to it inside Tablespace_dirs::open_ibd were not seen by
Tablespace_dirs::scan

Fix:
Adjusted Tablespace_dirs::scan to pass result variable by reference to
Tablespace_dirs::open_ibd