### PR TITLE
Add exponential backoff to upload/put retries

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -161,7 +161,7 @@ class S3_client {
                               const Http_client *http_client, Event_handler *h,
                               S3_client::async_upload_callback_t callback,
                               CURLcode rc, const Http_connection *conn,
-                              int count);
+                              int count, int retry_sleep_ms);
 
  public:
   S3_client(const Http_client *client, const std::string &region,


### PR DESCRIPTION
This PR causes `S3_client::upload_callback` to wait exponentially between retries. `xbcloud` has maximum retries hardcoded to `3`

Currently `xbcloud` retries without any wait period, retrying as fast as possible. When there is an intermittent problem this usually causes the retry logic to fail to fix the problem

For now a hardcoded wait period of 1000ms is used and grows exponentially on each retry. I plan to create a 2nd PR to add command line flags to tune these settings