### PR TITLE
Fixed PXB-2395 (xbstream and xbcrypt versions are incorrect)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -47,6 +47,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 using namespace xbcloud;
 
 #define XBCLOUD_VERSION XTRABACKUP_VERSION
+#define XBCLOUD_REVISION XTRABACKUP_REVISION
 
 /*****************************************************************************/
 
@@ -174,6 +175,9 @@ static struct my_option my_long_options[] = {
 
     {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0,
      0, 0, 0, 0, 0},
+
+     {"version", 'V', "Display version and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0,
+      0, 0, 0, 0, 0},
 
     {"storage", OPT_STORAGE, "Specify storage type S3/SWIFT.", &opt_storage,
      &opt_storage, &storage_typelib, GET_ENUM, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -338,8 +342,8 @@ static struct my_option my_long_options[] = {
     {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}};
 
 static void print_version() {
-  printf("%s  Ver %s for %s (%s)\n", my_progname, XBCLOUD_VERSION, SYSTEM_TYPE,
-         MACHINE_TYPE);
+  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname, XBCLOUD_VERSION, SYSTEM_TYPE,
+         MACHINE_TYPE, XBCLOUD_REVISION);
 }
 
 static void usage() {
@@ -377,6 +381,9 @@ static my_bool get_one_option(int optid,
   switch (optid) {
     case '?':
       usage();
+      exit(0);
+    case 'V':
+      print_version();
       exit(0);
     case OPT_SWIFT_PASSWORD:
     case OPT_SWIFT_KEY:

--- a/storage/innobase/xtrabackup/src/xbcrypt.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt.c
@@ -24,12 +24,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 #include "xbcrypt.h"
 #include "xbcrypt_common.h"
+#include "xtrabackup_version.h"
 #include "crc_glue.h"
 #include "datasink.h"
 #include "ds_decrypt.h"
 #include "ds_encrypt.h"
 
-#define XBCRYPT_VERSION "1.1"
+#define XBCRYPT_VERSION XTRABACKUP_VERSION
+#define XBCRYPT_REVISION XTRABACKUP_REVISION
 
 typedef enum {
 	RUN_MODE_NONE,
@@ -58,6 +60,9 @@ static struct my_option my_long_options[] =
 {
 	{"help", '?', "Display this help and exit.",
 	 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
+
+	{"version", 'V', "Display version and exit.",
+ 	 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
 
 	{"decrypt", 'd', "Decrypt data input to output.",
 	 0, 0, 0,
@@ -340,6 +345,9 @@ get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
 	case 'k':
 		hide_option(argument, &opt_encrypt_key);
 		break;
+	case 'V':
+		print_version();
+		exit(0);
 	case '?':
 		usage();
 		exit(0);
@@ -352,8 +360,8 @@ static
 void
 print_version(void)
 {
-	printf("%s  Ver %s for %s (%s)\n", my_progname, XBCRYPT_VERSION,
-	       SYSTEM_TYPE, MACHINE_TYPE);
+	printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname, XBCRYPT_VERSION,
+	       SYSTEM_TYPE, MACHINE_TYPE, XBCRYPT_REVISION);
 }
 
 static

--- a/storage/innobase/xtrabackup/src/xbstream.c
+++ b/storage/innobase/xtrabackup/src/xbstream.c
@@ -26,13 +26,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 #include "xbstream.h"
 #include "xbcrypt_common.h"
+#include "xtrabackup_version.h"
 #include "datasink.h"
 #include "ds_decrypt.h"
 #include "file_utils.h"
 #include "crc_glue.h"
 #include <gcrypt.h>
 
-#define XBSTREAM_VERSION "1.0"
+#define XBSTREAM_VERSION XTRABACKUP_VERSION
+#define XBSTREAM_REVISION XTRABACKUP_REVISION
 #define XBSTREAM_BUFFER_SIZE (10 * 1024 * 1024UL)
 
 #define START_FILE_HASH_SIZE 16
@@ -75,6 +77,8 @@ enum {
 static struct my_option my_long_options[] =
 {
 	{"help", '?', "Display this help and exit.",
+	 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
+	{"version", 'V', "Display version and exit.",
 	 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
 	{"create", 'c', "Stream the specified files to the standard output.",
 	 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -191,8 +195,8 @@ static
 void
 print_version(void)
 {
-	printf("%s  Ver %s for %s (%s)\n", my_progname, XBSTREAM_VERSION,
-	       SYSTEM_TYPE, MACHINE_TYPE);
+	printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname, XBSTREAM_VERSION,
+	       SYSTEM_TYPE, MACHINE_TYPE, XBSTREAM_REVISION);
 }
 
 static
@@ -250,6 +254,9 @@ get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
 	case 'k':
 		hide_option(argument, &opt_encrypt_key);
 		break;
+	case 'V':
+		print_version();
+		exit(0);
 	case '?':
 		usage();
 		exit(0);


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2395

Problem:
Auxiliary tools were not reporting same version as xtrabackup.

Fix:
Adjusted tools to report same version and build commit ID.
Added --version option to print version.

(cherry picked from commit a316ee90b434119bdaa676902b34d4303a90a3da)