### PR TITLE
PXB-8.0-2445 Initializing the libgcrypt in xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -48,6 +48,7 @@ MYSQL_ADD_EXECUTABLE(xbcloud
   ../xbstream_read.cc
   http.cc
   s3.cc
+  ../xbcrypt_common.cc
   swift.cc)
 
 SET_TARGET_PROPERTIES(xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <string>
 #include <unordered_map>
 #include "template_utils.h"
+#include "xbcrypt_common.h"
 
 #include <curl/curl.h>
 
@@ -981,6 +982,7 @@ int main(int argc, char **argv) {
 #ifndef NO_SIGPIPE
   signal(SIGPIPE, SIG_IGN);
 #endif
+  xb_libgcrypt_init();
 
   http_init();
   crc_init();


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2445

Problem:
When using xbcloud to upload or download backups, the following warning messages were being displayed in /var/log/syslog
xbcloud: Libgcrypt warning: missing initialization

Analysis
lbgcrypt is used without initializing in xbcloud/hash.h

Fix:
use xb_libgcrypt_init to initialize the libgcrypt library