### PR TITLE
Fixed PXB-2614 (xbstream sparse files support doesn't work on XFS)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -51,7 +51,8 @@ enum file_purpose_t {
 /************************************************************************
 Write buffer into .ibd file and preserve it's sparsiness. */
 bool write_ibd_buffer(ds_file_t *file, unsigned char *buf, size_t buf_len,
-                      size_t page_size, size_t block_size);
+                      size_t page_size, size_t block_size,
+                      bool punch_hole_supported);
 
 /************************************************************************
 Copy file for backup/restore.

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -124,11 +124,11 @@ int ds_is_sparse_write_supported(ds_file_t *file) {
 Write sparse chunk if supported.
 @return 0 on success, 1 on error. */
 int ds_write_sparse(ds_file_t *file, const void *buf, size_t len,
-                    size_t sparse_map_size,
-                    const ds_sparse_chunk_t *sparse_map) {
+                    size_t sparse_map_size, const ds_sparse_chunk_t *sparse_map,
+                    bool punch_hole_supported) {
   if (file->datasink->write_sparse != nullptr) {
     return file->datasink->write_sparse(file, buf, len, sparse_map_size,
-                                        sparse_map);
+                                        sparse_map, punch_hole_supported);
   }
   return 1;
 }

--- a/storage/innobase/xtrabackup/src/datasink.h
+++ b/storage/innobase/xtrabackup/src/datasink.h
@@ -35,6 +35,7 @@ typedef struct ds_ctxt {
   char *root;
   void *ptr;
   struct ds_ctxt *pipe_ctxt;
+  bool fs_support_punch_hole;
 } ds_ctxt_t;
 
 typedef struct {
@@ -54,7 +55,8 @@ struct datasink_struct {
   int (*write)(ds_file_t *file, const void *buf, size_t len);
   int (*write_sparse)(ds_file_t *file, const void *buf, size_t len,
                       size_t sparse_map_size,
-                      const ds_sparse_chunk_t *sparse_map);
+                      const ds_sparse_chunk_t *sparse_map,
+                      bool punch_hole_supported);
   int (*close)(ds_file_t *file);
   void (*deinit)(ds_ctxt_t *ctxt);
 };
