### PR TITLE
Fixed PXB-2551 (gr_basic test timeout in innodb80)

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -491,6 +491,14 @@ function shutdown_server()
 ########################################################################
 function start_group_replication_cluster()
 {
+  # PXB-2551 - Upstram MySQL Debug version doesn't work with GR
+  # https://bugs.mysql.com/bug.php?id=103316
+  if is_debug_server; then
+    if [[ $INNODB_FLAVOR = "InnoDB" ]];
+    then
+      require_server_version_higher_than 8.0.25
+    fi
+  fi
   local number_of_nodes=$1
   shift
   if [[ -z  $number_of_nodes ]];


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2551

Problem:
Upstream MySQL Debug version crash when starting GR. See bug
https://bugs.mysql.com/bug.php?id=103316

Fix:
Skip test if running on InnoDB (Upstream) and version lower than 8.0.25.
This makes us bump the skip version on each oracle new release.