### PR TITLE
Fixed PXB-2345 (ib_databases_file and ib_databases tests are unstable)

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -1113,6 +1113,11 @@ function innodb_wait_for_flush_all()
     while ! innodb_n_dirty_pages ; do
         sleep 1
     done
+
+    flushed_lsn=`innodb_flushed_lsn`
+    while [ `innodb_checkpoint_lsn` -lt "$flushed_lsn" ] ; do
+      sleep 1
+    done
 }
 
 # Return current LSN


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2345

Problem:
innodb_wait_for_flush_all relies on Innodb_buffer_pool_pages_dirty
status to report all dirty pages have been flushed. When using such a
function on xtrabackup testing, one expects the backup to not parse
redo log entries from before that point. However, the status might
report zero dirty pages, but checkpoint has not yet been performed,
causing xtrabackup to start parsing undesired entries from redolog.

Fix:
Added extra check to make sure checkpoint has been performed.