### PR TITLE
Fixed PXB-2496 - backup prepare always uses the daemon_keyring_proxy_…

### DIFF
--- a/storage/innobase/xtrabackup/test/t/innodb_keyring_proxy_plugin.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_keyring_proxy_plugin.sh
@@ -1,0 +1,19 @@
+#
+# PXB-2496 - backup prepare always uses the daemon_keyring_proxy_plugin without encryption
+#
+
+. inc/common.sh
+require_server_version_higher_than 8.0.23
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+if grep -q "Shutting down plugin 'daemon_keyring_proxy_plugin'" $OUTFILE
+then
+    die "daemon_keyring_proxy_plugin was started."
+fi
+
+stop_server
+rm -rf $topdir/


### PR DESCRIPTION
…plugin without encryption

https://jira.percona.com/browse/PXB-2496

Problem:
As part of the merge of 8.0.24, PXB was always starting
daemon_keyring_proxy_plugin.

Fix:
Only start daemon_keyring_proxy_plugin in case any keyring plugin will
be loaded.