### PR TITLE
PXB-2429 Assertion DB_SUCCESS == fil_reset_encryption(space_id) during

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2236,7 +2236,8 @@ static byte *recv_parse_or_apply_log_rec_body(
 #ifndef UNIV_HOTBACKUP
       /* Reset in-mem encryption information for the tablespace here if this
       is "resetting encryprion info" log. */
-      if (page_no == 0 && !fsp_is_system_or_temp_tablespace(space_id)) {
+      if (page_no == 0 && !fsp_is_system_or_temp_tablespace(space_id) &&
+          applying_redo) {
         byte buf[Encryption::INFO_SIZE] = {0};
 
         if (memcmp(ptr + 4, buf, Encryption::INFO_SIZE - 4) == 0) {

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -783,6 +783,13 @@ $MYSQL_VERSION_MINOR $MYSQL_VERSION_PATCH`
     [[ $server_str > $version_str ]]
 }
 
+function is_debug_server()
+{
+
+[[ $MYSQL_VERSION =~ .*debug ]]
+
+}
+
 #########################################################################
 # Require a server version higher than the first argument
 ########################################################################

--- a/storage/innobase/xtrabackup/test/t/pxb-2429.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2429.sh
@@ -1,0 +1,33 @@
+# PXB-2349 crash in PXB during tablespace encryption
+if ! is_debug_server  ; then
+	skip_test "Require debug server version"
+fi
+
+. inc/keyring_file.sh
+start_server
+
+mysql -e "create tablespace ts add datafile 'ts.ibd' encryption='y'" test 2>/dev/null >/dev/null
+innodb_wait_for_flush_all
+
+mysql -e "set global innodb_page_cleaner_disabled_debug=on" test 2>/dev/null >/dev/null
+mysql -e "set global innodb_checkpoint_disabled=on" test 2>/dev/null >/dev/null
+mysql -e "alter tablespace ts encryption='n'" test 2>/dev/null >/dev/null
+
+mkdir $topdir/backup
+
+vlog "Case#1 backup just after normal encryption"
+xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+start_server
+
+if mysql -e "select encryption from information_schema.INNODB_TABLESPACES where name='ts'" test | grep Y ; then
+  die "Tablespace encryption is wrong set"
+fi


### PR DESCRIPTION

    PXB-2429 Assertion DB_SUCCESS == fil_reset_encryption(space_id) during backup

    Problem:
    PXB crashes because an encryption reset operation cannot find
    a tablespace (fil_space_t) object

    Fix:
    Skip the encryption reset operation during the redo scan phase. It is
    required only for apply phase