### PR TITLE
Fixed PXB-2402 (Fix bootstrap script for PS 8.0.22)

### DIFF
--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -92,10 +92,13 @@ main () {
             ;;
         xtradb80)
             url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${VERSION}/binary/tarball"
-            if [[ $(echo ${VERSION} | awk -F "." '{ print $3 }' | cut -d '-' -f1) -lt "20" ]]; then
+	    short_version=$(echo ${VERSION} | awk -F "." '{ print $3 }' | cut -d '-' -f1)
+            if [[ ${short_version} -lt "20" ]]; then
                 tarball="Percona-Server-${VERSION}-Linux.${arch}.ssl$(ssl_version).tar.gz"
-            elif [[ $(echo ${VERSION} | awk -F "." '{ print $3 }' | cut -d '-' -f1) -ge "20" ]]; then
+            elif [[ ${short_version} -ge "20" && ${short_version} -lt "22" ]]; then
                 tarball="Percona-Server-${VERSION}-Linux.${arch}.glibc2.12.tar.gz"
+            elif [[ ${short_version} -ge "22" ]]; then
+                tarball="Percona-Server-${VERSION}-Linux.${arch}.glibc2.17.tar.gz"
             fi
             ;;
         *) 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2402

Problem:
Bootstrap script is trying to download glib version 12 for 8.0.22,
however it was compiled and it's named glib 17.

Fix:
Consider versions higher than .22 to download file with glib
version 17.