### PR TITLE
Fixed PXB-2517 - Check if files-from is successfully closed before rsync

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1035,6 +1035,7 @@ cleanup:
 
 bool backup_files(const char *from, bool prep_mode) {
   char rsync_tmpfile_name[FN_REFLEN];
+  char errbuf[MYSYS_STRERROR_SIZE];
   FILE *rsync_tmpfile = NULL;
   bool ret = true;
 
@@ -1079,7 +1080,11 @@ bool backup_files(const char *from, bool prep_mode) {
       rsync_list.insert("ib_lru_dump");
     }
 
-    fclose(rsync_tmpfile);
+    if (fclose(rsync_tmpfile) != 0) {
+      msg("Error: can't close file %s: %s\n", rsync_tmpfile_name,
+          my_strerror(errbuf, sizeof(errbuf), my_errno()));
+      return (false);
+    }
     rsync_tmpfile = NULL;
 
     cmd << "rsync -t . --files-from=" << rsync_tmpfile_name << " "


### PR DESCRIPTION
PXB-2517 : rsync non-InnoDB tables and files failed: No such file or directory

https://jira.percona.com/browse/PXB-2517

Issue
When hard disks ard under heavy workload, `fclose() ` of `xtrabackup_rsyncfiles_pass` may fail.
And the content of any unwritten output buffer will be lost.
So `rsync` will fail due to incomplete `--files-from` or synchronize incomplete file list.

Solution
Check if files-from is successfully closed before rsync.