### PR TITLE
PXB-2371 - Vulnerability: Path traversal

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -93,6 +93,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   ds_tmpfile.c
   ds_xbstream.c
   fil_cur.cc
+  file_utils.c
   quicklz/quicklz.c
   read_filt.cc
   write_filt.cc
@@ -147,6 +148,7 @@ MYSQL_ADD_EXECUTABLE(xbstream
   ds_stdout.c
   ds_decrypt.c
   datasink.c
+  file_utils.c
   xbstream.c
   xbstream_read.c
   xbstream_write.c

--- a/storage/innobase/xtrabackup/src/file_utils.c
+++ b/storage/innobase/xtrabackup/src/file_utils.c
@@ -1,0 +1,46 @@
+#include "file_utils.h"
+#include "common.h"
+
+#if defined _WIN32 || defined __CYGWIN__ \
+    || defined __EMX__ || defined __MSDOS__ || defined __DJGPP__
+# define _IS_DRIVE_LETTER(C) \
+    (((C) >= 'A' && (C) <= 'Z') || ((C) >= 'a' && (C) <= 'z'))
+# define HAS_DEVICE(Filename) \
+    (_IS_DRIVE_LETTER ((Filename)[0]) && (Filename)[1] == FN_DEVCHAR)
+# define FILE_SYSTEM_PREFIX_LEN(Filename) (HAS_DEVICE (Filename) ? 2 : 0)
+#else
+# define FILE_SYSTEM_PREFIX_LEN(Filename) ((void) (Filename), 0)
+#endif
+
+const char *safer_name_suffix(char const *file_name, int* prefix_len_out) {
+  char const *p;
+
+  /* Skip file system prefixes, leading file name components that contain
+     "..", and leading slashes.  */
+
+  int prefix_len = FILE_SYSTEM_PREFIX_LEN(file_name);
+
+  // Remove ../
+  for (p = file_name + prefix_len; *p;) {
+    if (p[0] == '.' && p[1] == '.' && (is_directory_separator(p[2]) || !p[2]))
+      prefix_len = p + 2 - file_name;
+
+    do {
+      char c = *p++;
+      if (is_directory_separator(c)) break;
+    } while (*p);
+  }
+
+  // Remove leading /
+  for (p = file_name + prefix_len; is_directory_separator(*p); p++) continue;
+  prefix_len = p - file_name;
+
+  if (prefix_len) {
+    msg("%s: removing leading '%.*s'.\n", my_progname, prefix_len, file_name);
+  }
+
+  /* Unlike tar, file_name is always a regular file, so p can't be null */
+
+  *prefix_len_out = prefix_len;
+  return p;
+}

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -1,0 +1,28 @@
+/******************************************************
+Copyright (c) 2021 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef FILE_UTILS_H
+#define FILE_UTILS_H
+
+/* Return a safer suffix of FILE_NAME, or "." if it has no safer
+   suffix.  Check for fully specified file names and other atrocities.
+   Warn the user if we do not return NAME. */
+/* Based on gnu tar */
+const char *safer_name_suffix(char const *file_name, int *prefix_len_out);
+
+#endif

--- a/storage/innobase/xtrabackup/test/t/pxb-2371.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2371.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#
+# PXB-2371: --Vulnerability: Path traversal 
+#
+
+. inc/common.sh
+
+my_dir=$TMPDIR
+file="$my_dir/a"
+dir_dst="$my_dir/dst"
+file_xb="$my_dir/test.xb"
+
+# Test 1: Creating without -P removes the absolute path prefix
+
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file > $file_xb
+rm -f $file
+mkdir -p $dir_dst/$(dirname $file)  # xbstream doesn't create parent directories
+run_cmd xbstream -v -x -C $dir_dst < $file_xb
+
+## Check: The file was extracted in the relative path
+run_cmd_expect_failure ls -l $file
+run_cmd ls -l $dir_dst/$file
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst
+
+# Test 2: Creating with -P preserves the absolute path
+
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file -P > $file_xb
+rm -f $file
+run_cmd xbstream -v -x -C $dir_dst -P < $file_xb
+
+## Check: The file was extracted in the absolute path
+run_cmd ls -l $file
+run_cmd_expect_failure ls -l $dir_dst/$file
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst
+
+# Test 3: Extracting a stream with an absolute path file
+# without -P is an error
+ 
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file -P > $file_xb
+rm -f $file
+run_cmd_expect_failure xbstream -v -x -C $dir_dst < $file_xb
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2371
https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/48/
https://pxb.cd.percona.com/view/PXB%208.0/job/pxb80-single-platform-run/21/

Modify xbstream so it creates/extracts streams as gnu tar does.

When creating a stream, the leading directory slashes and relative
directories are removed from the filename. Hence, when the stream is
extracted, the files will be created in the directory specified, e.i.
their paths are relative.

The parameter `-P`, or `--absolute-names`, has been added to allow
absolute paths.

It is an error if there is a file with an absolute path when extracting
a stream and the parameter `-P` has not been specified.