### PR TITLE
Fixed PXB-2648 - error: 'CURLE_HTTP2' is not a member of 'CURLcode'

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -340,11 +340,15 @@ class Http_client {
   bool insecure{false};
   bool verbose{false};
   std::string cacert;
+  /*
+   * CURLcode::CURLE_OBSOLETE16 is used as backwards compatible error.
+   * On newer versions of curl library it translates to CURLcode::CURLE_HTTP2.
+   */
   std::vector<CURLcode> curl_retriable_errors{
       CURLcode::CURLE_GOT_NOTHING,       CURLcode::CURLE_OPERATION_TIMEDOUT,
       CURLcode::CURLE_RECV_ERROR,        CURLcode::CURLE_SEND_ERROR,
       CURLcode::CURLE_SEND_FAIL_REWIND,  CURLcode::CURLE_PARTIAL_FILE,
-      CURLcode::CURLE_SSL_CONNECT_ERROR, CURLcode::CURLE_HTTP2};
+      CURLcode::CURLE_SSL_CONNECT_ERROR, CURLcode::CURLE_OBSOLETE16};
   std::vector<long> http_retriable_errors{503, 500, 504, 408};
   mutable curl_easy_unique_ptr curl{nullptr, curl_easy_cleanup};
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2648

Problem:
Curl version prior to 7.38.0 doesn't have CURLE_HTTP2, it has
CURLE_OBSOLETE16.

Fix:
Use CURLE_OBSOLETE16. On newer versions of libcurl it has an alias
that translates CURLE_OBSOLETE16 to CURLE_HTTP2.