### PR TITLE
PXB-2506 Error out if backup is not prepared during copy-back

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug983695.sh
+++ b/storage/innobase/xtrabackup/test/t/bug983695.sh
@@ -19,6 +19,7 @@ cd $topdir/backup
 for i in *.qp sakila/*.qp;  do qpress -d $i ./; done;
 cd -
 
+xtrabackup --prepare --target-dir=$topdir/backup
 xtrabackup --copy-back --target-dir=$topdir/backup
 
 run_cmd_expect_failure ls ${MYSQLD_DATADIR}/*.qp

--- a/storage/innobase/xtrabackup/test/t/validate_copy_back.sh
+++ b/storage/innobase/xtrabackup/test/t/validate_copy_back.sh
@@ -1,0 +1,10 @@
+
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup
+
+stop_server
+vlog "case#1 check copy-back should not work on new backup "
+rm -rf $MYSQLD_DATADIR/*
+run_cmd_expect_failure $XB_BIN $XB_ARGS --copy-back --target-dir=$topdir/backup
+run_cmd_expect_failure $XB_BIN $XB_ARGS --move-back --target-dir=$topdir/backup


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2506

Copy back allowed restoring backup which are not fully prepared.
for example prepared with *apply-log-only.*

This could end in restoring wrong backup.

Fix
add check to validate if backup is fully prepared.