### PR TITLE
PXB-61 - Enable --strict by default / PXB-2644 - Cannot perform backup with user created with REQUIRE x509 

### DIFF
--- a/include/sslopt-case.h
+++ b/include/sslopt-case.h
@@ -24,7 +24,6 @@
   @file include/sslopt-case.h
 */
 
-#if defined(HAVE_OPENSSL)
 
 #if defined(MYSQL_SERVER) && !defined(XTRABACKUP)
 #error This header is supposed to be used only in the client

--- a/include/sslopt-longopts.h
+++ b/include/sslopt-longopts.h
@@ -24,7 +24,6 @@
   @file include/sslopt-longopts.h
 */
 
-#if defined(HAVE_OPENSSL)
 #if !defined(MYSQL_SERVER) || defined(XTRABACKUP)
 {"ssl-mode",
  OPT_SSL_MODE,

--- a/include/sslopt-vars.h
+++ b/include/sslopt-vars.h
@@ -58,6 +58,7 @@ const char *ssl_fips_mode_names_lib[] = {"OFF", "ON", "STRICT", NullS};
 TYPELIB ssl_fips_mode_typelib = {array_elements(ssl_fips_mode_names_lib) - 1,
                                  "", ssl_fips_mode_names_lib, nullptr};
 
+#ifndef XTRABACKUP
 static uint opt_ssl_mode = SSL_MODE_PREFERRED;
 static char *opt_ssl_ca = nullptr;
 static char *opt_ssl_capath = nullptr;
@@ -70,8 +71,22 @@ static char *opt_ssl_crlpath = nullptr;
 static char *opt_tls_version = nullptr;
 static ulong opt_ssl_fips_mode = SSL_FIPS_MODE_OFF;
 static bool ssl_mode_set_explicitly = false;
-
 static inline int set_client_ssl_options(MYSQL *mysql) {
+#else
+uint opt_ssl_mode = SSL_MODE_PREFERRED;
+char *opt_ssl_ca = nullptr;
+char *opt_ssl_capath = nullptr;
+char *opt_ssl_cert = nullptr;
+char *opt_ssl_cipher = nullptr;
+char *opt_tls_ciphersuites = nullptr;
+char *opt_ssl_key = nullptr;
+char *opt_ssl_crl = nullptr;
+char *opt_ssl_crlpath = nullptr;
+char *opt_tls_version = nullptr;
+ulong opt_ssl_fips_mode = SSL_FIPS_MODE_OFF;
+bool ssl_mode_set_explicitly = false;
+int set_client_ssl_options(MYSQL *mysql) {
+#endif
   /*
     Print a warning if explicitly defined combination of --ssl-mode other than
     VERIFY_CA or VERIFY_IDENTITY with explicit --ssl-ca or --ssl-capath values.

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -70,18 +70,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "fsp0fsp.h"
 #include "xb_regex.h"
 
-extern uint opt_ssl_mode;
 extern bool opt_no_server_version_check;
-extern char *opt_ssl_ca;
-extern char *opt_ssl_capath;
-extern char *opt_ssl_cert;
-extern char *opt_ssl_cipher;
-extern char *opt_ssl_key;
-extern char *opt_ssl_crl;
-extern char *opt_ssl_crlpath;
-extern char *opt_tls_version;
-extern ulong opt_ssl_fips_mode;
-extern bool ssl_mode_set_explicitly;
 
 /** Possible values for system variable "innodb_checksum_algorithm". */
 extern const char *innodb_checksum_algorithm_names[];
@@ -169,30 +158,7 @@ MYSQL *xb_mysql_connect() {
       opt_port != 0 ? mysql_port_str : "not set",
       opt_socket ? opt_socket : "not set");
 
-#ifdef HAVE_OPENSSL
-  /*
-  Print a warning if explicitly defined combination of --ssl-mode other than
-  VERIFY_CA or VERIFY_IDENTITY with explicit --ssl-ca or --ssl-capath values.
-  */
-  if (ssl_mode_set_explicitly && opt_ssl_mode < SSL_MODE_VERIFY_CA &&
-      (opt_ssl_ca || opt_ssl_capath)) {
-    msg("WARNING: no verification of server certificate will "
-        "be done. Use --ssl-mode=VERIFY_CA or "
-        "VERIFY_IDENTITY.\n");
-  }
-
-  /* Set SSL parameters: key, cert, ca, capath, cipher, clr, clrpath. */
-  if (opt_ssl_mode >= SSL_MODE_VERIFY_CA)
-    mysql_ssl_set(connection, opt_ssl_key, opt_ssl_cert, opt_ssl_ca,
-                  opt_ssl_capath, opt_ssl_cipher);
-  else
-    mysql_ssl_set(connection, opt_ssl_key, opt_ssl_cert, NULL, NULL,
-                  opt_ssl_cipher);
-  mysql_options(connection, MYSQL_OPT_SSL_CRL, opt_ssl_crl);
-  mysql_options(connection, MYSQL_OPT_SSL_CRLPATH, opt_ssl_crlpath);
-  mysql_options(connection, MYSQL_OPT_TLS_VERSION, opt_tls_version);
-  mysql_options(connection, MYSQL_OPT_SSL_MODE, &opt_ssl_mode);
-#endif
+  set_client_ssl_options(connection);
 
   if (!mysql_real_connect(connection, opt_host ? opt_host : "localhost",
                           opt_user, opt_password, "" /*database*/, opt_port,

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -141,7 +141,6 @@ const char reserved_system_space_name[] = "innodb_system";
 /* This tablespace name is reserved by InnoDB for the predefined temporary
 tablespace. */
 const char reserved_temporary_space_name[] = "innodb_temporary";
-ulong opt_ssl_fips_mode = SSL_FIPS_MODE_OFF;
 
 /* === xtrabackup specific options === */
 char xtrabackup_real_target_dir[FN_REFLEN] = "./xtrabackup_backupfiles/";
@@ -480,6 +479,7 @@ std::vector<ulint> invalid_encrypted_tablespace_ids;
 extern TYPELIB innodb_flush_method_typelib;
 
 #include "caching_sha2_passwordopt-vars.h"
+#include "sslopt-vars.h"
 
 bool mdl_taken = FALSE;
 extern struct rand_struct sql_rand;
@@ -1232,6 +1232,7 @@ struct my_option xb_client_options[] = {
      0},
 
 #include "caching_sha2_passwordopt-longopts.h"
+#include "sslopt-longopts.h"
 
 #if !defined(HAVE_YASSL)
     {"server-public-key-path", OPT_SERVER_PUBLIC_KEY,
@@ -1826,6 +1827,9 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
     case OPT_XTRA_ENCRYPT_KEY:
       hide_option(argument, &xtrabackup_encrypt_key);
       break;
+
+#include "sslopt-case.h"
+
     case '?':
       usage();
       exit(EXIT_SUCCESS);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -221,7 +221,7 @@ bool io_watching_thread_running = false;
 bool xtrabackup_logfile_is_renamed = false;
 
 int xtrabackup_parallel;
-bool opt_strict = false;
+bool opt_strict = true;
 
 char *xtrabackup_stream_str = NULL;
 xb_stream_fmt_t xtrabackup_stream_fmt = XB_STREAM_FMT_NONE;
@@ -1282,7 +1282,7 @@ struct my_option xb_client_options[] = {
 
     {"strict", OPT_XTRA_STRICT,
      "Fail with error when invalid arguments were passed to the xtrabackup.",
-     (uchar *)&opt_strict, (uchar *)&opt_strict, 0, GET_BOOL, NO_ARG, 0, 0, 0,
+     (uchar *)&opt_strict, (uchar *)&opt_strict, 0, GET_BOOL, NO_ARG, 1, 0, 0,
      0, 0, 0},
 
     {"rocksdb-checkpoint-max-age", OPT_ROCKSDB_CHECKPOINT_MAX_AGE,

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_getopt.h>
 #include "changed_page_bitmap.h"
 #include "datasink.h"
+#include "mysql.h"
 #include "xb_regex.h"
 #include "xbstream.h"
 #include "xtrabackup_config.h"
@@ -205,6 +206,18 @@ extern bool opt_dump_innodb_buffer_pool;
 extern bool punch_hole_supported;
 extern bool compile_regex(const char *regex_string, const char *error_context,
                           xb_regex_t *compiled_re);
+/* sslopt-vars.h */
+extern uint opt_ssl_mode;
+extern char *opt_ssl_ca;
+extern char *opt_ssl_capath;
+extern char *opt_ssl_cert;
+extern char *opt_ssl_cipher;
+extern char *opt_ssl_key;
+extern char *opt_ssl_crl;
+extern char *opt_ssl_crlpath;
+extern char *opt_tls_version;
+extern bool ssl_mode_set_explicitly;
+extern int set_client_ssl_options(MYSQL *mysql);
 
 enum binlog_info_enum {
   BINLOG_INFO_OFF,

--- a/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
@@ -79,7 +79,6 @@ ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
 
 ${XB_BIN} --prepare --target-dir=$topdir/backup \
 	  --keyring-file-data=$keyring_file \
-	  --reencrypt-for-server-id=200 \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 stop_server

--- a/storage/innobase/xtrabackup/test/t/bug1028949.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1028949.sh
@@ -24,8 +24,7 @@ function test_bug_1028949()
 
   vlog "Starting backup"
 
-  xtrabackup --datadir=$mysql_datadir --backup --target-dir=$FULL_DIR \
-      $mysqld_additional_args
+  xtrabackup --datadir=$mysql_datadir --backup --target-dir=$FULL_DIR
 
   vlog "Full backup done"
 
@@ -55,24 +54,21 @@ function test_bug_1028949()
 
   # Incremental backup
   xtrabackup --datadir=$mysql_datadir --backup \
-      --target-dir=$DELTA_DIR --incremental-basedir=$FULL_DIR \
-      $mysqld_additional_args
+      --target-dir=$DELTA_DIR --incremental-basedir=$FULL_DIR
 
   vlog "Incremental backup done"
   vlog "Preparing backup"
 
   # Prepare backup
   xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
-      --target-dir=$FULL_DIR $mysqld_additional_args
+      --target-dir=$FULL_DIR
   vlog "Log applied to backup"
 
   xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
-      --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR \
-      $mysqld_additional_args
+      --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR
   vlog "Delta applied to backup"
 
-  xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$FULL_DIR \
-      $mysqld_additional_args
+  xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$FULL_DIR
   vlog "Data prepared for restore"
 
   # removing rows

--- a/storage/innobase/xtrabackup/test/t/pxb-1493.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1493.sh
@@ -4,12 +4,12 @@
 
 start_server
 
-err=$(${XB_BIN} ${XB_ARGS} --strict --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "unknown option")
+err=$(${XB_BIN} ${XB_ARGS} --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "unknown option")
 if [ -z "$err" ] ; then
     die "xtrabackup did not report error (--myoption)"
 fi
 
-err=$(${XB_BIN} ${XB_ARGS} --strict --backup --compress --copmress-threads=4 --target-dir=$topdir/backup 2>&1 | grep "unknown variable")
+err=$(${XB_BIN} ${XB_ARGS} --backup --compress --copmress-threads=4 --target-dir=$topdir/backup 2>&1 | grep "unknown variable")
 if [ -z "$err" ] ; then
     die "xtrabackup did not report error (--copmress-threads)"
 fi
@@ -26,7 +26,7 @@ if [ -z "$err" ] ; then
     die "xtrabackup did not report error (--myvariable)"
 fi
 
-err=$(${XB_BIN} ${XB_ARGS} --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "WARNING: unknown option")
+err=$(${XB_BIN} ${XB_ARGS} --skip-strict --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "WARNING: unknown option")
 if [ -z "$err" ] ; then
     die "xtrabackup did not report warning (--myoption)"
 fi

--- a/storage/innobase/xtrabackup/test/t/pxb-1914.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1914.sh
@@ -11,12 +11,12 @@ mysql -e "CREATE TABLE t (a INT) ENGINE=MyISAM" test
 mysql -e "SET GLOBAL general_log = 'ON'"
 mysql -e "SET GLOBAL log_output = 'TABLE'"
 
-xtrabackup --backup --target-dir=$topdir/bak1 --binlog-info=ON
+xtrabackup --backup --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1
 
 xtrabackup --backup --lock-ddl=false --backup-lock-retry-count=5 --backup-lock-timeout=3 \
-	   --target-dir=$topdir/bak1 --binlog-info=ON
+	   --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1
 

--- a/storage/innobase/xtrabackup/test/t/user_management.sh
+++ b/storage/innobase/xtrabackup/test/t/user_management.sh
@@ -1,0 +1,49 @@
+#
+# PXB-2644 - Cannot perform backup with user created with REQUIRE x509
+#
+
+
+########################################################################
+# Creates an user and perform a backup with the newly created user.
+# Expects up to 2 arguments:
+# - $1 is the GRANT option (eg.: IDENTIFIED WITH x BY y ).
+# - $2 is the options passed to xtrabackup (eg.: --password=x ).
+########################################################################
+function create_user_and_take_backup()
+{
+  GRANT_ARGS=$1
+  BACKUP_ARGS=${2:-""}
+  mysql -e "CREATE USER pxb@localhost ${GRANT_ARGS}"
+  mysql -e "GRANT ALL ON *.* TO pxb@localhost"
+
+  xtrabackup -u pxb --backup --target-dir=${topdir}/backup ${BACKUP_ARGS}
+
+  #Clean up
+  mysql -e "DROP USER pxb@localhost"
+  rm -rf ${topdir}/backup
+}
+start_server
+PASSWORD="SomeStr0ngPwD!"
+
+
+vlog "Test 1 - mysql_native_password"
+create_user_and_take_backup \
+"IDENTIFIED WITH 'mysql_native_password' BY '${PASSWORD}'" \
+"--password=${PASSWORD}"
+
+vlog "Test 2 - caching_sha2_password"
+create_user_and_take_backup \
+"IDENTIFIED WITH 'caching_sha2_password' BY '${PASSWORD}'" \
+"--password=${PASSWORD}"
+
+vlog "Test 3 - REQUIRE X509 via TCP"
+create_user_and_take_backup \
+"IDENTIFIED BY '${PASSWORD}' REQUIRE x509" \
+"--password=${PASSWORD} --host=127.0.0.1 --port=${MYSQLD_PORT} --ssl-key=${mysql_datadir}/client-key.pem --ssl-cert=${mysql_datadir}/client-cert.pem --ssl-ca=${mysql_datadir}/ca.pem"
+
+
+# Without sslopt-case.h socket connections over TCP won't work
+vlog "Test 4 - REQUIRE X509 via socket"
+create_user_and_take_backup \
+"IDENTIFIED BY '${PASSWORD}' REQUIRE x509" \
+"--password=${PASSWORD} --socket=${MYSQLD_SOCKET} --ssl-key=${mysql_datadir}/client-key.pem --ssl-cert=${mysql_datadir}/client-cert.pem --ssl-ca=${mysql_datadir}/ca.pem"


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2644

Problem:
Upstream at commit 1910e12 removed #ifdef HAVE_OPENSSL preprocessor.
However, PXB was still using it in order to decide if we would pass SSL
options to stablished connection.

Fix:
Removed preprocessor from PXB code.
Modified sslopt-vars.h in order for PXB to use the same function that
configure a connection to use SSL. Before we were mirroring the code at
backup_mysql.cc, which makes it hard to notice if something on that code
changed on the include file.


https://jira.percona.com/browse/PXB-61

Problem:
PXB accepts any command line parameters and only produces a warning.
This can be dangerous.

Fix:
Enable --strict by default.