### PR TITLE
Fixed PXB-2486 - PXB doesn't handle broken pipe correctly when --encr…

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_encrypt.c
+++ b/storage/innobase/xtrabackup/src/ds_encrypt.c
@@ -276,6 +276,8 @@ encrypt_write(ds_file_t *file, const void *buf, size_t len)
 						 encrypt_iv_len)) {
 				msg("encrypt: write to the destination file "
 				    "failed.\n");
+				pthread_mutex_unlock(&thd->data_mutex);
+				pthread_mutex_unlock(&thd->ctrl_mutex);
 				return 1;
 			}
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3399,6 +3399,9 @@ data_copy_thread_func(
 	my_thread_init();
 
 	debug_sync_point("data_copy_thread_func");
+	DBUG_EXECUTE_IF("simulate_compress_error", {
+		DBUG_SET("+d,compress_error");
+	});
 
 	while ((node = datafiles_iter_next(ctxt->it)) != NULL &&
 		!*(ctxt->error)) {

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -768,6 +768,26 @@ function require_server_version_higher_than()
     is_server_version_higher_than $1 || \
         skip_test "Requires server version higher than $1"
 }
+#########################################################################
+# Return 0 if debug pxb version
+########################################################################
+function is_debug_pxb_version()
+{
+    if $XB_BIN --help 2>&1 | grep -q debug.=name; then
+      return 0;
+    fi
+    return 1;
+}
+
+#########################################################################
+# Requires debug pxb version
+########################################################################
+function require_debug_pxb_version()
+{
+    if ! is_debug_pxb_version; then
+        skip_test "Requires debug build"
+    fi
+}
 
 ########################################################################
 # Return 0 if the server version is lower than the first argument


### PR DESCRIPTION
…ypt and --parallel is used

https://jira.percona.com/browse/PXB-2486

Problem:

Inside compress_write and encrypt_write we take thd->ctrl_mutex to
validate only one thread is writting at the time. In case of failure at
xb_crypt_write_chunk / ds_write / write_uint64_le or write_uint32_le we
will terminate the threads without releasing the mutex the thread owns.
In case other thread is waiting on this mutex, it will hang forever.

Fix:

Ensure threads release ctrl_mutex and data_mutex as part of error
handling.
Also added capabilities to detect if we are running on a debug binary.
Note that broken pipe test will not skip in case of non debug. Because
the test for --encrypt can be easily reproducible.