### PR TITLE
PXB-2274 xtrabackup restore failed when there are DML statements runn…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1444,6 +1444,8 @@ bool backup_start(Backup_context &context) {
 
   context.log_status = log_status_get(mysql_connection);
 
+  debug_sync_point("xtrabackup_after_query_log_status");
+
   if (!write_current_binlog_file(mysql_connection)) {
     return (false);
   }

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -97,7 +97,7 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
   return (true);
 }
 
-bool Redo_Log_Reader::find_last_checkpoint_lsn(lsn_t *lsn) {
+bool Redo_Log_Reader::validate_redo_log_file() {
   ulint max_cp_field;
   auto err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
 
@@ -105,11 +105,6 @@ bool Redo_Log_Reader::find_last_checkpoint_lsn(lsn_t *lsn) {
     msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
     return (false);
   }
-
-  log_files_header_read(*log_sys, max_cp_field);
-
-  *lsn = mach_read_from_8(log_sys->checkpoint_buf + LOG_CHECKPOINT_LSN);
-
   return (true);
 }
 
@@ -1176,12 +1171,10 @@ bool Redo_Log_Data_Manager::is_error() const { return (error); }
 
 Redo_Log_Data_Manager::~Redo_Log_Data_Manager() { os_event_destroy(event); }
 
-bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
-  bool last_checkpoint = reader.find_last_checkpoint_lsn(&last_checkpoint_lsn);
-  if (last_checkpoint) {
-    msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
-        last_checkpoint_lsn);
-  }
+bool Redo_Log_Data_Manager::stop_at(lsn_t lsn, lsn_t checkpoint_lsn) {
+  last_checkpoint_lsn = checkpoint_lsn;
+  msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
+      last_checkpoint_lsn);
   msg("xtrabackup: Stopping log copying thread at LSN " LSN_PF ".\n", lsn);
 
   stop_lsn = lsn;
@@ -1189,6 +1182,11 @@ bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
   thread.join();
 
   archived_log_monitor.stop();
+
+  /* check if redo log are disabled */
+  if (!reader.validate_redo_log_file()) {
+    return (false);
+  }
 
   scanned_lsn = reader.get_scanned_lsn();
 
@@ -1203,7 +1201,7 @@ bool Redo_Log_Data_Manager::stop_at(lsn_t lsn) {
     return (false);
   }
 
-  return last_checkpoint;
+  return (true);
 }
 
 void Redo_Log_Data_Manager::close() {

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -43,8 +43,8 @@ class Redo_Log_Reader {
   @return true if success. */
   bool find_start_checkpoint_lsn();
 
-  /** Check if redo logs were disabled during the backup.
-   @return true if success. */
+  /** Check if redo logs are disabled during the backup.
+  @return true if redo logs are disabled */
   bool validate_redo_log_file();
 
   /** Get log header. */

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -43,10 +43,9 @@ class Redo_Log_Reader {
   @return true if success. */
   bool find_start_checkpoint_lsn();
 
-  /** Find last checkpoint lsn.
-  @param[out] lsn               last checkpoint lsn
-  @return true if success. */
-  bool find_last_checkpoint_lsn(lsn_t *lsn);
+  /** Check if redo logs were disabled during the backup.
+   @return true if success. */
+  bool validate_redo_log_file();
 
   /** Get log header. */
   byte *get_header() const;
@@ -278,7 +277,7 @@ class Redo_Log_Data_Manager {
   void abort();
 
   /** Stop log copying at specific lsn. */
-  bool stop_at(lsn_t lsn);
+  bool stop_at(lsn_t lsn, lsn_t checkpoint_lsn);
 
   /** Close log file. */
   void close();

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4052,7 +4052,8 @@ void xtrabackup_backup_func(void) {
     os_thread_sleep(opt_debug_sleep_before_unlock * 1000);
   }
 
-  if (!redo_mgr.stop_at(backup_ctxt.log_status.lsn)) {
+  if (!redo_mgr.stop_at(backup_ctxt.log_status.lsn,
+                        backup_ctxt.log_status.lsn_checkpoint)) {
     exit(EXIT_FAILURE);
   }
   if (redo_mgr.is_error()) {

--- a/storage/innobase/xtrabackup/test/t/xb_pause_after_log_status.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_pause_after_log_status.sh
@@ -1,0 +1,103 @@
+#
+# 1. start backup and wait a moment after query p_s.log_status
+# 2. insert data and wait for a moment
+# 3. continue backup
+# 4. restore
+# 5. check data
+#
+
+if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
+    skip_test "Requires --debug-sync support"
+fi
+
+start_server
+
+function backup_local() {
+	xtrabackup --backup --debug-sync=xtrabackup_after_query_log_status --target-dir=$topdir/backup
+}
+
+function prepare_local() {
+	xtrabackup --prepare --target-dir=$topdir/backup
+}
+
+
+function restore() {
+  [[ -d $mysql_datadir ]] && rm -rf $mysql_datadir && mkdir -p $mysql_datadir
+  xtrabackup --copy-back --target-dir=$topdir/backup
+}
+
+function do_test() {
+
+  cat <<EOF | $MYSQL $MYSQL_ARGS
+CREATE DATABASE sakila;
+use sakila;
+CREATE TABLE t (a INT);
+INSERT INTO t (a) VALUES (1), (2), (3);
+EOF
+
+  innodb_wait_for_flush_all
+
+  (eval $backup_cmd) &
+  job_pid=$!
+
+  wait_for_xb_to_suspend $pid_file
+
+  xb_pid=`cat $pid_file`
+
+  checksum1=`checksum_table sakila t`
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t (a) VALUES (10), (20), (30);" sakila
+  $MYSQL $MYSQL_ARGS -Ns -e "DROP DATABASE sakila"
+
+  innodb_wait_for_flush_all
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+
+  # wait's return code will be the code returned by the background process
+  run_cmd wait $job_pid
+
+  stop_server
+
+  eval $prepare_cmd
+
+  eval $restore_cmd
+
+  start_server
+
+  row_count=`$MYSQL $MYSQL_ARGS -Ns -e "select count(1) from t" sakila | awk {'print $1'}`
+
+  vlog "row count in table t is $row_count"
+
+  if [ "$row_count" != 3 ]; then
+   vlog "rows in table t is $row_count when it should be 3"
+   exit -1
+  fi
+
+  checksum2=`checksum_table sakila t`
+
+  $MYSQL $MYSQL_ARGS -Ns -e "select * from t;" sakila
+
+  vlog "Old checksum: $checksum1"
+  vlog "New checksum: $checksum2"
+
+  if [ "$checksum1" != "$checksum2" ]; then
+  vlog "Checksums do not match"
+  exit -1
+  fi
+
+  rm -rf $topdir/backup
+  rm -rf $pid_file
+
+}
+
+
+vlog "##############################"
+vlog "# Local backup"
+vlog "##############################"
+
+export backup_cmd=backup_local
+export prepare_cmd=prepare_local
+export restore_cmd=restore
+export pid_file=$topdir/backup/xtrabackup_debug_sync
+do_test


### PR DESCRIPTION
…ing during backup stage.

PXB takes last_lsn from ps.log_status (which is a consistent snapshot across all engines including binlog). However, it was writing the last_checkpoint by querying the last copied checkpoint from the redo thread. This can cause prepare to fail.

Write last_checkpoint and LSN from ps.log_status