### PR TITLE
xbcloud: retry chunk-upload on `SSL connect error` (2.4)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -343,7 +343,8 @@ class Http_client {
   std::vector<CURLcode> curl_retriable_errors{
       CURLcode::CURLE_GOT_NOTHING,      CURLcode::CURLE_OPERATION_TIMEDOUT,
       CURLcode::CURLE_RECV_ERROR,       CURLcode::CURLE_SEND_ERROR,
-      CURLcode::CURLE_SEND_FAIL_REWIND, CURLcode::CURLE_PARTIAL_FILE};
+      CURLcode::CURLE_SEND_FAIL_REWIND, CURLcode::CURLE_PARTIAL_FILE,
+      CURLcode::CURLE_SSL_CONNECT_ERROR};
   std::vector<long> http_retriable_errors{503, 500, 504, 408};
   mutable curl_easy_unique_ptr curl{nullptr, curl_easy_cleanup};
 


### PR DESCRIPTION
After testing https://github.com/percona/percona-xtrabackup/pull/1111 / https://jira.percona.com/browse/PXB-2477 we noticed that sometimes we receive an SSL-related error in our uploads to S3 that is not retried by the new retry logic:
```
210727 02:30:36 xbcloud: Operation failed. Error: Failure when receiving data from the peer
210727 02:30:36 xbcloud: Sleeping for 2778 ms before retrying REDACTED-2021-07-26_0300/REDACTED/REDACTED.ibd.qp.xbcrypt.00000000000000011380 [1]
210727 02:34:39 xbcloud: Operation failed. Error: Failure when receiving data from the peer
210727 02:34:39 xbcloud: Sleeping for 2916 ms before retrying REDACTED-2021-07-26_0300/ibdata1.qp.xbcrypt.00000000000000006236 [1]
210727 02:45:40 xbcloud: Operation failed. Error: SSL connect error
210727 02:45:40 xbcloud: error: failed to upload chunk: REDACTED-2021-07-26_0300/REDACTED/REDACTED.ibd.qp.xbcrypt.00000000000000016802, size: 10434992
210727 02:45:43 xbcloud: Upload failed.
```
_Notice no retry occurs on `SSL connect error`_

This PR adds `CURLCode::CURLE_SSL_CONNECT_ERROR` as a retriable error to help with this scenario

cc @altmannmarcelo 🙇 