### PR TITLE
Fixed PXB-2505 - Keyring is not generated properly by generate-new-ma…

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -100,6 +100,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   backup_copy.cc
   keyring_plugins.cc
   keyring_components.cc
+  utils.cc
   kdf.cc
   space_map.cc
   redo_log.cc

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -1,0 +1,53 @@
+/******************************************************
+Copyright (c) 2021 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+#include <my_alloc.h>
+#include <my_default.h>
+#include <mysqld.h>
+
+namespace xtrabackup {
+namespace utils {
+
+bool load_backup_my_cnf(my_option *options, char *path) {
+  static MEM_ROOT argv_alloc{PSI_NOT_INSTRUMENTED, 512};
+  const char *groups[] = {"mysqld", NULL};
+
+  char *exename = (char *)"xtrabackup";
+  char **backup_my_argv = &exename;
+  int backup_my_argc = 1;
+  char config_file[FN_REFLEN];
+
+  /* we need full name so that only backup-my.cnf will be read */
+  if (fn_format(config_file, "backup-my.cnf", path, "",
+                MY_UNPACK_FILENAME | MY_SAFE_PATH) == NULL) {
+    return (false);
+  }
+
+  if (my_load_defaults(config_file, groups, &backup_my_argc, &backup_my_argv,
+                       &argv_alloc, NULL)) {
+    return (false);
+  }
+
+  if (handle_options(&backup_my_argc, &backup_my_argv, options, NULL)) {
+    return (false);
+  }
+
+  return (true);
+}
+
+}  // namespace utils
+}  // namespace xtrabackup

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -1,0 +1,36 @@
+/******************************************************
+Copyright (c) 2021 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef XTRABACKUP_UTILS_H
+#define XTRABACKUP_UTILS_H
+#include <my_getopt.h>
+namespace xtrabackup {
+namespace utils {
+
+/**
+  Reads list of options from backup-my.cnf at a given path
+
+  @param [in]  options       list of options to read
+  @param [in]  path       path where backup-my.cnf is located
+
+  @return false in case of error, true otherwise
+*/
+extern bool load_backup_my_cnf(my_option *options, char *path);
+}  // namespace utils
+}  // namespace xtrabackup
+#endif  // XTRABACKUP_UTILS_H

--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -139,7 +139,10 @@ EOF
     xtrabackup --copy-back --generate-new-master-key \
          $copyback_options \
          --target-dir=$topdir/backup
-
+    if grep -q "Could not find the data corresponding to Data ID: 'MySQLReplicationKey__1'" $OUTFILE
+    then
+      die "Cannot read uuid from backup-my.cnf file"
+    fi
     start_server
 
     verify_db_state test


### PR DESCRIPTION
…ster-key for component

https://jira.percona.com/browse/PXB-2505

Problem:
Keyring operations use server uuid in order to prefix the master key
name. Component implementation of xtrabackup was missing read it from
backup-my.cnf when starting offline operations.

Fix:
Added required functions to read server-uuid from backup-my.cnf file.