### PR TITLE
PXB-2566 Missing parameter on advanced encryption documentation (2.4)

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/advanced/encrypted_innodb_tablespace_backups.rst
+++ b/storage/innobase/xtrabackup/doc/source/advanced/encrypted_innodb_tablespace_backups.rst
@@ -392,8 +392,8 @@ Backup
 
 .. code-block:: bash
 
-   $ xtrabackup --backup --user=root -p --target-dir=/data/backup \
-   --generate-transition-key
+   $ xtrabackup --backup --target-dir=/data/backup \
+   --transition-key=MySecretKey
 
 Prepare
 --------------------------------------------------------------------------------


### PR DESCRIPTION
modified:   source/advanced/encrypted_innodb_tablespace_backups.rst