### PR TITLE
2.4 PXB-2445 Initializing the libgcrypt in xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -54,6 +54,7 @@ MYSQL_ADD_EXECUTABLE(xbcloud
   ../xbstream_read.c
   http.cc
   s3.cc
+  ../xbcrypt_common.c
   swift.cc)
 
 SET_TARGET_PROPERTIES(xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -43,6 +43,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xbcloud/s3.h"
 #include "xbcloud/swift.h"
 #include "xbcloud/util.h"
+#include "xbcrypt_common.h"
 
 using namespace xbcloud;
 
@@ -977,6 +978,7 @@ int main(int argc, char **argv) {
 #ifndef NO_SIGPIPE
   signal(SIGPIPE, SIG_IGN);
 #endif
+  xb_libgcrypt_init();
 
   http_init();
   crc_init();


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2445
PXB-2445 Initializing the libgcrypt in xbcloud

Problem:
When using xbcloud to upload or download backups, the following warning messages were being displayed in /var/log/syslog
xbcloud: Libgcrypt warning: missing initialization

Analysis
lbgcrypt is used without initializing in xbcloud/hash.h

Fix:
use xb_libgcrypt_init to initialize the libgcrypt library