### PR TITLE
Support mysql 5.5.0-m2 database backup

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -402,7 +402,7 @@ check_server_version(unsigned long version_number,
 	version_supported = version_supported
 		|| (mysql51 && innodb_version != NULL);
 	version_supported = version_supported
-		|| (version_number > 50500 && version_number < 50800);
+		|| (version_number >= 50500 && version_number < 50800);
 	version_supported = version_supported
 		|| ((version_number > 100000 && version_number < 100300)
 		    && server_flavor == FLAVOR_MARIADB);


### PR DESCRIPTION
MySQL officially supports the 5.5.0-m2 version of the database, and xtrabackup also promises to support the 5.5 version of the database, but after verification, the 5.5.0-m2 database does not support backup, by modifying the source code, I have passed the verification