### PR TITLE
PXB-2371 - Vulnerability: Path traversal

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -93,6 +93,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   ds_tmpfile.c
   ds_xbstream.c
   fil_cur.cc
+  file_utils.c
   quicklz/quicklz.c
   read_filt.cc
   write_filt.cc
@@ -147,6 +148,7 @@ MYSQL_ADD_EXECUTABLE(xbstream
   ds_stdout.c
   ds_decrypt.c
   datasink.c
+  file_utils.c
   xbstream.c
   xbstream_read.c
   xbstream_write.c

--- a/storage/innobase/xtrabackup/src/file_utils.c
+++ b/storage/innobase/xtrabackup/src/file_utils.c
@@ -1,0 +1,46 @@
+#include "file_utils.h"
+#include "common.h"
+
+#if defined _WIN32 || defined __CYGWIN__ \
+    || defined __EMX__ || defined __MSDOS__ || defined __DJGPP__
+# define _IS_DRIVE_LETTER(C) \
+    (((C) >= 'A' && (C) <= 'Z') || ((C) >= 'a' && (C) <= 'z'))
+# define HAS_DEVICE(Filename) \
+    (_IS_DRIVE_LETTER ((Filename)[0]) && (Filename)[1] == FN_DEVCHAR)
+# define FILE_SYSTEM_PREFIX_LEN(Filename) (HAS_DEVICE (Filename) ? 2 : 0)
+#else
+# define FILE_SYSTEM_PREFIX_LEN(Filename) ((void) (Filename), 0)
+#endif
+
+const char *safer_name_suffix(char const *file_name, int* prefix_len_out) {
+  char const *p;
+
+  /* Skip file system prefixes, leading file name components that contain
+     "..", and leading slashes.  */
+
+  int prefix_len = FILE_SYSTEM_PREFIX_LEN(file_name);
+
+  // Remove ../
+  for (p = file_name + prefix_len; *p;) {
+    if (p[0] == '.' && p[1] == '.' && (is_directory_separator(p[2]) || !p[2]))
+      prefix_len = p + 2 - file_name;
+
+    do {
+      char c = *p++;
+      if (is_directory_separator(c)) break;
+    } while (*p);
+  }
+
+  // Remove leading /
+  for (p = file_name + prefix_len; is_directory_separator(*p); p++) continue;
+  prefix_len = p - file_name;
+
+  if (prefix_len) {
+    msg("%s: removing leading '%.*s'.\n", my_progname, prefix_len, file_name);
+  }
+
+  /* Unlike tar, file_name is always a regular file, so p can't be null */
+
+  *prefix_len_out = prefix_len;
+  return p;
+}

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -1,0 +1,28 @@
+/******************************************************
+Copyright (c) 2021 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef FILE_UTILS_H
+#define FILE_UTILS_H
+
+/* Return a safer suffix of FILE_NAME, or "." if it has no safer
+   suffix.  Check for fully specified file names and other atrocities.
+   Warn the user if we do not return NAME. */
+/* Based on gnu tar */
+const char *safer_name_suffix(char const *file_name, int *prefix_len_out);
+
+#endif

--- a/storage/innobase/xtrabackup/src/xbstream.c
+++ b/storage/innobase/xtrabackup/src/xbstream.c
@@ -66,7 +66,7 @@ static ulong 		opt_encrypt_algo;
 static char 		*opt_encrypt_key_file = NULL;
 static char 		*opt_encrypt_key = NULL;
 static int		opt_encrypt_threads = 1;
-static int			opt_absolute_names = 0;
+static int		opt_absolute_names = 0;
 
 enum {
 	OPT_ENCRYPT_THREADS = 256
@@ -102,8 +102,8 @@ static struct my_option my_long_options[] =
 	 "The default value is 1.",
 	 &opt_encrypt_threads, &opt_encrypt_threads,
 	 0, GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
-    {"absolute-names", 'P', "Don't strip leading slashes from file names when creating archives.",
-      &opt_absolute_names, &opt_absolute_names, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+	{"absolute-names", 'P', "Don't strip leading slashes from file names when creating archives.",
+	 &opt_absolute_names, &opt_absolute_names, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
 	{0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
@@ -317,7 +317,7 @@ mode_create(int argc, char **argv)
 	for (i = 0; i < argc; i++) {
 		char			*filepath = argv[i];
 		const char		*filepath_dst;
-		int				filepath_prefix_len;
+		int			filepath_prefix_len;
 		File			src_file;
 		xb_wstream_file_t	*file;
 

--- a/storage/innobase/xtrabackup/src/xbstream.c
+++ b/storage/innobase/xtrabackup/src/xbstream.c
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xbcrypt_common.h"
 #include "datasink.h"
 #include "ds_decrypt.h"
+#include "file_utils.h"
 #include "crc_glue.h"
 #include <gcrypt.h>
 
@@ -65,6 +66,7 @@ static ulong 		opt_encrypt_algo;
 static char 		*opt_encrypt_key_file = NULL;
 static char 		*opt_encrypt_key = NULL;
 static int		opt_encrypt_threads = 1;
+static int			opt_absolute_names = 0;
 
 enum {
 	OPT_ENCRYPT_THREADS = 256
@@ -100,6 +102,8 @@ static struct my_option my_long_options[] =
 	 "The default value is 1.",
 	 &opt_encrypt_threads, &opt_encrypt_threads,
 	 0, GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
+    {"absolute-names", 'P', "Don't strip leading slashes from file names when creating archives.",
+      &opt_absolute_names, &opt_absolute_names, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
 	{0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
@@ -206,7 +210,7 @@ usage(void)
 	puts("Usage: ");
 	printf("  %s -c [OPTIONS...] FILES...	# stream specified files to "
 	       "standard output.\n", my_progname);
-	printf("  %s -x [OPTIONS...]		# extract files from the stream"
+	printf("  %s -x [OPTIONS...]		# extract files from the stream "
 	       "on the standard input.\n", my_progname);
 
 	puts("\nOptions:");
@@ -312,6 +316,8 @@ mode_create(int argc, char **argv)
 
 	for (i = 0; i < argc; i++) {
 		char			*filepath = argv[i];
+		const char		*filepath_dst;
+		int				filepath_prefix_len;
 		File			src_file;
 		xb_wstream_file_t	*file;
 
@@ -329,7 +335,8 @@ mode_create(int argc, char **argv)
 			goto err;
 		}
 
-		file = xb_stream_write_open(stream, filepath, &mystat, NULL, NULL);
+		filepath_dst = opt_absolute_names ? filepath : safer_name_suffix(filepath, &filepath_prefix_len);
+		file = xb_stream_write_open(stream, filepath_dst, &mystat, NULL, NULL);
 		if (file == NULL) {
 			goto err;
 		}
@@ -465,6 +472,17 @@ extract_worker_thread_func(void *arg)
 		    !(chunk.flags & XB_STREAM_FLAG_IGNORABLE)) {
 			pthread_mutex_unlock(ctxt->mutex);
 			continue;
+		}
+
+		if (!opt_absolute_names) {
+			int filepath_prefix_len;
+			safer_name_suffix(chunk.path, &filepath_prefix_len);
+			if (filepath_prefix_len != 0) {
+				msg("%s: absolute path not allowed: %.*s.\n", my_progname, chunk.pathlen, chunk.path);
+				res = XB_STREAM_READ_ERROR;
+				pthread_mutex_unlock(ctxt->mutex);
+				break;
+			}
 		}
 
 		/* See if we already have this file open */

--- a/storage/innobase/xtrabackup/test/t/pxb-2371.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2371.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+#
+# PXB-2371: --Vulnerability: Path traversal 
+#
+
+. inc/common.sh
+
+my_dir=$TMPDIR
+file="$my_dir/a"
+dir_dst="$my_dir/dst"
+file_xb="$my_dir/test.xb"
+
+# Test 1: Creating without -P removes the absolute path prefix
+
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file > $file_xb
+rm -f $file
+mkdir -p $dir_dst/$(dirname $file)  # xbstream doesn't create parent directories
+run_cmd xbstream -v -x -C $dir_dst < $file_xb
+
+## Check: The file was extracted in the relative path
+run_cmd_expect_failure ls -l $file
+run_cmd ls -l $dir_dst/$file
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst
+
+# Test 2: Creating with -P preserves the absolute path
+
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file -P > $file_xb
+rm -f $file
+run_cmd xbstream -v -x -C $dir_dst -P < $file_xb
+
+## Check: The file was extracted in the absolute path
+run_cmd ls -l $file
+run_cmd_expect_failure ls -l $dir_dst/$file
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst
+
+# Test 3: Extracting a stream with an absolute path file
+# without -P is an error
+ 
+## Set up
+rm -rf $file $file_xb $dir_dst
+mkdir -p $dir_dst
+echo "a" > $file
+
+## Run
+run_cmd xbstream -v -c $file -P > $file_xb
+rm -f $file
+run_cmd_expect_failure xbstream -v -x -C $dir_dst < $file_xb
+
+## Cleanup
+rm -rf $file $file_xb $dir_dst


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2371
https://pxb.cd.percona.com/job/percona-xtrabackup-2.4-param-medium/162


Modify xbstream so it creates/extracts streams as gnu tar does.

When creating a stream, the leading directory slashes and relative
directories are removed from the filename. Hence, when the stream is
extracted, the files will be created in the directory specified, e.i.
their paths are relative.

The parameter `-P`, or `--absolute-names`, has been added to allow
absolute paths.

It is an error if there is a file with an absolute path when extracting
a stream and the parameter `-P` has not been specified.