### PR TITLE
8.0 PXB-2477 (xbcloud should retry on error and utilize incremental backoff)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
 
 HTTP client implementation using cURL.
 
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include <curl/curl.h>
 #include <ev.h>
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <memory>
@@ -332,24 +333,23 @@ class Event_handler {
   void stop();
 };
 
-bool retriable_curl_error(CURLcode rc);
-
-bool retriable_http_error(long code);
-
 class Http_client {
  public:
   using async_callback_t = std::function<void(CURLcode, Http_connection *)>;
-
  private:
   bool insecure{false};
   bool verbose{false};
   std::string cacert;
-
+  std::vector<CURLcode> curl_retriable_errors{
+      CURLcode::CURLE_GOT_NOTHING,      CURLcode::CURLE_OPERATION_TIMEDOUT,
+      CURLcode::CURLE_RECV_ERROR,       CURLcode::CURLE_SEND_ERROR,
+      CURLcode::CURLE_SEND_FAIL_REWIND, CURLcode::CURLE_PARTIAL_FILE};
+  std::vector<long> http_retriable_errors{503, 500, 504, 408};
   mutable curl_easy_unique_ptr curl{nullptr, curl_easy_cleanup};
 
   static void async_result_callback(async_callback_t user_callback,
-                                    const char *action, Event_handler *h,
-                                    CURLcode rc, Http_connection *conn);
+                                    Event_handler *h, CURLcode rc,
+                                    Http_connection *conn);
 
   void setup_request(CURL *curl, const Http_request &request,
                      Http_response &response, curl_slist *&headers,
@@ -368,10 +368,33 @@ class Http_client {
                                   Http_response &response, Event_handler *h,
                                   async_callback_t callback = {},
                                   bool nowait = false) const;
+  template <typename CLIENT, typename CALLBACK>
+  void callback(CLIENT *client, std::string container, std::string name,
+                Http_request *req, Http_response *resp,
+                const Http_client *http_client, Event_handler *h,
+                CALLBACK callback, CURLcode rc, const Http_connection *conn,
+                ulong count) const;
   void set_verbose(bool val) { verbose = val; };
   void set_insecure(bool val) { insecure = val; };
   void set_cacaert(const std::string &val) { cacert = val; };
+  void set_curl_retriable_errors(CURLcode code) {
+    if (code < CURLcode::CURL_LAST) {
+      if (std::find(curl_retriable_errors.begin(), curl_retriable_errors.end(),
+                    code) == curl_retriable_errors.end()) {
+        curl_retriable_errors.push_back(code);
+      }
+    }
+  }
+  void set_http_retriable_errors(long error) {
+    if (std::find(http_retriable_errors.begin(), http_retriable_errors.end(),
+                  error) == http_retriable_errors.end()) {
+      http_retriable_errors.push_back(error);
+    }
+  }
+  bool retriable_curl_error(const CURLcode &rc) const;
+  bool retriable_http_error(const long &code) const;
   void reset() const { curl = nullptr; }
+  virtual bool get_verbose() const { return verbose; }
 };
 
 }  // namespace xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/object_store.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/object_store.h
