### PR TITLE
8.0 PXB-2519 test mdl_locks is not deterministic

### DIFF
--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -6,7 +6,7 @@ start_server
 
 load_sakila
 
-mysql -e 'CREATE TABLE t_hello_你好(id INT, PRIMARY KEY(id)) ENGINE=InnoDB' test
+mysql -e 'SET NAMES utf8; CREATE TABLE t_hello_你好(id INT, PRIMARY KEY(id)) ENGINE=InnoDB' test
 mysql test <<EOF
 CREATE TABLE R8EC8BBNEGLU37BCU93XW157W6NGEBL7I23VMK8YSTAVHFO0K8L3HD6K9L8N9CJ2 (
   a int(11) DEFAULT NULL


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2519

Problem:
Mdl_locks.sh test uses utf8 characters to validate the mdl lock query
executed by PXB will be able to handle those type of characters. However
we are not forcing the connection to use utf8 resulting in some failures
depending on the OS charset.

Fix:
Enforce UTF-8 charset to mysql connection.