### PR TITLE
Implemented PXB-2635 - Add circleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,20 @@
+version: 2
+jobs:
+  checking-branch-job:
+    docker:
+      - image: circleci/buildpack-deps:bionic
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+    steps:
+      - run: echo "Clang Format not required"
+workflows:
+  version: 2
+
+  build:
+    jobs:
+      - checking-branch-job:
+          filters:
+            branches:
+              only:
+                - none


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2635

Added a NONE config file to skip tests on 2.4 branch. We don't
enforce/use clang format on 2.4.