### PR TITLE
PXB-2614 post-fix - xbstream sparse files support doesn't work on XFS

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_local.cc
+++ b/storage/innobase/xtrabackup/src/ds_local.cc
@@ -158,7 +158,7 @@ static int local_write_sparse(ds_file_t *file, const void *buf, size_t len,
                               bool punch_hole_supported) {
   auto local_file = ((ds_local_file_t *)file->ptr);
   File fd = local_file->fd;
-  int seek = 0;
+  ulonglong seek = 0;
 
   const uchar *ptr = static_cast<const uchar *>(buf);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2614

Problem:
seek position that is passed to fallocate call was defined as int.
This will overflow the seek position if the file is bigger than what
int datatype can accept.

Fix:
use ulonglong type. This aligns seek with the return type of my_tell.