### PR TITLE
PXB-2658 PXB waits for checkpoint LSN to be greater than page tracking LSN in full and incremental backup

### DIFF
--- a/storage/innobase/xtrabackup/src/changed_page_tracking.h
+++ b/storage/innobase/xtrabackup/src/changed_page_tracking.h
@@ -49,6 +49,11 @@ the LSN interval incremental_lsn to checkpoint_lsn_start.
 @return the built map or nullptr if unable to build for any reason. */
 xb_space_map *init(lsn_t checkpoint_lsn_start, MYSQL *connection);
 
+/* Get the start page-tracking-lsn
+@param[in] connection               MySQL connectionn
+@return the page tracking start lsn */
+lsn_t get_pagetracking_start_lsn(MYSQL *connection);
+
 /** Free the tracking map.
 @param[in/out] space_map pagetracking map */
 void deinit(xb_space_map *space_map);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -171,7 +171,6 @@ lsn_t incremental_start_checkpoint_lsn;
 lsn_t incremental_to_lsn;
 lsn_t incremental_last_lsn;
 lsn_t incremental_flushed_lsn;
-lsn_t page_tracking_start_lsn = 0;
 xb_page_bitmap *changed_page_bitmap = NULL;
 pagetracking::xb_space_map *changed_page_tracking = nullptr;
 
@@ -4236,6 +4235,7 @@ void xtrabackup_backup_func(void) {
   }
   debug_sync_point("xtrabackup_suspend_at_start");
 
+  lsn_t page_tracking_start_lsn = 0;
   if (opt_page_tracking &&
       pagetracking::start(mysql_connection, &page_tracking_start_lsn)) {
     msg("xtrabackup: pagetracking is started on the server with LSN " LSN_PF

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -67,7 +67,6 @@ enum xtrabackup_compress_t {
 /* value of the --incremental option */
 extern lsn_t incremental_lsn;
 extern lsn_t incremental_start_checkpoint_lsn;
-extern lsn_t page_tracking_start_lsn;
 
 extern char *xtrabackup_target_dir;
 extern char xtrabackup_real_target_dir[FN_REFLEN];

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/validate_tracking_start_lsn.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/validate_tracking_start_lsn.sh
@@ -1,0 +1,83 @@
+############################################################################
+#PXB-2658 PXB waits for checkpoint LSN to be greater than page tracking LSN in full and incremental backup
+############################################################################
+
+. inc/common.sh
+. inc/keyring_file.sh
+
+require_debug_server
+require_debug_pxb_version
+
+start_server
+
+vlog "case#1 backup should wait till pagetracking lsn is more than checkpoint lsn"
+mysql test <<EOF
+CREATE TABLE t1(a INT) ENGINE=INNODB;
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+INSTALL COMPONENT "file://component_mysqlbackup";
+INSERT INTO t1 VALUES(100);
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup --page-tracking --debug_sync="xtrabackup_after_wait_page_tracking" 2>&1 | tee $topdir/pxb.log &
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+mysql test << EOF
+SET GLOBAL innodb_page_cleaner_disabled_debug = 0;
+SET GLOBAL innodb_log_checkpoint_now = 1;
+EOF
+
+vlog "Resuming xtrabackup full backup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+if ! grep -q ' pagetracking: Sleeping for 1 second' $topdir/pxb.log
+then
+	die "xtrabackup should print wait time for pagetracking."
+fi
+
+# run it multiple time so page tracking lsn can move
+for i in {1..10}
+do
+ load_sakila
+ drop_dbase sakila
+done
+
+mysql test << EOF
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+INSERT INTO t1 VALUES(100);
+EOF
+
+vlog "case#2 checkpoint is stopped and still incremental should complete "
+
+xtrabackup --backup --target-dir=$topdir/inc  --incremental-basedir=$topdir/backup  --page-tracking --debug_sync="xtrabackup_after_wait_page_tracking" 2>&1 | tee $topdir/pxb_inc.log &
+job_pid=$!
+
+pid_file=$topdir/inc/xtrabackup_debug_sync
+
+wait_for_xb_to_suspend $pid_file
+
+xb_pid=`cat $pid_file`
+
+mysql test << EOF
+SET GLOBAL innodb_page_cleaner_disabled_debug = 0;
+SET GLOBAL innodb_log_checkpoint_now = 1;
+EOF
+
+vlog "Resuming xtrabackup full backup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+if  grep -q ' pagetracking: Sleeping for 1 second' $topdir/pxb_inc.log
+then
+	die "xtrabackup should not print wait time for pagetracking."
+fi


### PR DESCRIPTION
PXB-2658 PXB waits for checkpoint LSN to be greater than page tracking LSN in full and incremental backup
https://jira.percona.com/browse/PXB-2658

Problem:
PXB waits for checkpoint LSN to be greater than page tracking  reset LSN in
full and incremental backup.

Fix:
Instead of checking if page tracking reset LSN is more than the
checkpoint LSN. The sufficient condition is to check if page tracking
start lsn is more than the checkpoint LSN.