### PR TITLE
PXB-2426 lock-ddl-per-table does not work after lock-ddl was enabled …

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6843,8 +6843,8 @@ bool xb_init() {
 
   /* sanity checks */
   if (opt_lock_ddl && opt_lock_ddl_per_table) {
-    msg("Error: %s and %s are mutually exclusive\n", "--lock-ddl",
-        "--lock-ddl-per-table");
+    msg("Error: --lock-ddl and --lock-ddl-per-table are mutually exclusive. "
+        "Please specify --lock-ddl=false to use --lock-ddl-per-table.\n");
     return (false);
   }
 


### PR DESCRIPTION
…by default

If lock-ddl-per-table is given in the backup command
when lock-ddl is enabled by default, this error is displayed:
Error: --lock-ddl and --lock-ddl-per-table are mutually exclusive

So Modified the error message to
 --lock-ddl and --lock-ddl-per-table are mutually exclusive.
Please specify --lock-ddl=false to use --lock-ddl-per-table