### PR TITLE
Fixed PXB-2594 - kill-long-queries-timeout segmentation fault.

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1021,11 +1021,11 @@ static void kill_query_thread() {
   mysql_close(mysql);
 
 stop_thread:
-  msg_ts("Kill query thread stopped\n");
-
   my_thread_end();
 
   os_event_set(kill_query_thread_stopped);
+
+  msg_ts("Kill query thread stopped\n");
 }
 
 static void start_query_killer() {
@@ -1040,7 +1040,7 @@ static void start_query_killer() {
 
 static void stop_query_killer() {
   os_event_set(kill_query_thread_stop);
-  os_event_wait_time(kill_query_thread_stopped, 60000);
+  os_event_wait(kill_query_thread_stopped);
 
   os_event_destroy(kill_query_thread_stop);
   os_event_destroy(kill_query_thread_started);


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2594

Problem:
When we call stop_query_killer we set kill_query_thread_stop event
which tells the kill_query_thread it should start its stop_thread
routine. As part of this routine, it will call my_thread_end and then
set kill_query_thread_stopped event. On the main thread where we are
executing stop_query_killer, we will wait 60ms for
kill_query_thread_stopped event to be set and then continue the routine
that deletes the os_events created to add syncronization to
kill_query_thread. In case my_thread_end called from kill_query_thread
takes more than 60ms the main thread will continue its workflow and
destroy kill_query_thread_stopped event. Later when kill_query_thread
completes my_thread_end it will try to set kill_query_thread_stopped
but the event is already destroyed.

Fix:
Adjust main thread to keep waiting for kill_query_thread_stopped to be
set before destroying the event.