### PR TITLE
Fixed PXB-2465 (Xtrabackup fails to backup replication coordination w…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1394,6 +1394,9 @@ bool write_slave_info(MYSQL *connection) {
   int channel_idx = 0;
   for (auto &channel : log_status.channels) {
     auto ch = channels.find(channel.channel_name);
+    if (channel.channel_name == "group_replication_applier" ||
+        channel.channel_name == "group_replication_recovery")
+      continue;
     std::string for_channel;
 
     if (!channel.channel_name.empty()) {

--- a/storage/innobase/xtrabackup/test/suites/gr/slave_info.sh
+++ b/storage/innobase/xtrabackup/test/suites/gr/slave_info.sh
@@ -1,0 +1,35 @@
+# PXB should not try to get group_replication_applier channel
+
+start_group_replication_cluster 2
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE t1 (c1 VARCHAR(100) PRIMARY KEY);
+INSERT INTO t1 (c1) VALUES ('ONE'), ('TWO'), ('THREE');
+INSERT INTO t1 (c1) VALUES ('10'), ('20'), ('30');
+CREATE TABLE t2 (c1 VARCHAR(100) PRIMARY KEY);
+INSERT INTO t2 SELECT * FROM t1;
+EOF
+
+GTID_EXECUTED=$($MYSQL ${MYSQL_ARGS} -NBe "SELECT @@global.GTID_EXECUTED")
+switch_server 2
+$MYSQL ${MYSQL_ARGS} -e "SELECT WAIT_FOR_EXECUTED_GTID_SET('${GTID_EXECUTED}')"
+# This is required as after the backup we will have gtid_purged
+MYSQLDUMP_ARGS="--set-gtid-purged=OFF"
+record_db_state test
+xtrabackup --backup --slave-info --target-dir=${topdir}/../backup
+${MYSQLADMIN} ${MYSQL_ARGS} shutdown
+rm -rf ${mysql_datadir}
+switch_server 1
+${MYSQLADMIN} ${MYSQL_ARGS} shutdown
+rm -rf ${mysql_datadir}
+
+# Restore the backup on and validate
+xtrabackup --prepare --target-dir=${topdir}/../backup
+xtrabackup --copy-back --target-dir=${topdir}/../backup --datadir=${mysql_datadir}
+switch_server 2
+xtrabackup --copy-back --target-dir=${topdir}/../backup --datadir=${mysql_datadir}
+shutdown_server_with_id 1
+shutdown_server_with_id 2
+start_group_replication_cluster 2
+switch_server 2
+MYSQLDUMP_ARGS="--set-gtid-purged=OFF"
+run_cmd verify_db_state test


### PR DESCRIPTION
…ith GR)

https://jira.percona.com/browse/PXB-2465

Problem:
Xtrabackup retrives a snapshot of all SE's and replication at the end of
the backup by querying ps.log_status. GR channels are part of that list.
In order to produce a proper CHANGE MASTER TO command it has to get
further info, such as master_host. To do so it run SHOW SLAVE STATUS.
Group replication channels group_replication_applier and
group_replication_recovery do not appear on SHOW SLAVE STATUS.

Fix:
Skip channel if name matches group_replication_applier or
group_replication_recovery