@@ -96,8 +98,8 @@ int ds_is_sparse_write_supported(ds_file_t *file);
 Write sparse chunk if supported.
 @return 0 on success, 1 on error. */
 int ds_write_sparse(ds_file_t *file, const void *buf, size_t len,
-                    size_t sparse_map_size,
-                    const ds_sparse_chunk_t *sparse_map);
+                    size_t sparse_map_size, const ds_sparse_chunk_t *sparse_map,
+                    bool punch_hole_supported);
 
 /************************************************************************
 Close a datasink file.

--- a/storage/innobase/xtrabackup/src/ds_xbstream.cc
+++ b/storage/innobase/xtrabackup/src/ds_xbstream.cc
@@ -46,7 +46,8 @@ static ds_file_t *xbstream_open(ds_ctxt_t *ctxt, const char *path,
 static int xbstream_write(ds_file_t *file, const void *buf, size_t len);
 static int xbstream_write_sparse(ds_file_t *file, const void *buf, size_t len,
                                  size_t sparse_map_size,
-                                 const ds_sparse_chunk_t *sparse_map);
+                                 const ds_sparse_chunk_t *sparse_map,
+                                 bool punch_hole_supported);
 static int xbstream_close(ds_file_t *file);
 static void xbstream_deinit(ds_ctxt_t *ctxt);
 
@@ -176,7 +177,8 @@ static int xbstream_write(ds_file_t *file, const void *buf, size_t len) {
 
 static int xbstream_write_sparse(ds_file_t *file, const void *buf, size_t len,
                                  size_t sparse_map_size,
-                                 const ds_sparse_chunk_t *sparse_map) {
+                                 const ds_sparse_chunk_t *sparse_map,
+                                 bool punch_hole_supported) {
   ds_stream_file_t *stream_file;
   xb_wstream_file_t *xbstream_file;
 

--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -202,7 +202,7 @@ Write the next batch of pages to the destination datasink.
 static bool wf_wt_process(xb_write_filt_ctxt_t *ctxt, ds_file_t *dstfile) {
   const auto cursor = ctxt->cursor;
 
-  return write_ibd_buffer(dstfile, cursor->buf,
-                          cursor->buf_npages * cursor->page_size,
-                          cursor->page_size, cursor->block_size);
+  return write_ibd_buffer(
+      dstfile, cursor->buf, cursor->buf_npages * cursor->page_size,
+      cursor->page_size, cursor->block_size, punch_hole_supported);
 }

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -177,9 +177,13 @@ int main(int argc, char **argv) {
 
   if (opt_output_file) {
     output_file = opt_output_file;
+    char dirpath[FN_REFLEN];
+    size_t dirpath_len;
+
     if (opt_verbose) msg("%s: output file \"%s\".\n", my_progname, output_file);
 
-    output_ds = ds_create(".", DS_TYPE_LOCAL);
+    dirname_part(dirpath, output_file, &dirpath_len);
+    output_ds = ds_create(dirpath, DS_TYPE_LOCAL);
   } else {
     if (opt_verbose) msg("%s: output to standard output.\n", my_progname);
     output_ds = ds_create(".", DS_TYPE_STDOUT);

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -531,7 +531,8 @@ static void *extract_worker_thread_func(void *arg) {
       entry->offset += chunk.length;
     } else if (chunk.type == XB_CHUNK_TYPE_SPARSE) {
       if (ds_write_sparse(entry->file, chunk.data, chunk.length,
-                          chunk.sparse_map_size, chunk.sparse_map)) {
+                          chunk.sparse_map_size, chunk.sparse_map,
+                          ctxt->ds_ctxt->fs_support_punch_hole)) {
         msg("%s: my_write() failed.\n", my_progname);
         pthread_mutex_unlock(&entry->mutex);
         res = XB_STREAM_READ_ERROR;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -441,6 +441,8 @@ uint opt_dump_innodb_buffer_pool_timeout = 10;
 uint opt_dump_innodb_buffer_pool_pct = 0;
 bool opt_dump_innodb_buffer_pool = FALSE;
 
+bool punch_hole_supported = FALSE;
+
 bool opt_lock_ddl = FALSE;
 bool opt_lock_ddl_per_table = FALSE;
 uint opt_lock_ddl_timeout = 0;
@@ -3254,6 +3256,7 @@ static void xtrabackup_init_datasinks(void) {
     /* Local filesystem */
     ds_data = ds_meta = ds_redo =
         ds_create(xtrabackup_target_dir, DS_TYPE_LOCAL);
+    punch_hole_supported = ds_data->fs_support_punch_hole;
   }
 
   /* Track it for destruction */

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -201,6 +201,8 @@ extern bool opt_generate_new_master_key;
 extern uint opt_dump_innodb_buffer_pool_timeout;
 extern uint opt_dump_innodb_buffer_pool_pct;
 extern bool opt_dump_innodb_buffer_pool;
+
+extern bool punch_hole_supported;
 extern bool compile_regex(const char *regex_string, const char *error_context,
                           xb_regex_t *compiled_re);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2614

Problem:
A whole in a file consists in a free space between data. A whole (at the
time of a write) is done by moving the file pointer (lseek) to a
specific offset beyond the end of the file and then write some data
after that.

Xbstream sparse file support works by having a map of those wholes in
the original file, when extracting each chunk, we re-create those wholes
by doing lseek to advance the file pointer to pass the whole and then
we write the actual data.

XFS has a feature called speculative preallocation
https://linux-xfs.oss.sgi.narkive.com/jjjfnyI1/faq-xfs-speculative-preallocation
Basically when you write some data, it allocates some extra blocks after
the end of the file for the next write.

The problem lies in the fact that for XFS, if the lseek doesn't cross
the space preallocated from the previous write, the next time we write
data to the file this allocation will be made permanent and no
space/whole will be created on the file.

Fix:
Manually punch a whole at the desired offset using fallocate.