### PR TITLE
PXB-2362 (Extra binaries in PXB after merge of MS8.0.22)

### DIFF
--- a/storage/myisam/CMakeLists.txt
+++ b/storage/myisam/CMakeLists.txt
@@ -112,16 +112,16 @@ MYSQL_ADD_PLUGIN(myisam ha_myisam.cc
 )
 
 
-MYSQL_ADD_EXECUTABLE(myisam_ftdump myisam_ftdump.cc
+MYSQL_ADD_EXECUTABLE(myisam_ftdump myisam_ftdump.cc SKIP_INSTALL
   LINK_LIBRARIES myisam_library)
 
-MYSQL_ADD_EXECUTABLE(myisamchk myisamchk.cc
+MYSQL_ADD_EXECUTABLE(myisamchk myisamchk.cc SKIP_INSTALL
   LINK_LIBRARIES myisam_library)
 
-MYSQL_ADD_EXECUTABLE(myisamlog myisamlog.cc
+MYSQL_ADD_EXECUTABLE(myisamlog myisamlog.cc SKIP_INSTALL
   LINK_LIBRARIES myisam_library ${LIBSOCKET})
 
-MYSQL_ADD_EXECUTABLE(myisampack myisampack.cc
+MYSQL_ADD_EXECUTABLE(myisampack myisampack.cc SKIP_INSTALL
   LINK_LIBRARIES myisam_library)
 
 IF (WIN32)


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2362

Problem:
After 8.0.22 mysql merge, storage/myisam/CMakeLists.txt got overwritten
which caused extra binaries to be installed on bin directory.

Fix:
Add CMake SKIP_INSTALL flag on those binaries.