### PR TITLE
PXB-2357 hang in backup with redo log archive

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -610,10 +610,14 @@ uint32_t Archived_Redo_Log_Monitor::get_first_log_block_checksum() const {
   return first_log_block_checksum;
 }
 
-void Archived_Redo_Log_Monitor::skip_for_block(lsn_t lsn, uint32_t no,
-                                               uint32_t checksum) {
+void Archived_Redo_Log_Monitor::skip_for_block(lsn_t lsn,
+                                               const byte *redo_buf) {
   bool finished = false;
   lsn_t bytes_read = OS_FILE_LOG_BLOCK_SIZE;
+
+  auto redo_block_no = log_block_get_hdr_no(redo_buf);
+  auto redo_block_checksum = log_block_get_checksum(redo_buf);
+  auto redo_block_len = log_block_get_data_len(redo_buf);
 
   while (true) {
     auto len = reader.read_logfile(&finished);
@@ -621,7 +625,14 @@ void Archived_Redo_Log_Monitor::skip_for_block(lsn_t lsn, uint32_t no,
          ptr += OS_FILE_LOG_BLOCK_SIZE, bytes_read += OS_FILE_LOG_BLOCK_SIZE) {
       auto arch_block_no = log_block_get_hdr_no(ptr);
       auto arch_block_checksum = log_block_get_checksum(ptr);
-      if (no == arch_block_no && checksum == arch_block_checksum) {
+      auto arch_block_len = log_block_get_data_len(ptr);
+      /* When checksum of redo and archive blocks are different, allow PXB to
+      switch to archive if the data length of blocks is different. This can
+      happen when the last block is partially filled in redolog and when it
+      reaches the archive file, the same block could be filled more */
+      if (redo_block_no == arch_block_no &&
+          (redo_block_checksum == arch_block_checksum ||
+           redo_block_len != arch_block_len)) {
         msg("xtrabackup: Archived redo log has caught up\n");
         reader.set_start_lsn(lsn - bytes_read);
         return;
@@ -1034,9 +1045,8 @@ void Redo_Log_Data_Manager::track_archived_log(lsn_t start_lsn, const byte *buf,
 
   if (archived_log_state == ARCHIVED_LOG_NONE) {
     auto no = log_block_get_hdr_no(buf);
-    auto checksum = log_block_get_checksum(buf);
     if (no > archived_log_monitor.get_first_log_block_no()) {
-      archived_log_monitor.skip_for_block(start_lsn, no, checksum);
+      archived_log_monitor.skip_for_block(start_lsn, buf);
       archived_log_state = ARCHIVED_LOG_MATCHED;
     }
   }

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -231,7 +231,7 @@ class Archived_Redo_Log_Monitor {
   uint32_t get_first_log_block_checksum() const;
 
   /** Read archived log until the given log block. */
-  void skip_for_block(lsn_t lsn, uint32_t no, uint32_t checksum);
+  void skip_for_block(lsn_t lsn, const byte *redo_buf);
 
  private:
   /** Parse the value of innodb_redo_log_archive_dirs. */

--- a/storage/innobase/xtrabackup/test/t/pxb-2357.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2357.sh
@@ -1,0 +1,37 @@
+# PXB-2357: hang in backup with redo log archive#
+
+if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
+    skip_test "Requires --debug-sync support"
+fi
+
+require_server_version_higher_than 8.0.16
+
+mkdir $TEST_VAR_ROOT/b
+
+start_server --innodb-redo-log-archive-dirs=":$TEST_VAR_ROOT/b"
+
+mkdir $topdir/backup
+
+xtrabackup --backup --target-dir=$topdir/backup \
+           --debug-sync="stop_before_redo_archive" \
+           2> >(tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+mysql -e "create table t(i int)" test 2>/dev/null >/dev/null
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+while true ; do
+	mysql -e "create table t2(i int)" test 2>/dev/null >/dev/null
+	mysql -e "insert into t2 select * from t" test 2>/dev/null >/dev/null
+	mysql -e "drop table t2" test 2>/dev/null >/dev/null
+done  &
+
+run_cmd wait $job_pid


### PR DESCRIPTION
    Problem:
    Hang is backup when redo archive log is enabled and there is
    not enough redo log generated at the end of the backup.

    Analysis:
    When the first log block number in the archive file is lower than the current
    log block number, PXB pauses log copying and wait for archived redo log to
    catch up and switched when the block number and checksum is same as redo
    log file checksum.

    The problem is block checksum of main redo file
    doesn't match with archive redo block and it waits for infinite.
    It happens because pxb copies block number and checksum of partial written
    block and checksum which are later overwritten by the server when more redo are
    generated.

    Fix:
    Since checksum of redo file and archive file can  be different,
    switched only based on block number.