### PR TITLE
8.0 PXB-2625 - Error in the HTTP2 framing layer / Large backup fails on D…

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -341,10 +341,10 @@ class Http_client {
   bool verbose{false};
   std::string cacert;
   std::vector<CURLcode> curl_retriable_errors{
-      CURLcode::CURLE_GOT_NOTHING,      CURLcode::CURLE_OPERATION_TIMEDOUT,
-      CURLcode::CURLE_RECV_ERROR,       CURLcode::CURLE_SEND_ERROR,
-      CURLcode::CURLE_SEND_FAIL_REWIND, CURLcode::CURLE_PARTIAL_FILE,
-      CURLcode::CURLE_SSL_CONNECT_ERROR};
+      CURLcode::CURLE_GOT_NOTHING,       CURLcode::CURLE_OPERATION_TIMEDOUT,
+      CURLcode::CURLE_RECV_ERROR,        CURLcode::CURLE_SEND_ERROR,
+      CURLcode::CURLE_SEND_FAIL_REWIND,  CURLcode::CURLE_PARTIAL_FILE,
+      CURLcode::CURLE_SSL_CONNECT_ERROR, CURLcode::CURLE_HTTP2};
   std::vector<long> http_retriable_errors{503, 500, 504, 408};
   mutable curl_easy_unique_ptr curl{nullptr, curl_easy_cleanup};
 


### PR DESCRIPTION
…ebian Buster

https://jira.percona.com/browse/PXB-2625

Problem:
In some version of curl after 7.52.1 (default for Debian 9/Stretch) and
version 7.64.0 (default for Debian 10/Buster) a regression was
introduced that caused curl fail to identify a TLS HTTP2 connection was
closed and it tried to re-use the closed connection causing xbcloud
fail to download / upload chunks with 'Error in the HTTP2 framing layer'
message / Curl error code 16 - CURLE_HTTP2.

Fix:
Curl has fixed it at
curl/curl@3f5da4e
and delivered it on 7.65.0. For users that cannot update the curl
version and to provide a better user experience by making the backup to
complete we are adding error CURLE_HTTP2 retriable by default.

Thanks to Johan Andersson for reporting and helping troubleshooting.