@@ -41,11 +41,10 @@ class Object_store {
   virtual bool upload_object(const std::string &container,
                              const std::string &object,
                              const Http_buffer &contents) = 0;
-  virtual bool async_upload_object(const std::string &container,
-                                   const std::string &object,
-                                   const Http_buffer &contents,
-                                   Event_handler *h,
-                                   std::function<void(bool)> f = {}) = 0;
+  virtual bool async_upload_object(
+      const std::string &container, const std::string &object,
+      const Http_buffer &contents, Event_handler *h,
+      std::function<void(bool, const Http_buffer &contents)> f = {}) = 0;
   virtual bool async_download_object(
       const std::string &container, const std::string &object, Event_handler *h,
       std::function<void(bool, const Http_buffer &contents)> f = {}) = 0;

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019, 2020 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
 
 AWS S3 client implementation.
 
@@ -541,48 +541,9 @@ void S3_client::upload_callback(
     S3_client *client, std::string bucket, std::string name, Http_request *req,
     Http_response *resp, const Http_client *http_client, Event_handler *h,
     S3_client::async_upload_callback_t callback, CURLcode rc,
-    const Http_connection *conn, int count) {
-  bool retry_error = false;
-  if (retriable_curl_error(rc) ||
-      retriable_http_error(conn->response().http_code())) {
-    retry_error = true;
-  }
-
-  if (rc == CURLE_OK && !resp->ok()) {
-    S3_response s3_resp;
-    if (!s3_resp.parse_http_response(*resp)) {
-      msg_ts(
-          "%s: Failed to upload object %s/%s. Failed to parse XML "
-          "response.\n",
-          my_progname, bucket.c_str(), name.c_str());
-    } else if (s3_resp.error()) {
-      msg_ts("%s: Failed to upload object %s/%s. Error message: %s\n",
-             my_progname, bucket.c_str(), name.c_str(),
-             s3_resp.error_message().c_str());
-      if (s3_resp.error_code() == "RequestTimeout") {
-        retry_error = true;
-      }
-    }
-  }
-
-  if (retry_error && count <= 3) {
-    msg_ts("%s: Retrying %s [%d]\n", my_progname, name.c_str(), count);
-    resp->reset_body();
-    client->signer->sign_request(client->hostname(bucket), bucket, *req,
-                                 time(0));
-    http_client->make_async_request(
-        *req, *resp, h,
-        std::bind(S3_client::upload_callback, client, bucket, name, req, resp,
-                  http_client, h, callback, std::placeholders::_1,
-                  std::placeholders::_2, count + 1),
-        true);
-    return;
-  }
-  if (callback) {
-    callback(rc == CURLE_OK && resp->ok());
-  }
-  delete req;
-  delete resp;
+    const Http_connection *conn, ulong count) {
+  http_client->callback(client, bucket, name, req, resp, http_client, h,
+                        callback, rc, conn, count);
 }
 
 bool S3_client::async_upload_object(
@@ -622,6 +583,15 @@ bool S3_client::async_upload_object(
   return true;
 }
 
+void S3_client::download_callback(
+    S3_client *client, std::string bucket, std::string name, Http_request *req,
+    Http_response *resp, const Http_client *http_client, Event_handler *h,
+    S3_client::async_download_callback_t callback, CURLcode rc,
+    const Http_connection *conn, ulong count) {
+  http_client->callback(client, bucket, name, req, resp, http_client, h,
+                        callback, rc, conn, count);
+}
+
 bool S3_client::async_download_object(
     const std::string &bucket, const std::string &name, Event_handler *h,
     const async_download_callback_t callback,
@@ -647,29 +617,11 @@ bool S3_client::async_download_object(
     return false;
   }
 
-  auto f = [callback, bucket, name, req, resp](
-               CURLcode rc, const Http_connection *conn) mutable -> void {
-    if (rc == CURLE_OK && !resp->ok()) {
-      S3_response s3_resp;
-      if (!s3_resp.parse_http_response(*resp)) {
-        msg_ts(
-            "%s: Failed to download object %s/%s. Failed to parse XML "
-            "response.\n",
-            my_progname, bucket.c_str(), name.c_str());
-      } else if (s3_resp.error()) {
-        msg_ts("%s: Failed to download object %s/%s. Error message: %s\n",
-               my_progname, bucket.c_str(), name.c_str(),
-               s3_resp.error_message().c_str());
-      }
-    }
-    if (callback) {
-      callback(rc == CURLE_OK && resp->ok(), resp->body());
-    }
-    delete req;
-    delete resp;
-  };
-
-  http_client->make_async_request(*req, *resp, h, f);
+  http_client->make_async_request(
+      *req, *resp, h,
+      std::bind(S3_client::download_callback, this, bucket, name, req, resp,
+                http_client, h, callback, std::placeholders::_1,
+                std::placeholders::_2, 1));
 
   return true;
 }
@@ -770,6 +722,19 @@ bool S3_client::list_objects_with_prefix(const std::string &bucket,
   }
 
   return true;
+}
+
+void S3_client::retry_error(Http_response *resp, bool *retry) {
+  S3_response s3_resp;
+  if (!s3_resp.parse_http_response(*resp)) {
+    msg_ts("%s: Failed to parse XML response.\n", my_progname);
+  } else if (s3_resp.error()) {
+    msg_ts("%s: S3 error message: %s\n", my_progname,
+           s3_resp.error_message().c_str());
+    if (s3_resp.error_code() == "RequestTimeout") {
+      *retry = true;
+    }
+  }
 }
 
 }  // namespace xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019, 2020 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
 
 AWS S3 client implementation.
 
