### PR TITLE
Fixed PXB-2504 - Stats functionality does not work if keyring compone…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -318,6 +318,7 @@ char *opt_transition_key = NULL;
 char *opt_xtra_plugin_dir = NULL;
 char *opt_xtra_plugin_load = NULL;
 char *opt_keyring_file_data = nullptr;
+char *opt_component_keyring_file_config = nullptr;
 
 bool opt_generate_new_master_key = FALSE;
 bool opt_generate_transition_key = FALSE;
@@ -677,6 +678,7 @@ enum options_xtrabackup {
   OPT_XB_SECURE_AUTH,
   OPT_TRANSITION_KEY,
   OPT_KEYRING_FILE_DATA,
+  OPT_COMPONENT_KEYRING_FILE_CONFIG,
   OPT_GENERATE_TRANSITION_KEY,
   OPT_XTRA_PLUGIN_DIR,
   OPT_XTRA_PLUGIN_LOAD,
@@ -1252,6 +1254,12 @@ struct my_option xb_client_options[] = {
       "Path to keyring file.",
       &opt_keyring_file_data, &opt_keyring_file_data, 0, GET_STR,
       OPT_ARG, 0, 0, 0, 0, 0, 0},
+
+    {"component-keyring-file-config", OPT_COMPONENT_KEYRING_FILE_CONFIG,
+     "Path to load keyring component config. Used for --prepare, --move-back,"
+     " --copy-back and --stats.",
+     &opt_component_keyring_file_config, &opt_component_keyring_file_config, 0,
+     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
     {"parallel", OPT_XTRA_PARALLEL,
      "Number of threads to use for parallel datafiles transfer. "
@@ -3905,6 +3913,10 @@ void xtrabackup_backup_func(void) {
   crc_init();
 
   xb_filters_init();
+  if (opt_component_keyring_file_config != nullptr) {
+    msg("xtrabackup: Warning: --component-keyring-file-config will be ignored "
+        "for --backup operation\n");
+  }
 
   if (have_keyring_component &&
       !xtrabackup::components::keyring_init_online(mysql_connection)) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -194,6 +194,7 @@ extern uint opt_read_buffer_size;
 extern char *opt_xtra_plugin_dir;
 extern char *opt_transition_key;
 extern char *opt_keyring_file_data;
+extern char *opt_component_keyring_file_config;
 extern bool opt_generate_transition_key;
 extern bool opt_generate_new_master_key;
 

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -815,6 +815,23 @@ function egrep()
     return ${PIPESTATUS[0]}
 }
 
+########################################################################
+# Run grep against a file using a pattern and exit in case occurencies
+# don't match
+########################################################################
+function grep_count()
+{
+  local pattern=$1
+  local file=$2
+  local expect=$3
+  local occurencies=$(grep -c "${pattern}" ${file})
+  if [[ $occurencies -ne $expect ]];
+  then
+    vlog "grep_count expected ${expect} for pattern ${pattern} but found ${occurencies}"
+    exit -1
+  fi
+}
+
 ####################################################
 # Helper functions for testing incremental backups #
 ####################################################

--- a/storage/innobase/xtrabackup/test/t/innodb_keyring_file_component.sh
+++ b/storage/innobase/xtrabackup/test/t/innodb_keyring_file_component.sh
@@ -1,0 +1,87 @@
+#
+# Component keyring file specific variables
+#
+require_server_version_higher_than 8.0.23
+
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+configure_server_with_component
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE t1 (c1 VARCHAR(100)) ENCRYPTION='y';
+INSERT INTO t1 (c1) VALUES ('ONE'), ('TWO'), ('THREE');
+INSERT INTO t1 (c1) VALUES ('10'), ('20'), ('30');
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+CREATE TABLE t2 (c1 VARCHAR(100)) ENCRYPTION='y';
+INSERT INTO t2 SELECT * FROM t1;
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup1 \
+--component-keyring-file-config=${MYSQLD_DATADIR}/component_keyring_file.cnf 2>&1 | tee $topdir/pxb.log
+grep_count "xtrabackup: Warning: \-\-component-keyring-file-config will be ignored for \-\-backup operation" $topdir/pxb.log 1
+
+cp -r $topdir/backup1 $topdir/backup2
+record_db_state test
+shutdown_server
+
+xtrabackup --stats --datadir=${mysql_datadir} \
+  --component-keyring-file-config=${MYSQLD_DATADIR}/component_keyring_file.cnf \
+  --xtrabackup-plugin-dir=${plugin_dir} 2>&1 | tee $topdir/pxb.log
+
+grep_count "Encryption can't find master key, please check the keyring is loaded." $topdir/pxb.log 0
+
+# Test 1: Pass non existing configuration file:
+run_cmd_expect_failure $XB_BIN $XB_ARGS \
+--prepare --target-dir=$topdir/backup1 --xtrabackup-plugin-dir=${plugin_dir} \
+--component-keyring-file-config=$topdir/xtrabackup_component_keyring_file_invalid.cnf 2>&1 | tee $topdir/pxb.log
+
+grep_count "Component configuration file is not readable or not found" $topdir/pxb.log 1
+
+# Test 2: Pass non existing configuration file:
+touch $topdir/xtrabackup_component_keyring_file_invalid.cnf
+run_cmd_expect_failure $XB_BIN $XB_ARGS \
+--prepare --target-dir=$topdir/backup1 --xtrabackup-plugin-dir=${plugin_dir} \
+--component-keyring-file-config=$topdir/xtrabackup_component_keyring_file_invalid.cnf 2>&1 | tee $topdir/pxb.log
+
+grep_count "Component configuration file is empty" $topdir/pxb.log 1
+
+# Test 3: Try to prepare with rubbish on component config on target-dir
+cp $topdir/backup1/xtrabackup_component_keyring_file.cnf $topdir
+echo "bla" > $topdir/backup1/xtrabackup_component_keyring_file.cnf
+run_cmd_expect_failure $XB_BIN $XB_ARGS \
+--prepare --target-dir=$topdir/backup1 --xtrabackup-plugin-dir=${plugin_dir} 2>&1 | tee $topdir/pxb.log
+
+grep_count "Component configuration file is not a valid JSON" $topdir/pxb.log 1
+
+# Test 4: Pass valid JSON config file without path member
+echo "{}" > $topdir/xtrabackup_component_keyring_file_invalid.cnf
+run_cmd_expect_failure $XB_BIN $XB_ARGS \
+--prepare --target-dir=$topdir/backup1 --xtrabackup-plugin-dir=${plugin_dir} \
+--component-keyring-file-config=$topdir/xtrabackup_component_keyring_file_invalid.cnf 2>&1 | tee $topdir/pxb.log
+
+grep_count "Component configuration does not have path member" $topdir/pxb.log 1
+
+# Test 5: Try to prepare with good component config on target-dir but
+# pass rubbish as parameter
+run_cmd_expect_failure $XB_BIN $XB_ARGS \
+--prepare --target-dir=$topdir/backup2 \
+--component-keyring-file-config=$topdir/backup1/xtrabackup_component_keyring_file.cnf \
+--xtrabackup-plugin-dir=${plugin_dir} 2>&1 | tee $topdir/pxb.log
+grep_count "Component configuration file is not a valid JSON" $topdir/pxb.log 1
+
+# Test 6: Try to prepare with rubbish on component config on target-dir but
+# pass good config as parameter
+xtrabackup --prepare --target-dir=$topdir/backup1 \
+--component-keyring-file-config=$topdir/xtrabackup_component_keyring_file.cnf \
+--xtrabackup-plugin-dir=${plugin_dir} 2>&1 | tee $topdir/pxb.log
+
+rm -rf ${mysql_datadir}
+xtrabackup --move-back --target-dir=$topdir/backup1
+
+start_server
+run_cmd verify_db_state test


### PR DESCRIPTION
…nt is needed on a mysql datadir

https://jira.percona.com/browse/PXB-2504

Problem:
Components expect manifest file to be placed at the same folder of
running binary to decide which components to load, with that list of
components, it will go to the plugin dir, read the corresponding .so
and a .cnf file with the same name of component.
The component implementation on xtrabackup was done in two parts:
  * Online - used at backup - We query PS.keyring_component_status,
load the component and config from there and save this config on
backup --target-dir as xtrabackup_keyring_component_file.cnf
  * Offline - used at everything else (prepare, copy/move back, stats) -
we read xtrabackup_keyring_component_file.cnf to load the component,
if --keyring-file-data is passed, we read the keyring master keys from
the file passed to it instead of what is saved at
xtrabackup_keyring_component_file.cnf.

The problem with status is that if executing against a datadir instead
of a backup dir. xtrabackup_keyring_component_file.cnf will not be
present. Here the issue is where to load the manifest file to decide if
encryption has to be enabled and from where to read the .cnf file from.

Fix:
Added a new variable named --component-keyring-file-config.
This variable is used on offline operations and will take precedence
over xtrabackup_keyring_component_file.cnf file if it exists.