### PR TITLE
follow up fix for PXB-2274 xtrabackup restore failed when there are DML statements running during backup stage.

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3278,6 +3278,11 @@ bool meb_scan_log_recs(
   ut_ad(len >= OS_FILE_LOG_BLOCK_SIZE);
 
   do {
+    if (scanned_lsn >= to_lsn) {
+      finished = true;
+      break;
+    }
+
     ut_ad(!finished);
 
     ulint no = log_block_get_hdr_no(log_block);
@@ -3395,6 +3400,10 @@ bool meb_scan_log_recs(
       recv_track_changes_of_recovered_lsn();
     }
 
+    // adjust data_len if we are in last block, so it stops at exact to_lsn
+    if (scanned_lsn + data_len > to_lsn) {
+      data_len = to_lsn - scanned_lsn;
+    }
     scanned_lsn += data_len;
 
     if (scanned_lsn > recv_sys->scanned_lsn) {
@@ -3682,6 +3691,7 @@ static void recv_recovery_begin(log_t &log, lsn_t *contiguous_lsn,
   }
 
   DBUG_PRINT("ib_log", ("scan " LSN_PF " completed", log.scanned_lsn));
+  ut_ad(to_lsn == LSN_MAX || to_lsn == log.scanned_lsn);
 }
 
 /** Initialize crash recovery environment. Can be called iff

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2304,7 +2304,7 @@ static bool innodb_init(bool init_dd, bool for_apply_log) {
     return (false);
   }
 
-  lsn_t to_lsn = ULLONG_MAX;
+  lsn_t to_lsn = LSN_MAX;
   if (for_apply_log && (metadata_type == METADATA_FULL_BACKUP ||
                         xtrabackup_incremental_dir != nullptr)) {
     to_lsn = (xtrabackup_incremental_dir == nullptr) ? metadata_last_lsn

--- a/storage/innobase/xtrabackup/test/t/pxb-2357.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2357.sh
@@ -1,8 +1,6 @@
 # PXB-2357: hang in backup with redo log archive#
 
-if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
-    skip_test "Requires --debug-sync support"
-fi
+require_debug_pxb_version
 
 require_server_version_higher_than 8.0.16
 

--- a/storage/innobase/xtrabackup/test/t/xb_pause_after_log_status.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_pause_after_log_status.sh
@@ -6,9 +6,7 @@
 # 5. check data
 #
 
-if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
-    skip_test "Requires --debug-sync support"
-fi
+require_debug_pxb_version
 
 start_server
 
@@ -46,7 +44,6 @@ EOF
 
   checksum1=`checksum_table sakila t`
   $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t (a) VALUES (10), (20), (30);" sakila
-  $MYSQL $MYSQL_ARGS -Ns -e "DROP DATABASE sakila"
 
   innodb_wait_for_flush_all
 


### PR DESCRIPTION
follow up fix
    PXB-2274 xtrabackup restore failed when there are DML statements running during backup stage.

    During prepare pxb is processing last block of redo log. so if there are
    transaction in that last block they are processed.

    Fix:
    Stop apply log at exact LSN