### PR TITLE
Fixed PXB-2427 (Update xtrabackup help description of parameter --str…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -798,7 +798,7 @@ struct my_option xb_client_options[] =
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
   {"stream", OPT_XTRA_STREAM, "Stream all backup files to the standard output "
-   "in the specified format. Currently the only supported format is 'tar'.",
+   "in the specified format. Currently supported formats are 'tar' and 'xbstream'.",
    (G_PTR*) &xtrabackup_stream_str, (G_PTR*) &xtrabackup_stream_str, 0, GET_STR,
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 


### PR DESCRIPTION
…eam)

https://jira.percona.com/browse/PXB-2427

Problem:
xtrabackup --help text were displaying the only supported format for
--stream option was tar.

Fix:
Added xbstream to the list of supported formats for --stream.