### PR TITLE
PXB-2280: SELinux and AppArmor policy

### DIFF
--- a/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
+++ b/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
@@ -1,0 +1,77 @@
+#include <tunables/global>
+
+/usr/bin/xtrabackup {
+  #include <abstractions/base>
+  #include <abstractions/mysql>
+
+  capability dac_override,
+  capability dac_read_search,
+  capability sys_nice,
+
+  /etc/ssl/openssl.cnf r,
+  /etc/nsswitch.conf r,
+  /etc/services r,
+  /etc/mysql/** r,
+  /usr/bin/dash ix,
+  /bin/sh ix,
+
+  # allowed by abstractions/mysql
+  # /run/mysqld/mysqld.sock wr,
+
+  /var/lib/mysql/** rw,
+  /var/lib/mysql/ rw,
+  /tmp/** wr,
+
+  # enable storing backups only in /backups directory
+  # /backups/** rwk,
+
+  # enable storing backups anywhere in caller user home directory
+  /@{HOME}/** rwk,
+
+  /usr/bin/cat ix,
+  /usr/bin/xbcrypt ix,
+
+
+  # xbcloud
+  /usr/bin/which ixr,
+  /usr/bin/perl ix,
+  /usr/share/perl/** r,
+  /usr/share/mysql/** r,
+}
+
+/usr/bin/xbcloud {
+  #include <abstractions/base>
+ 
+  /etc/host.conf r,
+  /run/systemd/resolve/stub-resolv.conf r,
+  /etc/nsswitch.conf r,
+  /etc/ssl/openssl.cnf r,
+  /etc/hosts r,
+  /etc/mysql/mysql.cnf r,
+  /etc/ssl/certs/ca-certificates.crt r,
+  /etc/mysql/** r,
+
+  network inet,
+  network inet6,
+}
+
+/usr/bin/xbcrypt {
+  #include <abstractions/base>
+
+  # enable storing backups only in /backups directory
+  # /backups/** rwk,
+
+  # enable storing backups anywhere in caller user home directory
+  /@{HOME}/** rwk,
+}
+
+/usr/bin/xbstream {
+  #include <abstractions/base>
+  
+  # enable storing backups only in /backups directory
+  # /backups/** rwk,
+
+  # enable storing backups anywhere in caller user home directory
+  /@{HOME}/** rwk,
+}
+

--- a/packaging/percona/selinx/xtrabackup.fc
+++ b/packaging/percona/selinx/xtrabackup.fc
@@ -1,0 +1,8 @@
+/usr/bin/xtrabackup		--	gen_context(system_u:object_r:xtrabackup_exec_t,s0)
+/usr/bin/xbcrypt		--	gen_context(system_u:object_r:xtrabackup_exec_t,s0)
+/usr/bin/xbstream		--	gen_context(system_u:object_r:xtrabackup_exec_t,s0)
+/usr/bin/xbcloud		--	gen_context(system_u:object_r:xtrabackup_exec_t,s0)
+
+# This file context is needed only if if backups are to be stored in /backups directory. If they will be stored in the user's home directory, this line should be omitted. See xtrabackup.te file for more details
+# /backups(/.*)?			system_u:object_r:xtrabackup_data_t:s0
+

--- a/packaging/percona/selinx/xtrabackup.te
+++ b/packaging/percona/selinx/xtrabackup.te
@@ -1,0 +1,128 @@
+policy_module(xtrabackup, 1.0.0)
+
+require {
+  type bin_t;
+  type sssd_var_lib_t;
+
+  # See 'write to destination directory' below section for details
+  # type admin_home_t;
+  type user_home_t;
+  type user_home_dir_t;
+
+  type unconfined_t;
+  type unreserved_port_t;
+  type xtrabackup_t;
+  type tmp_t;
+  type mysqld_etc_t;
+  type xtrabackup_exec_t;
+  type cert_t;
+  type mysqld_t;
+  type user_devpts_t;
+  type mysqld_port_t;
+  type mysqld_var_run_t;
+  type var_lib_t;
+  type mysqld_db_t;
+  type sssd_t;
+  type shell_exec_t;
+  type system_dbusd_t;
+  type setroubleshootd_t;
+
+  class chr_file { append getattr read write };
+  class file { create execute execute_no_trans getattr lock map open read rename unlink write };
+  class dir { add_name create getattr open read remove_name rmdir search write };
+  class lnk_file read;
+  class sock_file { getattr write };
+  class unix_stream_socket connectto;
+  class capability { dac_override dac_read_search sys_nice };
+  class tcp_socket { connect create name_connect read setopt shutdown write };
+  class process { setsched transition };
+
+  role unconfined_r;
+}
+
+########################################
+#
+# Declarations
+#
+
+type xtrabackup_t;
+domain_type(xtrabackup_t);
+type xtrabackup_exec_t;
+files_type(xtrabackup_exec_t);
+
+type xtrabackup_data_t;
+files_type(xtrabackup_data_t);
+
+role unconfined_r types xtrabackup_t;
+
+########################################
+#
+# xtrabackup policy
+#
+
+allow xtrabackup_t xtrabackup_exec_t : file { ioctl read getattr lock execute execute_no_trans entrypoint open };
+type_transition unconfined_t xtrabackup_exec_t : process xtrabackup_t;
+allow unconfined_t xtrabackup_t : process transition;
+
+allow xtrabackup_t xtrabackup_exec_t:file map;
+allow xtrabackup_t user_devpts_t:chr_file { append read write };
+
+allow xtrabackup_t mysqld_db_t:dir { open read write search getattr };
+allow xtrabackup_t mysqld_db_t:file { open read write create getattr };
+allow xtrabackup_t mysqld_etc_t:file { getattr read open };
+
+allow xtrabackup_t mysqld_var_run_t:sock_file { write getattr };
+allow xtrabackup_t mysqld_t:unix_stream_socket connectto;
+allow xtrabackup_t self:tcp_socket { create connect shutdown setopt getopt read write };
+allow xtrabackup_t mysqld_port_t:tcp_socket name_connect;
+allow xtrabackup_t unreserved_port_t:tcp_socket name_connect;
+
+allow xtrabackup_t shell_exec_t:file { map execute execute_no_trans };
+
+allow xtrabackup_t self:capability { dac_override dac_read_search };
+allow xtrabackup_t self:process setsched;
+allow xtrabackup_t self:capability sys_nice;
+
+allow xtrabackup_t sssd_var_lib_t:dir search;
+allow xtrabackup_t sssd_var_lib_t:sock_file write;
+allow xtrabackup_t sssd_t:unix_stream_socket connectto;
+
+allow xtrabackup_t cert_t:dir { search read };
+allow xtrabackup_t cert_t:file { open read getattr };
+allow xtrabackup_t user_devpts_t:chr_file { ioctl getattr };
+
+# which
+allow xtrabackup_t bin_t:file { execute execute_no_trans map };
+
+# ------------------- write to destination directory -------------------
+# Use these rules if corresponding tagging rules are present in xtrabackup.fc file.
+# This way it is possible to specify the exact directory where backups can be stored.
+# allow xtrabackup_t xtrabackup_data_t:dir { create write add_name remove_name read rmdir getattr search open };
+# allow xtrabackup_t xtrabackup_data_t:file { create open write getattr read lock rename unlink };
+
+# Use these rules to allow backups to be stored in regular user's home directory
+allow xtrabackup_t user_home_t:dir { create write add_name remove_name read rmdir getattr search open };
+allow xtrabackup_t user_home_t:file { create open write getattr read lock rename unlink };
+allow xtrabackup_t user_home_dir_t:dir { read getattr search open };
+
+# Use these rules to allow backups to be stored in root's home directory
+# allow xtrabackup_t admin_home_t:dir { create write add_name remove_name read rmdir getattr search open };
+# allow xtrabackup_t admin_home_t:file { create open write getattr read lock rename unlink };
+# ----------------------------------------------------------------------
+
+# tmp directory
+allow xtrabackup_t tmp_t:dir { write read add_name };
+allow xtrabackup_t tmp_t:file write;
+
+# restore
+allow xtrabackup_t var_lib_t:dir { add_name create read write };
+allow xtrabackup_t mysqld_db_t:dir { add_name create };
+allow xtrabackup_t var_lib_t:file { create open write getattr };
+
+# encrypt
+allow xtrabackup_t cert_t:lnk_file read;
+
+# connect over ip
+allow system_dbusd_t self:capability net_admin;
+allow system_dbusd_t setroubleshootd_t:process { noatsecure rlimitinh siginh };
+


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2280

Added SELinux and AppArmor configuration files.
Please note that these configurations are not distributed along with
PXB. It is up to the user to set SELinux/AppArmor with the guidance of
the online documentation provided by Percona. The purpose of these files
is to provide simple, working configuration which can be adjusted to the
specific needs.