### PR TITLE
Fixed PXB-2584 (xtrabackup stuck waiting for redo follow thread)

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -633,6 +633,12 @@ void Archived_Redo_Log_Monitor::skip_for_block(lsn_t lsn,
         return;
       }
     }
+    if (finished) {
+      msg_ts(
+          "xtrabackup: Finished reading archive, did not find a matching "
+          "block\n");
+      return;
+    }
   }
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2584

Problem
While we are inside skip_for_block waiting to find a matching
point/block to switch between normal redo log follow to archive file
we keep reading the the archive file. However, we didn't take into
consideration that we might have finished to read the archive file and
didn't find the matching point. Thus we kept inside the while loop
even thought we did not have new data on archive file (finished is true)
and len is 0.

Fix
When the archive thread don't have any blocks to read and we cannot
reach the desired LSN in the archive redo file, let the main thread
read another block from main redo log file before attempting to switch
to archive file again.