### PR TITLE
PXB-1961 Prepare of full backup fails for encrypted tables with Gener…

### DIFF
--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -343,6 +343,10 @@ static const char ENCRYPTION_KEY_MAGIC_V2[] = "lCB";
 information version. */
 static const char ENCRYPTION_KEY_MAGIC_V3[] = "lCC";
 
+/* CRYPT_DATA in ENCRYPTION='N' tablespaces always have unencrypted scheme */
+static const uint CRYPT_SCHEME_UNENCRYPTED = 0;
+static const char ENCRYPTION_KEY_MAGIC_PS_V1[] = "PSA";
+
 /** Encryption magic bytes for not yet flushed page */
 static const char ENCRYPTION_KEY_MAGIC_EMPTY[] = "\0\0\0";
 

--- a/storage/innobase/xtrabackup/test/t/keyring_encryption.sh
+++ b/storage/innobase/xtrabackup/test/t/keyring_encryption.sh
@@ -1,0 +1,49 @@
+############################################################################
+# PXB-1961: xtrabackup fails with encryption='n' with Percona server
+############################################################################
+
+. inc/common.sh
+. inc/keyring_file.sh
+
+require_debug_server
+require_server_version_higher_than 5.7.0
+
+start_server
+
+vlog "case#1 restore table created with encryption='n'"
+mysql test <<EOF
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+CREATE TABLE t1(a INT) ENGINE=INNODB ENCRYPTION='N';
+INSERT INTO t1 VALUES(100);
+EOF
+backup_and_restore test
+
+vlog "case#2 check if table can be altered with encryption='n'"
+mysql test <<EOF
+SET GLOBAL innodb_master_thread_disabled_debug = 0;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 0;
+SET GLOBAL innodb_log_checkpoint_now = 1;
+ALTER TABLE t1 ENCRYPTION='Y';
+ALTER TABLE t1 ENCRYPTION='N';
+INSERT INTO t1 VALUES(100);
+EOF
+innodb_wait_for_flush_all
+backup_and_restore test
+
+#for the remaining test need PS server
+require_xtradb
+
+vlog "case#3 try to restore encryption='keyring'"
+mysql test <<EOF
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+CREATE TABLE t2(a INT) ENGINE=INNODB ENCRYPTION='keyring';
+INSERT INTO t2 VALUES(100);
+EOF
+rm -rf $topdir/backup
+mkdir -p $topdir/backup
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup --xtrabackup-plugin-dir=${plugin_dir}
+stop_server


### PR DESCRIPTION
…ic error

https://jira.percona.com/browse/PXB-1961

Problem:
PXB is not handling PS encryption types.

Analysis:
PS support addition encrytion types like keyring which is not handled.
This bugs only adresses encryption='n'

Fix:
Handle and process ENCRYPTION_KEY_MAGIC_PS_V3 in PXB