### PR TITLE
PXB-2662 : pxb with page-tracking crashes during prepare, cannot apply an insert redo on page

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -25,7 +25,7 @@ extern bool innodb_log_checksums_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern bool opt_lock_ddl_per_table;
-extern bool mdl_taken;
+extern bool redo_catchup_completed;
 
 extern bool use_dumped_tablespace_keys;
 

--- a/storage/innobase/xtrabackup/src/changed_page_tracking.cc
+++ b/storage/innobase/xtrabackup/src/changed_page_tracking.cc
@@ -50,7 +50,7 @@ xb_space_map *init(lsn_t checkpoint_lsn_start, MYSQL *connection)
 
   if (page_start_lsn == page_end_lsn) {
     msg("xtrabackup: pagetracking: incremental backup LSN is same as last "
-        "checkpoint LSN " LSN_PF " not calling mysql component",
+        "checkpoint LSN " LSN_PF " not calling mysql component\n",
         page_start_lsn);
     space_map = new xb_space_map;
     return space_map;

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1026,7 +1026,7 @@ bool Redo_Log_Data_Manager::start() {
    * MLOG_INDEX_LOAD event is parsed as its not safe to continue the backup
    * in any situation (with or without --lock-ddl-per-table).
    */
-  mdl_taken = true;
+  redo_catchup_completed = true;
 
   debug_sync_point("xtrabackup_pause_after_redo_catchup");
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -485,7 +485,7 @@ extern TYPELIB innodb_flush_method_typelib;
 #include "caching_sha2_passwordopt-vars.h"
 #include "sslopt-vars.h"
 
-bool mdl_taken = FALSE;
+bool redo_catchup_completed = false;
 extern struct rand_struct sql_rand;
 extern mysql_mutex_t LOCK_sql_rand;
 


### PR DESCRIPTION

    PXB-2662 : pxb crashes during prepare, cannot apply an insert redo on page
    https://jira.percona.com/browse/PXB-2662

    Background:
    -----------
    With --page-tracking enabled, incremental backups rely on pages given
    by server's page-tracking component. Another requirement is that PXB
    should copy redo logs in background

    Analysis
    --------
    There are inplace DDLs (like ADD INDEX, OPTIMIZE TABLE etc) which create
    secondary indexes using the BulkLoad (bottom-up build). These DDLs do not
    write redo-log for the secondary index changes.

    A change done in server is either retrieved via page-tracking component or via
    change in redo. But for the above DDLs, which happen after the checkpoint_lsn,
    appear only in page-tracking only at the next checkpoint.

    So for these inplace DDLs that happen after full-backup, PXB during incremental
    backup, cannot find all the changes done to tablespace using page-tracking and
    redo.

    Fix:
    ----
    Server writes a MLOG_INDEX_LOAD redo for the secondary indexes built using BulkLoad.
    So we fall-back to copying the entire IBD file if we find this redo log record.