### PR TITLE
8.0 Implemented PXB-2554 (logic to skip tests under ASAN is not working)

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -885,6 +885,25 @@ function require_tokudb()
     fi
 }
 
+########################################################################
+# Return 0 if the xtrabackup has AddressSanitizer support
+########################################################################
+function is_asan()
+{
+    ldd $XB_BIN | grep -q libasan
+    return $?
+}
+
+#########################################################################
+# Skip test if xtrabackup has AddressSanitizer support
+########################################################################
+function skip_if_asan()
+{
+    if is_asan; then
+        skip_test "Incompatible with AddressSanitizer"
+    fi
+}
+
 ##############################################################################
 # Start a server with TokuDB plugins loaded and enabled.
 # Server id is 1, any arguments are passsed to the mysqld.

--- a/storage/innobase/xtrabackup/test/t/bug1414221.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1414221.sh
@@ -4,10 +4,7 @@
 ############################################################################
 . inc/common.sh
 
-if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
-then
-    skip_test "Incompatible with AddressSanitizer"
-fi
+skip_if_asan
 
 start_server --innodb_file_per_table
 load_sakila

--- a/storage/innobase/xtrabackup/test/t/bug1532101.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1532101.sh
@@ -5,10 +5,7 @@
 
 . inc/common.sh
 
-if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
-then
-    skip_test "Incompatible with AddressSanitizer"
-fi
+skip_if_asan
 
 require_server_version_higher_than 5.6.0
 

--- a/storage/innobase/xtrabackup/test/t/bug766305.sh
+++ b/storage/innobase/xtrabackup/test/t/bug766305.sh
@@ -2,12 +2,9 @@
 # Bug #766305: Use MySQL Code to get stack trace
 ########################################################################
 
-start_server --innodb_file_per_table
+skip_if_asan
 
-if [ ${ASAN_OPTIONS:-undefined} != "undefined" ]
-then
-    skip_test "Incompatible with AddressSanitizer"
-fi
+start_server --innodb_file_per_table
 
 mkdir $topdir/backup
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2554

Problem:
currently we have some logic to skip tests under ASAN that require
$ASAN_OPTIONS variable to be populated. However there is no place that
we populate this variable to let tests know we are running under ASAN.

Fix:
Create proper functions on common.sh to let tests to be skipped under
ASAN.