@@ -113,10 +113,13 @@ class S3_signerV2 : public S3_signer {
 
 class S3_client {
  public:
-  using async_upload_callback_t = std::function<void(bool)>;
+  using async_upload_callback_t =
+      std::function<void(bool, const Http_buffer &)>;
   using async_download_callback_t =
       std::function<void(bool, const Http_buffer &)>;
   using async_delete_callback_t = std::function<void(bool)>;
+
+  std::unique_ptr<S3_signer> signer;
 
  private:
   const Http_client *http_client;
@@ -133,19 +136,12 @@ class S3_client {
 
   s3_bucket_lookup_t bucket_lookup{LOOKUP_AUTO};
 
-  std::unique_ptr<S3_signer> signer;
-
   std::string base_url;
 
   Http_request::protocol_t protocol;
 
-  std::string hostname(const std::string &bucket) const {
-    if (bucket_lookup == LOOKUP_DNS) {
-      return bucket + "." + host;
-    } else {
-      return host;
-    }
-  }
+  ulong max_retries;
+  ulong max_backoff;
 
   std::string bucketname(const std::string &bucket) const {
     if (bucket_lookup == LOOKUP_PATH) {
@@ -161,15 +157,24 @@ class S3_client {
                               const Http_client *http_client, Event_handler *h,
                               S3_client::async_upload_callback_t callback,
                               CURLcode rc, const Http_connection *conn,
-                              int count);
+                              ulong count);
+
+  static void download_callback(
+      S3_client *client, std::string bucket, std::string name,
+      Http_request *req, Http_response *resp, const Http_client *http_client,
+      Event_handler *h, S3_client::async_download_callback_t callback,
+      CURLcode rc, const Http_connection *conn, ulong count);
 
  public:
   S3_client(const Http_client *client, const std::string &region,
-            const std::string &access_key, const std::string &secret_key)
+            const std::string &access_key, const std::string &secret_key,
+            const ulong max_retries, const ulong max_backoff)
       : http_client(client),
         region(region),
         access_key(access_key),
-        secret_key(secret_key) {
+        secret_key(secret_key),
+        max_retries(max_retries),
+        max_backoff(max_backoff) {
     host = "s3." + region + ".amazonaws.com";
     endpoint = "https://" + host;
     protocol = Http_request::HTTPS;
@@ -233,6 +238,20 @@ class S3_client {
   bool list_objects_with_prefix(const std::string &bucket,
                                 const std::string &prefix,
                                 std::vector<std::string> &objects);
+
+  ulong get_max_retries() { return max_retries; }
+
+  ulong get_max_backoff() { return max_backoff; }
+
+  void retry_error(Http_response *resp, bool *retry);
+
+  std::string hostname(const std::string &bucket) const {
+    if (bucket_lookup == LOOKUP_DNS) {
+      return bucket + "." + host;
+    } else {
+      return host;
+    }
+  }
 };
 
 class S3_object_store : public Object_store {
@@ -244,11 +263,13 @@ class S3_object_store : public Object_store {
   S3_object_store(const Http_client *client, std::string &region,
                   const std::string &access_key, const std::string &secret_key,
                   const std::string &session_token,
-                  const std::string &storage_class,
+                  const std::string &storage_class, const ulong max_retries,
+                  const ulong max_backoff,
                   const std::string &endpoint = std::string(),
                   s3_bucket_lookup_t bucket_lookup = LOOKUP_DNS,
                   s3_api_version_t api_version = S3_V_AUTO)
-      : s3_client{client, region, access_key, secret_key} {
+      : s3_client{client,     region,      access_key,
+                  secret_key, max_retries, max_backoff} {
     if (!session_token.empty()) s3_client.set_session_token(session_token);
     if (!storage_class.empty()) s3_client.set_storage_class(storage_class);
     if (!endpoint.empty()) s3_client.set_endpoint(endpoint);
@@ -279,16 +300,16 @@ class S3_object_store : public Object_store {
                              const Http_buffer &contents) override {
     return s3_client.upload_object(container, object, contents);
   }
-  virtual bool async_upload_object(const std::string &container,
-                                   const std::string &object,
-                                   const Http_buffer &contents,
-                                   Event_handler *h,
-                                   std::function<void(bool)> f = {}) override {
-    return s3_client.async_upload_object(container, object, contents, h,
-                                         [f](bool success) {
-                                           if (f) f(success);
-                                         },
-                                         extra_http_headers);
+  virtual bool async_upload_object(
+      const std::string &container, const std::string &object,
+      const Http_buffer &contents, Event_handler *h,
+      std::function<void(bool, const Http_buffer &contents)> f = {}) override {
+    return s3_client.async_upload_object(
+        container, object, contents, h,
+        [f](bool success, const Http_buffer &contents) {
+          if (f) f(success, contents);
+        },
+        extra_http_headers);
   }
   virtual bool async_download_object(
       const std::string &container, const std::string &object, Event_handler *h,

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
 
 Openstack Swift client implementation.
 
@@ -36,11 +36,11 @@ namespace xbcloud {
 const rapidjson::Value &json_get_member(const rapidjson::Document &doc,
                                         const char *name) {
   if (!doc.IsObject()) {
-    msg_ts("%s: cannot get member '%s' of non object", my_progname, name);
+    msg_ts("%s: cannot get member '%s' of non object\n", my_progname, name);
   }
   auto member = doc.FindMember(name);
   if (member == doc.MemberEnd()) {
-    msg_ts("%s: cannot find member '%s' of an object", my_progname, name);
+    msg_ts("%s: cannot find member '%s' of an object\n", my_progname, name);
   }
   return member->value;
 }
@@ -48,11 +48,11 @@ const rapidjson::Value &json_get_member(const rapidjson::Document &doc,
 const rapidjson::Value &json_get_member(const rapidjson::Value &obj,
                                         const char *name) {
   if (!obj.IsObject()) {
-    msg_ts("%s: cannot get member '%s' of non object", my_progname, name);
+    msg_ts("%s: cannot get member '%s' of non object\n", my_progname, name);
   }
   auto member = obj.FindMember(name);
   if (member == obj.MemberEnd()) {
-    msg_ts("%s: cannot find member '%s' of an object", my_progname, name);
+    msg_ts("%s: cannot find member '%s' of an object\n", my_progname, name);
   }
   return member->value;
 }
@@ -668,6 +668,15 @@ Http_buffer Swift_client::download_object(const std::string &container,
   return resp.move_body();
 }
 
+void Swift_client::download_callback(
+    Swift_client *client, std::string container, std::string name,
+    Http_request *req, Http_response *resp, const Http_client *http_client,
+    Event_handler *h, Swift_client::async_download_callback_t callback,
+    CURLcode rc, const Http_connection *conn, ulong count) {
+  http_client->callback(client, container, name, req, resp, http_client, h,
+                        callback, rc, conn, count);
+}
+
 bool Swift_client::create_container(const std::string &name) {
   Http_request req(Http_request::PUT, protocol, host, path + name);
   req.add_header("X-Auth-Token", token);
@@ -744,6 +753,15 @@ bool Swift_client::upload_object(const std::string &container,
   return false;
 }
 
+void Swift_client::upload_callback(
+    Swift_client *client, std::string container, std::string name,
+    Http_request *req, Http_response *resp, const Http_client *http_client,
+    Event_handler *h, Swift_client::async_upload_callback_t callback,
+    CURLcode rc, const Http_connection *conn, ulong count) {
+  http_client->callback(client, container, name, req, resp, http_client, h,
+                        callback, rc, conn, count);
+}
+
 bool Swift_client::async_upload_object(const std::string &container,
                                        const std::string &name,
                                        const Http_buffer &contents,
@@ -770,21 +788,11 @@ bool Swift_client::async_upload_object(const std::string &container,
     return false;
   }
 
-  auto f = [callback, container, name, req, resp](
-               CURLcode rc, const Http_connection *conn) mutable -> void {
-    if (rc == CURLE_OK && !resp->ok()) {
-      msg_ts("%s: Failed to upload object. Http error code: %lu\n", my_progname,
-             resp->http_code());
-    }
-    bool valid = rc == CURLE_OK && validate_response(*req, *resp);
-    if (callback) {
-      callback(rc == CURLE_OK && valid && resp->ok());
-    }
-    delete req;
-    delete resp;
-  };
-
-  http_client->make_async_request(*req, *resp, h, f);
+  http_client->make_async_request(
+      *req, *resp, h,
+      std::bind(Swift_client::upload_callback, this, container, name, req, resp,
+                http_client, h, callback, std::placeholders::_1,
+                std::placeholders::_2, 1));
 
   return true;
 }
@@ -810,20 +818,11 @@ bool Swift_client::async_download_object(const std::string &container,
     return false;
   }
 
-  auto f = [callback, container, name, req, resp](
-               CURLcode rc, const Http_connection *conn) mutable -> void {
-    if (rc == CURLE_OK && !resp->ok()) {
-      msg_ts("%s: Failed to download object. Http error code: %lu\n",
-             my_progname, resp->http_code());
-    }
-    if (callback) {
-      callback(rc == CURLE_OK && resp->ok(), resp->body());
-    }
-    delete req;
-    delete resp;
-  };
-
-  http_client->make_async_request(*req, *resp, h, f);
+  http_client->make_async_request(
+      *req, *resp, h,
+      std::bind(Swift_client::download_callback, this, container, name, req,
+                resp, http_client, h, callback, std::placeholders::_1,
+                std::placeholders::_2, 1));
 
   return true;
 }

--- a/storage/innobase/xtrabackup/src/xbcloud/util.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/util.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
 
 Aux functions used by xbcloud.
 
@@ -96,6 +96,12 @@ static inline std::pair<std::string, std::string> parse_http_header(
   auto r = header;
   trim(r);
   return std::make_pair(r, std::string());
+}
+
+inline ulong get_exponential_backoff(int count, uint64_t max_backoff) {
+  uint64_t delay = pow(2, count) * 1000;
+  int random = (rand() % 1000) + 1;
+  return std::min(delay + random, max_backoff);
 }
 
 template <typename T>

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2014-2020 Percona LLC and/or its affiliates.
+Copyright (c) 2014, 2021 Percona LLC and/or its affiliates.
 
 xbcloud utility. Manage backups on cloud storage services.
 
@@ -102,6 +102,9 @@ static char *opt_google_bucket = nullptr;
 static std::string backup_name;
 static char *opt_cacert = nullptr;
 static ulong opt_parallel = 1;
+static ulong opt_max_retries = 10;
+static u_int32_t opt_max_backoff = 300000;
+
 static bool opt_insecure = false;
 static bool opt_md5 = false;
 static enum { MODE_GET, MODE_PUT, MODE_DELETE } opt_mode;
@@ -120,6 +123,8 @@ TYPELIB s3_bucket_lookup_typelib = {array_elements(s3_bucket_lookup_names) - 1,
 
 TYPELIB s3_api_version_typelib = {array_elements(s3_api_version_names) - 1, "",
                                   s3_api_version_names, nullptr};
+
+Http_client http_client;
 
 enum {
   OPT_STORAGE = 256,
@@ -161,11 +166,15 @@ enum {
   OPT_GOOGLE_BUCKET,
 
   OPT_PARALLEL,
+  OPT_MAX_RETRIES,
+  OPT_MAX_BACKOFF,
   OPT_CACERT,
   OPT_HEADER,
   OPT_INSECURE,
   OPT_MD5,
-  OPT_VERBOSE
+  OPT_VERBOSE,
+  OPT_CURL_RETRIABLE_ERRORS,
+  OPT_HTTP_RETRIABLE_ERRORS
 };
 
 static struct my_option my_long_options[] = {
@@ -177,8 +186,8 @@ static struct my_option my_long_options[] = {
     {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0,
      0, 0, 0, 0, 0},
 
-     {"version", 'V', "Display version and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0,
-      0, 0, 0, 0, 0},
+    {"version", 'V', "Display version and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG,
+     0, 0, 0, 0, 0, 0},
 
     {"storage", OPT_STORAGE, "Specify storage type S3/SWIFT.", &opt_storage,
      &opt_storage, &storage_typelib, GET_ENUM, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -260,6 +269,19 @@ static struct my_option my_long_options[] = {
      &opt_parallel, &opt_parallel, 0, GET_ULONG, REQUIRED_ARG, 1, 1, ULONG_MAX,
      0, 0, 0},
 
+    {"max-retries", OPT_MAX_RETRIES,
+     "Number of retries of chunk uploads/downloads after a failure (Default "
+     "10).",
+     &opt_max_retries, &opt_max_retries, 0, GET_ULONG, REQUIRED_ARG, 10, 1,
+     ULONG_MAX, 0, 0, 0},
+
+    {"max-backoff", OPT_MAX_BACKOFF,
+     "Maximum backoff delay in milliseconds in between chunk uploads/downloads "
+     "retries "
+     "(Default 300000).",
+     &opt_max_backoff, &opt_max_backoff, 0, GET_UINT32, REQUIRED_ARG, 300000, 1,
+     UINT_MAX32, 0, 0, 0},
+
     {"s3-region", OPT_S3_REGION, "S3 region.", &opt_s3_region, &opt_s3_region,
      0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
@@ -340,6 +362,16 @@ static struct my_option my_long_options[] = {
     {"verbose", OPT_VERBOSE, "Turn ON cURL tracing.", &opt_verbose,
      &opt_verbose, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
 
+    {"curl-retriable-errors", OPT_CURL_RETRIABLE_ERRORS,
+     "Add a new curl error code as retriable. For multiple codes, use a comma "
+     "separated list of codes.",
+     0, 0, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
+    {"http-retriable-errors", OPT_HTTP_RETRIABLE_ERRORS,
+     "Add a new http error code as retriable. For multiple codes, use a comma "
+     "separated list of codes.",
+     0, 0, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
     {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}};
 
 static void print_version() {
@@ -349,7 +381,7 @@ static void print_version() {
 
 static void usage() {
   print_version();
-  puts("Copyright (C) 2015-2019 Percona LLC and/or its affiliates.");
+  puts("Copyright (C) 2015, 2021 Percona LLC and/or its affiliates.");
   puts(
       "This software comes with ABSOLUTELY NO WARRANTY. "
       "This is free software,\nand you are welcome to modify and "
@@ -403,6 +435,31 @@ static my_bool get_one_option(int optid,
     case OPT_HEADER:
       if (argument != nullptr) {
         extra_http_headers.insert(parse_http_header(argument));
+      }
+      break;
+    case OPT_CURL_RETRIABLE_ERRORS:
+      if (argument != nullptr) {
+        std::istringstream iss(argument);
+        for (std::string val; std::getline(iss, val, ',');) {
+          char *ptr;
+          long int code = strtol(val.c_str(), &ptr, 10);
+          if (!*ptr) {
+            http_client.set_curl_retriable_errors(
+                std::move(static_cast<CURLcode>(code)));
+          }
+        }
+      }
+      break;
+    case OPT_HTTP_RETRIABLE_ERRORS:
+      if (argument != nullptr) {
+        std::istringstream iss(argument);
+        for (std::string val; std::getline(iss, val, ',');) {
+          char *ptr;
+          long int code = strtol(val.c_str(), &ptr, 10);
+          if (!*ptr) {
+            http_client.set_http_retriable_errors(std::move(code));
+          }
+        }
       }
       break;
   }
@@ -998,7 +1055,6 @@ int main(int argc, char **argv) {
   }
 
   std::unique_ptr<Object_store> object_store = nullptr;
-  Http_client http_client;
   if (opt_verbose) {
     http_client.set_verbose(true);
   }
@@ -1109,7 +1165,8 @@ int main(int argc, char **argv) {
     msg_ts("Object store URL: %s\n", auth_info.url.c_str());
 
     object_store = std::unique_ptr<Object_store>(
-        new Swift_object_store(&http_client, auth_info.url, auth_info.token));
+        new Swift_object_store(&http_client, auth_info.url, auth_info.token,
+                               opt_max_retries, opt_max_backoff));
 
     container_name = opt_swift_container;
 
@@ -1125,7 +1182,8 @@ int main(int argc, char **argv) {
         opt_s3_storage_class != nullptr ? opt_s3_storage_class : "";
     object_store = std::unique_ptr<Object_store>(new S3_object_store(
         &http_client, region, access_key, secret_key, session_token,
-        storage_class, opt_s3_endpoint != nullptr ? opt_s3_endpoint : "",
+        storage_class, opt_max_retries, opt_max_backoff,
+        opt_s3_endpoint != nullptr ? opt_s3_endpoint : "",
         static_cast<s3_bucket_lookup_t>(opt_s3_bucket_lookup),
         static_cast<s3_api_version_t>(opt_s3_api_version)));
 
@@ -1157,7 +1215,7 @@ int main(int argc, char **argv) {
 
     object_store = std::unique_ptr<Object_store>(new S3_object_store(
         &http_client, region, access_key, secret_key, session_token,
-        storage_class,
+        storage_class, opt_max_retries, opt_max_backoff,
         opt_google_endpoint != nullptr ? opt_google_endpoint
                                        : "https://storage.googleapis.com/",
         LOOKUP_DNS, S3_V4));


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2477

Problem
Currently we only support retries on s3 api for upload/put action.
The current implementation retries 3 times without any delay in between
attemps. This is goes against network transmission best practices.

Solution

Implemented retry callback for swift (upload/download) and
S3 (download) - upload was already implemented.

Implement truncated exponential backoff to avoid network congestion.
This alows users to choose how many times they will want a chunk to be
retransmitted before erroring out. Also, users will have the ability to
choose a maximum delay in between retries, in which the exponential
time delay will stop increasing while still retrying.

Added an option to extend the fixed list of curl errors that will be
considered as retriable. This can be used with --verbose flag to display
which error curl has returned and which parameter value has to be added
in order to allow that extra error(s).

Fixed some swift error messages that were missing \n.

Fixed Http_client::make_async_request to report proper action, as it
had "upload object" action hardcoded.

Thanks to @timvaillancourt for the initial contribution on this subject.