### PR TITLE
PXB-2661: Improve BiDiScan Azure job to properly handle empty commits (8.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,4 +9,10 @@ jobs:
 
   - script: |
       git fetch origin 8.0
-      python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v $(git diff --name-only --relative --diff-filter AMR origin/8.0 -- . | tr '\n' ' ')
+      CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/8.0 -- . | tr '\n' ' ')
+
+      if [ -z "${CHANGED_FILES}" ]; then
+          echo --- No changed files
+      else
+          python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
+      fi


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2661

It is possible to have PR which doesn't actually change any file
(Null merge for example). Improve BiDiScan Azure job to skip
actual check in case there are not any files changed in PR.

(cherry picked from commit 3578769bc3eaba351f1f7f2da5438830017cee5b)