### PR TITLE
PXB-2466 Xbcrypt crashes when overwriting an existing file

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_encrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_encrypt.cc
@@ -187,7 +187,8 @@ err:
   if (crypt_file->dest_file) {
     ds_close(crypt_file->dest_file);
   }
-  my_free(file);
+  delete file;
+  delete crypt_file;
   return NULL;
 }
 

--- a/storage/innobase/xtrabackup/test/t/xbcrypt.sh
+++ b/storage/innobase/xtrabackup/test/t/xbcrypt.sh
@@ -18,6 +18,13 @@ run_cmd xbcrypt -i inc/decrypt_v1_test_file.txt \
     -o ${test_file}.xbcrypt \
     -a ${encrypt_algo} -k ${encrypt_key}
 
+vlog "check double encryption should fail"
+run_cmd_expect_failure xbcrypt -i inc/decrypt_v1_test_file.txt \
+    -o ${test_file}.xbcrypt \
+    -a ${encrypt_algo} -k ${encrypt_key}
+
+grep -qi "assert" $OUTFILE && die "Unexpected assertion instead of graceful exit on double encryption"
+
 vlog "Verifying output file..."
 ls -l ${test_file}.xbcrypt
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2466

Problem:
Xbcrypt crashes when Encrypt the file again in the same location

Analysis:
Incase of error, Xbcrypt is using my_free to clear object memory
which is created with new operator

Fix
Use the delete operator instead of my_free