### PR TITLE
PXB-2543  Add IB_EXPORT_CFG_VERSION_V6 for exporting cfg file for a t…

### DIFF
--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -771,6 +771,11 @@ dict_table_t *dd_table_create_on_dd_obj(const dd::Table *dd_table,
   /* Add system columns to make adding index work */
   dict_table_add_system_columns(table, heap);
 
+  /* add instant column default value */
+  if (table->has_instant_cols()) {
+    dd_fill_instant_columns(*dd_table, table);
+  }
+
   /* It appears that index list for InnoDB table always starts with
   primary key */
   ut_ad(dd_table->indexes().size() > 0);
@@ -3568,8 +3573,12 @@ inline int dd_fill_dict_index(const dd::Table &dd_table, const TABLE *m_form,
 /** Read the metadata of default values for all columns added instantly
 @param[in]	dd_table	dd::Table
 @param[in,out]	table		InnoDB table object */
+#ifdef XTRABACKUP
+void dd_fill_instant_columns(const dd::Table &dd_table,
+#else
 static void dd_fill_instant_columns(const dd::Table &dd_table,
-                                    dict_table_t *table) {
+#endif /*XTRABACKUP */
+                             dict_table_t *table) {
   ut_ad(table->has_instant_cols());
   ut_ad(dd_table_has_instant_cols(dd_table));
 

--- a/storage/innobase/include/dict0dd.h
+++ b/storage/innobase/include/dict0dd.h
@@ -679,6 +679,13 @@ template <typename Index>
 const dict_index_t *dd_find_index(const dict_table_t *table, Index *dd_index);
 MY_COMPILER_DIAGNOSTIC_POP()
 
+#ifdef XTRABACKUP
+/** Read the metadata of default values for all columns added instantly
+@param[in]	dd_table	dd::Table
+@param[in,out]	table		InnoDB table object */
+void dd_fill_instant_columns(const dd::Table &dd_table, dict_table_t *table);
+#endif /*XTRABACKUP */
+
 /** Acquire a shared metadata lock.
 @param[in,out]	thd	current thread
 @param[out]	mdl	metadata lock

--- a/storage/innobase/include/row0quiesce.h
+++ b/storage/innobase/include/row0quiesce.h
@@ -73,4 +73,9 @@ dberr_t row_quiesce_set_state(
 @param[in,out] trx Transaction/session */
 void row_quiesce_table_complete(dict_table_t *table, trx_t *trx);
 
+#ifdef XTRABACKUP
+MY_ATTRIBUTE((warn_unused_result))
+dberr_t row_quiesce_write_default_value(const dict_col_t *col, FILE *file);
+#endif
+
 #endif /* row0quiesce_h */

--- a/storage/innobase/row/row0quiesce.cc
+++ b/storage/innobase/row/row0quiesce.cc
@@ -237,7 +237,12 @@ of dict_col_t default value part if exists.
 @param[in]	col	column to which the default value belongs
 @param[in]	file	file to write to
 @return DB_SUCCESS or DB_IO_ERROR. */
+#ifdef XTRABACKUP
+MY_ATTRIBUTE((warn_unused_result))
+dberr_t
+#else
 static MY_ATTRIBUTE((warn_unused_result)) dberr_t
+#endif
     row_quiesce_write_default_value(const dict_col_t *col, FILE *file) {
   byte row[6];
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -61,6 +61,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "rpl_log_encryption.h"
 #include "space_map.h"
 #include "typelib.h"
+#include "utils.h"
 #include "xb0xb.h"
 #include "xtrabackup.h"
 #include "xtrabackup_version.h"
@@ -365,24 +366,6 @@ void parse_show_engine_innodb_status(MYSQL *connection) {
   mysql_free_result(mysql_result);
 }
 
-/* find the pxb base version */
-static unsigned long pxb_base_version() {
-  std::string pxb_base = MYSQL_SERVER_VERSION;
-  unsigned long major = 0, minor = 0, version = 0;
-  std::size_t major_p = pxb_base.find(".");
-  if (major_p != std::string::npos) major = stoi(pxb_base.substr(0, major_p));
-
-  std::size_t minor_p = pxb_base.find(".", major_p + 1);
-  if (minor_p != std::string::npos)
-    minor = stoi(pxb_base.substr(major_p + 1, minor_p - major_p));
-
-  std::size_t version_p = pxb_base.find(".", minor_p + 1);
-  if (version_p != std::string::npos)
-    version = stoi(pxb_base.substr(minor_p + 1, version_p - minor_p));
-  else
-    version = stoi(pxb_base.substr(minor_p + 1));
-  return major * 10000 + minor * 100 + version;
-}
 
 static bool check_server_version(unsigned long version_number,
                                  const char *version_string,
@@ -429,8 +412,8 @@ static bool check_server_version(unsigned long version_number,
     }
   }
 
-
-  auto pxb_base_ver = pxb_base_version();
+  auto pxb_base_ver =
+      xtrabackup::utils::get_version_number(MYSQL_SERVER_VERSION);
 
   DBUG_EXECUTE_IF("simulate_lower_version", pxb_base_ver = 80014;);
 

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -80,5 +80,24 @@ bool read_server_uuid() {
   return (true);
 }
 
+/* find the pxb base version */
+unsigned long get_version_number(std::string version_str) {
+  unsigned long major = 0, minor = 0, version = 0;
+  std::size_t major_p = version_str.find(".");
+  if (major_p != std::string::npos)
+    major = stoi(version_str.substr(0, major_p));
+
+  std::size_t minor_p = version_str.find(".", major_p + 1);
+  if (minor_p != std::string::npos)
+    minor = stoi(version_str.substr(major_p + 1, minor_p - major_p));
+
+  std::size_t version_p = version_str.find(".", minor_p + 1);
+  if (version_p != std::string::npos)
+    version = stoi(version_str.substr(minor_p + 1, version_p - minor_p));
+  else
+    version = stoi(version_str.substr(minor_p + 1));
+  return major * 10000 + minor * 100 + version;
+}
+
 }  // namespace utils
 }  // namespace xtrabackup

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -38,6 +38,12 @@ extern bool load_backup_my_cnf(my_option *options, char *path);
   @return false in case of error, true otherwise
 */
 bool read_server_uuid();
+
+/* convert the version_str to version
+@param[in] version_str version string like 8.0.22.debug
+@return version_number like 80022 */
+unsigned long get_version_number(std::string version_str);
+
 }  // namespace utils
 }  // namespace xtrabackup
 #endif  // XTRABACKUP_UTILS_H

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -46,6 +46,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <mysql_version.h>
 #include <mysqld.h>
 #include <sql_bitmap.h>
+#include "row0quiesce.h"
 
 #include <fcntl.h>
 #include <signal.h>
@@ -194,6 +195,8 @@ static hash_table_t *tables_exclude_hash = NULL;
 
 /* map of schema name and schema id */
 static std::map<std::string, uint64> dd_schema_map;
+
+static uint32_t cfg_version = IB_EXPORT_CFG_VERSION_V6;
 
 /* map of <schema id, name> and SDI id*/
 static std::map<std::pair<int, std::string>, uint64> dd_table_map;
@@ -2537,6 +2540,48 @@ static bool innodb_end(void) {
   internal_innobase_data_file_path = NULL;
 
   return (FALSE);
+}
+
+/* Read backup meta info.
+@param[in] filename filename to read mysql version
+@return TRUE on success, FALSE on failure. */
+static bool xtrabackup_read_info(char *filename) {
+  FILE *fp;
+  bool r = TRUE;
+  char mysql_server_version_str[30] = ""; /* 8.0.20.debug| 8.0.20 */
+  unsigned long mysql_server_version;
+
+  fp = fopen(filename, "r");
+  if (!fp) {
+    msg("xtrabackup: Error: cannot open %s\n", filename);
+    return (FALSE);
+  }
+  /* skip uuid, name, tool_name, tool_command, tool_version, ibbackup_version */
+  for (int i = 0; i < 6; i++) {
+    char c;
+    do {
+      c = fgetc(fp);
+    } while (c != '\n');
+  }
+
+  if (fscanf(fp, "server_version = %29s\n", mysql_server_version_str) != 1) {
+    r = FALSE;
+    goto end;
+  }
+  mysql_server_version =
+      xtrabackup::utils::get_version_number(mysql_server_version_str);
+
+  ut_ad(mysql_server_version > 80000 && mysql_server_version < 90000);
+  if (mysql_server_version < 80019) {
+    cfg_version = IB_EXPORT_CFG_VERSION_V3;
+  } else if (mysql_server_version < 80020) {
+    cfg_version = IB_EXPORT_CFG_VERSION_V4;
+  } else if (mysql_server_version < 80023) {
+    cfg_version = IB_EXPORT_CFG_VERSION_V5;
+  }
+end:
+  fclose(fp);
+  return (r);
 }
 
 /* ================= common ================= */
@@ -5978,7 +6023,10 @@ static bool xb_export_cfg_write_index_fields(
                                this index */
     FILE *file)                /*!< in: file to write to */
 {
-  byte row[sizeof(ib_uint32_t) * 2];
+  /* This row will store prefix_len, fixed_len,
+  and in IB_EXPORT_CFG_VERSION_V4, is_ascending */
+  byte row[sizeof(ib_uint32_t) * 3];
+  size_t row_len = sizeof(row);
 
   for (ulint i = 0; i < index->n_fields; ++i) {
     byte *ptr = row;
@@ -5989,7 +6037,16 @@ static bool xb_export_cfg_write_index_fields(
 
     mach_write_to_4(ptr, field->fixed_len);
 
-    if (fwrite(row, 1, sizeof(row), file) != sizeof(row)) {
+    if (cfg_version >= IB_EXPORT_CFG_VERSION_V4)
+    {
+      ptr += sizeof(ib_uint32_t);
+      /* In IB_EXPORT_CFG_VERSION_V4 we also write the is_ascending boolean. */
+      mach_write_to_4(ptr, field->is_ascending);
+    } else {
+      row_len = sizeof(ib_uint32_t) * 2;
+    }
+
+    if (fwrite(row, 1, row_len, file) != row_len) {
       msg("xtrabackup: Error: writing index fields.");
 
       return (false);
@@ -6114,13 +6171,12 @@ xb_export_cfg_write_indexes(
   if (has_sdi) {
     dict_index_t *index = dict_sdi_get_index(table->space);
 
-    ut_ad(index != NULL);
+    ut_ad(index != nullptr);
     ret = xb_export_cfg_write_one_index(index, file);
   }
 
   /* Write the index meta data. */
-  for (const dict_index_t *index = UT_LIST_GET_FIRST(table->indexes);
-       index != 0 && ret; index = UT_LIST_GET_NEXT(indexes, index)) {
+  for (const dict_index_t *index : table->indexes) {
     ret = xb_export_cfg_write_one_index(index, file);
   }
 
@@ -6192,6 +6248,12 @@ xb_export_cfg_write_table(
 
       return (false);
     }
+
+    if (cfg_version >= IB_EXPORT_CFG_VERSION_V3) {
+      if (row_quiesce_write_default_value(col, file) != DB_SUCCESS) {
+        return (false);
+      }
+    }
   }
 
   return (true);
@@ -6210,7 +6272,7 @@ xb_export_cfg_write_header(
   byte value[sizeof(ib_uint32_t)];
 
   /* Write the meta-data version number. */
-  mach_write_to_4(value, IB_EXPORT_CFG_VERSION_V2);
+  mach_write_to_4(value, cfg_version);
 
   if (fwrite(&value, 1, sizeof(value), file) != sizeof(value)) {
     msg("xtrabackup: Error: writing meta-data version number.");
@@ -6277,6 +6339,17 @@ xb_export_cfg_write_header(
     return (false);
   }
 
+  if (cfg_version >= IB_EXPORT_CFG_VERSION_V5) {
+    /* write number of nullable column before first instant column */
+    mach_write_to_4(value, table->first_index()->n_instant_nullable);
+
+    if (fwrite(&value, 1, sizeof(value), file) != sizeof(value)) {
+      msg("xtrabackup: Error: writing table meta-data.");
+
+      return (false);
+    }
+  }
+
   /* Write the space flags */
   ulint space_flags = fil_space_get_flags(table->space);
   ut_ad(space_flags != ULINT_UNDEFINED);
@@ -6285,6 +6358,19 @@ xb_export_cfg_write_header(
   if (fwrite(&value, 1, sizeof(value), file) != sizeof(value)) {
     msg("xtrabackup: Error: writing writing space_flags.");
     return (false);
+  }
+
+  if (cfg_version >= IB_EXPORT_CFG_VERSION_V6) {
+    /* Write compression type info. */
+    uint8_t compression_type =
+        static_cast<uint8_t>(fil_get_compression(table->space));
+    mach_write_to_1(value, compression_type);
+
+    if (fwrite(&value, 1, sizeof(uint8_t), file) != sizeof(uint8_t)) {
+      msg("xtrabackup: Error: writing compression type info.");
+
+      return (false);
+    }
   }
 
   return (true);
@@ -6520,6 +6606,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
   fil_node_t *node;
   fil_space_t *space;
   char metadata_path[FN_REFLEN];
+  char xtrabackup_info_path[FN_REFLEN];
   IORequest write_request(IORequest::WRITE);
 
   /* cd to target-dir */
@@ -6546,6 +6633,20 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
         metadata_path);
     exit(EXIT_FAILURE);
   }
+
+  sprintf(metadata_path, "%s/%s", xtrabackup_target_dir,
+          XTRABACKUP_METADATA_FILENAME);
+
+  /* read xtrabackup_info file only in the case of export since we need the
+   * server version */
+  sprintf(xtrabackup_info_path, "%s/%s", xtrabackup_target_dir,
+          XTRABACKUP_INFO);
+  if (xtrabackup_export && !xtrabackup_read_info(xtrabackup_info_path)) {
+    msg("xtrabackup: Error: failed to read xtrabackup_info from '%s'\n",
+        xtrabackup_info_path);
+    exit(EXIT_FAILURE);
+  }
+
 
   if (!strcmp(metadata_type_str, "full-backuped")) {
     msg("xtrabackup: This target seems to be not prepared yet.\n");

--- a/storage/innobase/xtrabackup/test/t/xb_export.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_export.sh
@@ -116,6 +116,13 @@ col11 varchar(20), col12 bit ,col13 decimal, col14 blob, col16 json,
 col17 mediumtext, col18 enum("01","2"), col19 SET("0","1","2"),
 col20 varchar(255) character set latin1 )' incremental_sample;
 
+mysql -e 'CREATE TABLE test5(a int, b int, PRIMARY KEY (a), KEY (b DESC))' incremental_sample
+mysql -e 'CREATE TABLE test6(a int)' incremental_sample
+mysql -e 'ALTER TABLE test6 ADD COLUMN v1 VARCHAR(255), ALGORITHM=INSTANT' incremental_sample
+mysql -e 'CREATE TABLE test7(a int) row_format=compressed' incremental_sample
+mysql -e 'CREATE TABLE test8(c1 INT) ENGINE = InnoDB' incremental_sample
+mysql -e 'ALTER TABLE test8 ADD COLUMN c2 INT DEFAULT 500' incremental_sample
+
 checksum_1=`checksum_table incremental_sample test`
 rowsnum_1=`${MYSQL} ${MYSQL_ARGS} -Ns -e "select count(*) from test" incremental_sample`
 vlog "rowsnum_1 is $rowsnum_1"
@@ -138,22 +145,32 @@ col5 timestamp, col6 long, col7 date, col8 time, col9 datetime, col10 year,
 col11 varchar(20), col12 bit ,col13 decimal, col14 blob, col16 json,
 col17 mediumtext, col18 enum("01","2"), col19 SET("0","1","2"),
 col20 varchar(255) character set latin1 )' incremental_sample;
+mysql -e 'CREATE TABLE test5(a int, b int, PRIMARY KEY (a), KEY (b DESC))' incremental_sample
+mysql -e 'CREATE TABLE test6(a int)' incremental_sample
+mysql -e 'ALTER TABLE test6 ADD COLUMN v1 VARCHAR(255), ALGORITHM=INSTANT' incremental_sample
+mysql -e 'CREATE TABLE test7(a int) row_format=compressed' incremental_sample
+mysql -e 'CREATE TABLE test8(c1 INT) ENGINE = InnoDB' incremental_sample
+mysql -e 'ALTER TABLE test8 ADD COLUMN c2 INT DEFAULT 500' incremental_sample
 vlog "Database was re-initialized"
 
 mysql -e "alter table test discard tablespace;" incremental_sample
 mysql -e "alter table test2 discard tablespace;" incremental_sample
 mysql -e "alter table test3 discard tablespace;" incremental_sample
 mysql -e "alter table test4 discard tablespace;" incremental_sample
+mysql -e "alter table test5 discard tablespace;" incremental_sample
+mysql -e "alter table test6 discard tablespace;" incremental_sample
+mysql -e "alter table test7 discard tablespace;" incremental_sample
+mysql -e "alter table test8 discard tablespace;" incremental_sample
 
 xtrabackup --datadir=$mysql_datadir --prepare --export \
     --target-dir=$backup_dir
 
 ls -tlr $backup_dir/incremental_sample/*cfg
 cfg_count=`find $backup_dir/incremental_sample -name '*.cfg' | wc -l`
-vlog "Verifying .cfg files in backup, expecting 6."
-if [ $cfg_count -ne 6 ]
+vlog "Verifying .cfg files in backup, expecting 10."
+if [ $cfg_count -ne 10 ]
 then
-   vlog "Expecting 6 cfg files. Found only $cfg_count"
+   vlog "Expecting 10 cfg files. Found only $cfg_count"
    exit -1
 fi
 
@@ -162,6 +179,10 @@ mysql -e "alter table test import tablespace" incremental_sample
 mysql -e "alter table test2 import tablespace" incremental_sample
 mysql -e "alter table test3 import tablespace" incremental_sample
 mysql -e "alter table test4 import tablespace" incremental_sample
+mysql -e "alter table test5 import tablespace" incremental_sample
+mysql -e "alter table test6 import tablespace" incremental_sample
+mysql -e "alter table test7 import tablespace" incremental_sample
+mysql -e "alter table test8 import tablespace" incremental_sample
 vlog "Table has been imported"
 
 vlog "Cheking checksums"

--- a/storage/innobase/xtrabackup/test/t/xb_export_check_cfg.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_export_check_cfg.sh
@@ -1,0 +1,45 @@
+. inc/common.sh
+
+start_server 
+
+vlog "check if cfg version is 6 in table"
+
+mkfifo $topdir/fifo
+
+$MYSQL $MYSQL_ARGS <$topdir/fifo &
+
+client_pid=$!
+
+# Open the pipe for writing. This is required to prevent cat from closing the
+# pipe when stdout is redirected to it
+
+exec 3>$topdir/fifo
+
+cat >&3 <<EOF
+USE test;
+CREATE TABLE t1(a INT) ENGINE=InnoDB;
+FLUSH TABLE t1 FOR EXPORT;
+EOF
+
+
+# Let the client complete the above set of statements
+vlog "waiting for 3 seconds to ensure cfg file is generated"
+sleep 3
+
+CFG_VERSION=`od -j3 -N1 -t x1 -An $mysql_datadir/test/t1.cfg  | head -30 | tr -d ' ' | tr -d '\n'`
+CFG_VERSION_B=$(xxd -b -l4 -s0 $mysql_datadir/test/t1.cfg | awk '{print $2 $3 $4 $5}')
+CFG_VERSION=$((2#$CFG_VERSION_B))
+
+if [ "$CFG_VERSION" -le "6" ]; then
+	vlog "version of CFG is $CFG_VERSION"
+else
+	vlog "PXB should have changed the source code to handle the new version $CFG_VERSION"
+	exit -1
+fi
+
+# Terminate the background client
+echo "exit" >&3
+exec 3>&-
+wait $client_pid
+
+


### PR DESCRIPTION
…able

https://jira.percona.com/browse/PXB-2543

Problem:
PXB can't export single table with instant column, compression
information and default columns.

Analysis:
PXB export IB_EXPORT_CFG_VERSION_V2 whereas mysql 8.0.23 is using
IB_EXPORT_CFG_VERSION_V6.

Fix:
Generate IB_EXPORT_CFG_VERSION_V6 if using mysql 8.0.23 or later