### PR TITLE
PXB-2442/PXB-2443: AppArmor profile updated

### DIFF
--- a/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
+++ b/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
@@ -3,17 +3,18 @@
 /usr/bin/xtrabackup {
   #include <abstractions/base>
   #include <abstractions/mysql>
+  #include <abstractions/openssl>
 
   capability dac_override,
   capability dac_read_search,
   capability sys_nice,
 
-  /etc/ssl/openssl.cnf r,
   /etc/nsswitch.conf r,
   /etc/services r,
   /etc/mysql/** r,
-  /usr/bin/dash ix,
-  /bin/sh ix,
+  /{usr/,}bin/?ash ix,
+  /{usr/,}bin/sh ix,
+  /{usr/,}bin/{,?}awk ix,
 
   # allowed by abstractions/mysql
   # /run/mysqld/mysqld.sock wr,
@@ -28,31 +29,32 @@
   # enable storing backups anywhere in caller user home directory
   /@{HOME}/** rwk,
 
-  /usr/bin/cat ix,
-  /usr/bin/xbcrypt ix,
+  /{usr/,}bin/qpress ix,
+  /{usr/,}bin/lz4 ix,
+  /{usr/,}bin/cat ix,
+  /{usr/,}bin/xbcrypt ix,
 
 
   # xbcloud
-  /usr/bin/which ixr,
-  /usr/bin/perl ix,
-  /usr/share/perl/** r,
+  /{usr/,}bin/which ixr,
+  /{usr/,}bin/perl ix,
+  /usr/share/perl*/** r,
   /usr/share/mysql/** r,
+
+  # needed by percona-version-check
+  #include <abstractions/nameservice>
+  /etc/percona-toolkit/* rw,
+  /{usr/,}bin/uname ix,
 }
 
 /usr/bin/xbcloud {
   #include <abstractions/base>
- 
-  /etc/host.conf r,
-  /run/systemd/resolve/stub-resolv.conf r,
-  /etc/nsswitch.conf r,
-  /etc/ssl/openssl.cnf r,
-  /etc/hosts r,
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+
   /etc/mysql/mysql.cnf r,
   /etc/ssl/certs/ca-certificates.crt r,
   /etc/mysql/** r,
-
-  network inet,
-  network inet6,
 }
 
 /usr/bin/xbcrypt {
@@ -67,11 +69,10 @@
 
 /usr/bin/xbstream {
   #include <abstractions/base>
-  
+
   # enable storing backups only in /backups directory
   # /backups/** rwk,
 
   # enable storing backups anywhere in caller user home directory
   /@{HOME}/** rwk,
 }
-


### PR DESCRIPTION
AppArmor profile updated

Fixed issues:

PXB-2442: Backup cannot be decompressed using the apparmor profile
https://jira.percona.com/browse/PXB-2442
Allowed usage of qpress and lz4.

PXB-2443: Version check fails with apparmor profile
https://jira.percona.com/browse/PXB-2443
Allowed perl5 and DNS access

Additionally used abstractions/ssl and abstractions/nameservice instead
of explicitly providing detailed rules.