### PR TITLE
Increased size of binlog_pos field on xtrabackup_history table

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1862,7 +1862,7 @@ write_xtrabackup_info(MYSQL *connection)
 		"start_time TIMESTAMP NULL DEFAULT NULL,"
 		"end_time TIMESTAMP NULL DEFAULT NULL,"
 		"lock_time BIGINT UNSIGNED DEFAULT NULL,"
-		"binlog_pos VARCHAR(128) DEFAULT NULL,"
+		"binlog_pos VARCHAR(255) DEFAULT NULL,"
 		"innodb_from_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"innodb_to_lsn BIGINT UNSIGNED DEFAULT NULL,"
 		"partial ENUM('Y', 'N') DEFAULT NULL,"


### PR DESCRIPTION
We have found that in our systems, sometimes xtrabackup fails silently when the binlog_pos data is bigger than the column size, so as we rely on this table to get the last LSN for incremental backups, all of them are failing. We have manually done an alter on this table increasing the size of this field so it doesn't complain anymore.

We are using percona xtradb clusters and as sometimes the GTID can get so long depending on how many servers acted as master you can go up further than 128 characters. For instance:

filename 'binlog.000256', position '234', GTID of the last change '1b0bd4a1-d4b5-11e9-a234-246e968699a0:1-21387,
ab258228-0993-ee17-4f8a-71ca3cf400e8:1-133171360'

so we propose to make this field a varchar(255) to give support to xtradb clusters with at least 3 nodes.