### PR TITLE
Fixed PXB-2500 - Fix places were DBUG_OFF is used

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1432,14 +1432,14 @@ Disable with --skip-innodb-checksums.",
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #endif
 
-#ifndef DBUG_OFF
+#ifndef NDEBUG
     {"debug", '#',
      "Output debug log. See " REFMAN "dbug-package.html"
      " Default all ib_log output to stderr. To redirect all ib_log output"
      " to separate file, use --debug=d,ib_log:o,/tmp/xtrabackup.trace",
      &dbug_setting, &dbug_setting, nullptr, GET_STR, OPT_ARG, 0, 0, 0, nullptr,
      0, nullptr},
-#endif /* !DBUG_OFF */
+#endif /* !NDEBUG */
     {"innodb_checksum_algorithm", OPT_INNODB_CHECKSUM_ALGORITHM,
      "The algorithm InnoDB uses for page checksumming. [CRC32, STRICT_CRC32, "
      "INNODB, STRICT_INNODB, NONE, STRICT_NONE]",


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2500

Problem:
c3588e1 changed the terminology of debug capabilities from DBUG_OFF to NDEBUG.
Xtrabackup was still using it to validate if --debug=name would be
compiled.

Fix:
Adjust ifndef statement to reflect new terminology.