### PR TITLE
Fixed PXB-2549 (test pxb-1913 is unstable)

### DIFF
--- a/storage/innobase/xtrabackup/test/t/pxb-1913.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1913.sh
@@ -42,8 +42,6 @@ done
 
 xtrabackup --backup --target-dir=$topdir/backup
 
-cp -av $topdir/backup /dev/shm/bak11
-
 stop_server
 
 rm -rf $mysql_datadir


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2549

Problem:
Test pxb-1913 sometimes fails due to lack of space on /dev/shm.
Looking to the test, we do the following actions:
* take a backup to $topdir/backup
* copy $topdir/backup to /dev/shm
* prepare the backup at $topdir/backup
* copy back the backup from $topdir/backup
There is no technical reason for having the cp instruction as part of
the test.

Fix:
Remove the cp to /dev/shm