### PR TITLE
PXB-2415: Add missing build dependencies for Debian/Ubuntu systems

### DIFF
--- a/storage/innobase/xtrabackup/utils/debian/control
+++ b/storage/innobase/xtrabackup/utils/debian/control
@@ -15,8 +15,11 @@ Build-Depends: automake,
                libz-dev,
                libgcrypt-dev,
                libev-dev,
-               libcurl-dev,
+               libcurl-dev | libcurl4-openssl-dev,
                lsb-release,
+               fakeroot,
+               libsasl2-dev,
+               vim-common,
                python-sphinx (>= 1.0.1) | python3-sphinx (>= 1.8.5),
                python-docutils (>= 0.6) | python3-docutils (>= 0.16)
 Standards-Version: 3.9.5

--- a/storage/innobase/xtrabackup/utils/percona-xtrabackup-8.0_builder.sh
+++ b/storage/innobase/xtrabackup/utils/percona-xtrabackup-8.0_builder.sh
@@ -276,7 +276,7 @@ install_deps() {
         apt-get update
 
         PKGLIST+=" bison cmake devscripts debconf debhelper automake bison ca-certificates libcurl4-openssl-dev"
-        PKGLIST+=" cmake debhelper libaio-dev libncurses-dev libtool libz-dev"
+        PKGLIST+=" cmake debhelper libaio-dev libncurses-dev libtool libz-dev libsasl2-dev"
         PKGLIST+=" libgcrypt-dev libev-dev lsb-release"
         PKGLIST+=" build-essential rsync libdbd-mysql-perl libnuma1 socat libssl-dev patchelf"
 


### PR DESCRIPTION
Builds for Docker: https://rel.cd.percona.com/job/percona-xtrabackup-80-debian-src/label_exp=min-bionic-x64/