### PR TITLE
PXB-2443: Version check fails with apparmor profile

### DIFF
--- a/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
+++ b/packaging/percona/apparmor/apparmor.d/usr.sbin.xtrabackup
@@ -34,7 +34,6 @@
   /{usr/,}bin/cat ix,
   /{usr/,}bin/xbcrypt ix,
 
-
   # xbcloud
   /{usr/,}bin/which ixr,
   /{usr/,}bin/perl ix,
@@ -45,6 +44,7 @@
   #include <abstractions/nameservice>
   /etc/percona-toolkit/* rw,
   /{usr/,}bin/uname ix,
+  /{usr/,}bin/lsb_release PUx,
 }
 
 /usr/bin/xbcloud {


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2443

Allowed lsb_release execution by Percona Toolkit (PUx to avoid
configuration of PT dependencies)