### PR TITLE
PXB-2670 : Use new logging mechanism in xtrabackup

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -6484,8 +6484,8 @@ fil_load_status Fil_shard::ibd_open_for_recovery(space_id_t space_id,
       use_dumped_tablespace_keys) {
     err = xb_set_encryption(space);
     if (err != DB_SUCCESS) {
-      ib::error() << "Cannot find encryption key for tablespace '%s'."
-                  << space->name;
+      xb::error() << "Cannot find encryption key for tablespace "
+                  << SQUOTE(space->name);
       return (FIL_LOAD_INVALID);
     }
   }
@@ -10481,7 +10481,7 @@ bool Fil_system::open_for_recovery(space_id_t space_id) {
 
     return (true);
   } else if (status == FIL_LOAD_INVALID_ENCRYPTION_META) {
-    ib::error() << "Invalid encryption metadata in tablespace header.";
+    xb::error() << "Invalid encryption metadata in tablespace header.";
     exit(EXIT_FAILURE);
   }
 
@@ -10843,7 +10843,7 @@ byte *fil_tablespace_redo_create(byte *ptr, const byte *end,
     bool exists = Fil_path(abs_file_path).is_file_and_exists();
 
     if (!exists && !fil_space_get(page_id.space())) {
-      ib::info() << "Creating the tablespace : " << abs_file_path
+      xb::info() << "Creating the tablespace : " << abs_file_path
                  << ", space_id : " << page_id.space();
 
       dberr_t ret = fil_ibd_create(page_id.space(), tablespace_name.c_str(),
@@ -10851,7 +10851,7 @@ byte *fil_tablespace_redo_create(byte *ptr, const byte *end,
                                    FIL_IBD_FILE_INITIAL_SIZE);
 
       if (ret != DB_SUCCESS) {
-        ib::fatal(UT_LOCATION_HERE)
+        xb::fatal(UT_LOCATION_HERE)
             << "Could not create the tablespace : " << abs_file_path
             << " with space Id : " << page_id.space();
       }
@@ -10859,7 +10859,7 @@ byte *fil_tablespace_redo_create(byte *ptr, const byte *end,
       bool success = fil_system->insert(page_id.space(), abs_file_path);
 
       if (!success) {
-        ib::fatal(UT_LOCATION_HERE)
+        xb::fatal(UT_LOCATION_HERE)
             << "Could not insert the tablespace : " << abs_file_path
             << " with space Id : " << page_id.space() << " to "
             << "the list of known tablespaces";
@@ -11021,7 +11021,7 @@ byte *fil_tablespace_redo_rename(byte *ptr, const byte *end,
     success = fil_tablespace_open_for_recovery(page_id.space());
 
     if (!success) {
-      ib::info() << "Rename failed. Cannot find '" << from_name << "'!";
+      xb::info() << "Rename failed. Cannot find " << SQUOTE(from_name) << "!";
       return (ptr);
     }
 
@@ -11049,7 +11049,7 @@ byte *fil_tablespace_redo_rename(byte *ptr, const byte *end,
     success = fil_system->insert(page_id.space(), to_name);
 
     if (!success) {
-      ib::fatal(UT_LOCATION_HERE)
+      xb::fatal(UT_LOCATION_HERE)
           << "Could not insert the tablespace : " << to_name
           << " with space Id : " << page_id.space() << " to "
           << "the list of known tablespaces";
@@ -11290,7 +11290,7 @@ byte *fil_tablespace_redo_delete(byte *ptr, const byte *end,
     success = fil_tablespace_open_for_recovery(page_id.space());
 
     if (!success) {
-      ib::info(ER_IB_MSG_356) << "Delete '" << name << "' failed!";
+      xb::info(ER_IB_MSG_356) << "Delete " << SQUOTE(name) << " failed!";
       return (ptr);
     }
 
@@ -11396,7 +11396,7 @@ byte *fil_tablespace_redo_encryption(byte *ptr, const byte *end,
     if (!Encryption::decode_encryption_info(space_id, e_key, encryption_ptr,
                                             true)) {
       if (!srv_backup_mode) {
-        ib::error() << "Cannot decode encryption information in the redo log.";
+        xb::error() << "Cannot decode encryption information in the redo log.";
         exit(EXIT_FAILURE);
       }
       return (ptr + len);
@@ -11881,7 +11881,7 @@ dberr_t fil_open_for_xtrabackup(const std::string &path,
   /* by opening the tablespace we forcing node and space objects
   in the cache to be populated with fields from space header */
   if (!fil_space_open(space->id)) {
-    ib::error() << "Failed to open tablespace " << space->name;
+    xb::error() << "Failed to open tablespace " << space->name;
   }
 
   if (!srv_backup_mode || srv_close_files) {

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -689,7 +689,7 @@ dberr_t Datafile::validate_first_page(space_id_t space_id, lsn_t *flush_lsn,
         ut::free(m_encryption_iv);
         m_encryption_key = nullptr;
         m_encryption_iv = nullptr;
-        ib::info() << "Failed to decrypt table " << m_filepath << " with space"
+        xb::info() << "Failed to decrypt table " << m_filepath << " with space"
                    << " id " << m_space_id
                    << ". Will check if encrytion key has been"
                    << " parsed at the end of backup.";

--- a/storage/innobase/fsp/fsp0sysspace.cc
+++ b/storage/innobase/fsp/fsp0sysspace.cc
@@ -933,7 +933,7 @@ dberr_t SysTablespace::open_or_create(bool is_temp, bool create_new_db,
     }
 
     if (err != DB_SUCCESS) {
-      ib::error(ER_IB_MSG_312, space->name);
+      xb::error(ER_IB_MSG_312, space->name);
     }
   }
 

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -73,4 +73,5 @@ bool check_if_skip_table(
     const char *name); /*!< in: path to the table */
 
 extern bool xtrabackup_stats;
+#define SQUOTE(str) "'" << str << "'"
 #endif

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1696,10 +1696,10 @@ static byte *recv_parse_or_apply_log_rec_body(
       /* error out backup if undo truncation happens during backup */
       if (srv_backup_mode && fsp_is_undo_tablespace(space_id) &&
           backup_redo_log_flushed_lsn < recv_sys->recovered_lsn) {
-        ib::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
+        xb::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
                    << " undo_delete lsn " << recv_sys->recovered_lsn;
 
-        ib::error(ER_IB_MSG_716)
+        xb::error(ER_IB_MSG_716)
             << "An undo ddl truncation (could be automatic)"
             << " operation has been"
             << " performed. \n"
@@ -1762,17 +1762,17 @@ static byte *recv_parse_or_apply_log_rec_body(
       if (!recv_recovery_on) {
         if (redo_catchup_completed) {
           if (backup_redo_log_flushed_lsn < recv_sys->recovered_lsn) {
-            ib::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
+            xb::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
                        << " load_index lsn " << recv_sys->recovered_lsn;
 
             if (backup_redo_log_flushed_lsn == 0) {
-              ib::error(ER_IB_MSG_715) << "PXB was not able"
+              xb::error(ER_IB_MSG_715) << "PXB was not able"
                                        << " to determine the"
                                        << " InnoDB Engine"
                                        << " Status";
             }
 
-            ib::error(ER_IB_MSG_716) << "An optimized (without"
+            xb::error(ER_IB_MSG_716) << "An optimized (without"
                                      << " redo logging) DDL"
                                      << " operation has been"
                                      << " performed. All modified"
@@ -1806,10 +1806,10 @@ static byte *recv_parse_or_apply_log_rec_body(
             index_load_map[space_id] = true;
           }
           /* offline backup */
-          ib::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
+          xb::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
                      << " load_index lsn " << recv_sys->recovered_lsn;
 
-          ib::warn(ER_IB_MSG_717);
+          xb::warn(ER_IB_MSG_717);
         }
       }
 #endif /* UNIV_HOTBACKUP || XTRABACKUP */
@@ -1846,7 +1846,7 @@ static byte *recv_parse_or_apply_log_rec_body(
             ptr_copy += Encryption::MAGIC_SIZE;
             uint type = mach_read_from_1(ptr_copy);
             if (type != Encryption::CRYPT_SCHEME_UNENCRYPTED) {
-              ib::error(ER_IB_MSG_716)
+              xb::error(ER_IB_MSG_716)
                   << "Can't take backup of tablespace encrypted with KEYRING "
                   << "encryption";
               exit(EXIT_FAILURE);

--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2832,7 +2832,7 @@ bool log_read_encryption() {
       fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
       err = xb_set_encryption(space);
       if (err != DB_SUCCESS) {
-        ib::error() << "Cannot find encryption key for redo log.";
+        xb::error() << "Cannot find encryption key for redo log.";
         return (false);
       }
       return (true);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1107,7 +1107,7 @@ static dberr_t srv_undo_tablespaces_open(bool backup_mode) {
 
         err = srv_undo_tablespace_open_by_id(space_id);
         if (err != DB_SUCCESS) {
-          ib::error(ER_IB_MSG_CANNOT_OPEN_57_UNDO, ulong{space_id});
+          xb::error(ER_IB_MSG_CANNOT_OPEN_57_UNDO, ulong{space_id});
           return (err);
         }
       }
@@ -2607,7 +2607,7 @@ files_checked:
       // Missing tablespaces in the redo log are a valid possibility
       // with partial backups.
       // But keep them in the output for visibility
-      ib::warn(ER_IB_MSG_1139);
+      xb::warn(ER_IB_MSG_1139);
     }
 
     /* We have successfully recovered from the redo log. The

--- a/storage/innobase/xtrabackup/src/common.h
+++ b/storage/innobase/xtrabackup/src/common.h
@@ -26,13 +26,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql_version.h>
 #include <stdarg.h>
 
-#define xb_a(expr)                                                \
-  do {                                                            \
-    if (!(expr)) {                                                \
-      msg("Assertion \"%s\" failed at %s:%lu\n", #expr, __FILE__, \
-          (ulong)__LINE__);                                       \
-      abort();                                                    \
-    }                                                             \
+#define xb_a(expr)                                                            \
+  do {                                                                        \
+    if (!(expr)) {                                                            \
+      fprintf(stderr, "Assertion \"%s\" failed at %s:%lu\n", #expr, __FILE__, \
+              (ulong)__LINE__);                                               \
+      abort();                                                                \
+    }                                                                         \
   } while (0);
 
 #ifdef XB_DEBUG
@@ -42,42 +42,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #endif
 
 #define XB_DELTA_INFO_SUFFIX ".meta"
-
-static inline int msg(const char *fmt, ...)
-    __attribute__((format(printf, 1, 2)));
-static inline int msg(const char *fmt, ...) {
-  int result;
-  va_list args;
-
-  va_start(args, fmt);
-  result = vfprintf(stderr, fmt, args);
-  va_end(args);
-
-  return result;
-}
-
-static inline int msg_ts(const char *fmt, ...)
-    __attribute__((format(printf, 1, 2)));
-static inline int msg_ts(const char *fmt, ...) {
-  int result;
-  time_t t = time(NULL);
-  char date[100];
-  char *line;
-  va_list args;
-
-  strftime(date, sizeof(date), "%y%m%d %H:%M:%S", localtime(&t));
-
-  va_start(args, fmt);
-  result = vasprintf(&line, fmt, args);
-  va_end(args);
-
-  if (result != -1) {
-    result = fprintf(stderr, "%s %s", date, line);
-    free(line);
-  }
-
-  return result;
-}
 
   /* Use POSIX_FADV_NORMAL when available */
 

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -32,6 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "ds_stdout.h"
 #include "ds_tmpfile.h"
 #include "ds_xbstream.h"
+#include "msg.h"
 
 /************************************************************************
 Create a datasink of the specified type */

--- a/storage/innobase/xtrabackup/src/ds_buffer.cc
+++ b/storage/innobase/xtrabackup/src/ds_buffer.cc
@@ -29,6 +29,7 @@ exception for the last write for a file. */
 #include <mysql_version.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 
 #define DS_DEFAULT_BUFFER_SIZE (64 * 1024)
 

--- a/storage/innobase/xtrabackup/src/ds_compress.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress.cc
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <zlib.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 #include "thread_pool.h"
 
 #define COMPRESS_CHUNK_SIZE ((size_t)(xtrabackup_compress_chunk_size))

--- a/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql_version.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 #include "my_xxhash.h"
 #include "thread_pool.h"
 

--- a/storage/innobase/xtrabackup/src/ds_decompress.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress.cc
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <zlib.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 #include "thread_pool.h"
 
 /* Possible states of input data parsing. There are quite a few different

--- a/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 #include "datasink.h"
 #include "ds_istream.h"
+#include "msg.h"
 #include "my_xxhash.h"
 #include "thread_pool.h"
 

--- a/storage/innobase/xtrabackup/src/ds_decrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_decrypt.cc
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "crc_glue.h"
 #include "datasink.h"
 #include "ds_istream.h"
+#include "msg.h"
 #include "thread_pool.h"
 #include "xbcrypt.h"
 #include "xbcrypt_common.h"

--- a/storage/innobase/xtrabackup/src/ds_encrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_encrypt.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql/service_mysql_alloc.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 #include "thread_pool.h"
 #include "xbcrypt.h"
 #include "xbcrypt_common.h"

--- a/storage/innobase/xtrabackup/src/ds_tmpfile.cc
+++ b/storage/innobase/xtrabackup/src/ds_tmpfile.cc
@@ -29,6 +29,7 @@ datasink in a serialized way in deinit(). */
 #include <mysql/service_mysql_alloc.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 
 typedef struct {
   pthread_mutex_t mutex;

--- a/storage/innobase/xtrabackup/src/ds_xbstream.cc
+++ b/storage/innobase/xtrabackup/src/ds_xbstream.cc
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql_version.h>
 #include "common.h"
 #include "datasink.h"
+#include "msg.h"
 #include "xbstream.h"
 
 typedef struct {

--- a/storage/innobase/xtrabackup/src/file_utils.cc
+++ b/storage/innobase/xtrabackup/src/file_utils.cc
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "msg.h"
 #include "my_io.h"
 
 #if defined _WIN32 || defined __CYGWIN__ || defined __EMX__ || \

--- a/storage/innobase/xtrabackup/src/keyring_components.cc
+++ b/storage/innobase/xtrabackup/src/keyring_components.cc
@@ -61,17 +61,17 @@ bool inititialize_service_handles() {
 
   reg_srv = mysql_plugin_registry_acquire();
   if (reg_srv == nullptr) {
-    msg("xtrabackup: mysql_plugin_registry_acquire failed\n");
+    xb::error() << "mysql_plugin_registry_acquire failed";
     return false;
   }
 
   /* Add module specific initialization here */
   if (innobase::encryption::init_keyring_services(reg_srv) == false) {
-    msg("xtrabackup: init_keyring_services failed\n");
+    xb::error() << "init_keyring_services failed";
     cleanup();
     return false;
   }
-  msg("xtrabackup: inititialize_service_handles suceeded\n");
+  xb::info() << "inititialize_service_handles suceeded";
   service_handler_initialized = true;
   return true;
 }
@@ -230,8 +230,8 @@ bool keyring_init_offline() {
   component_name = "file://component_keyring_file";
   if (!component_file_config.valid()) {
     if (opt_component_keyring_file_config != nullptr) {
-      msg("xtrabackup: Error: Component configuration file is not readable or "
-          "not found.\n");
+      xb::error() << "Component configuration file is not readable or "
+                     "not found.";
       return false;
     }
 
@@ -245,21 +245,22 @@ bool keyring_init_offline() {
   }
 
   if (xtrabackup_stats) {
-    msg_ts("xtrabackup: Encryption is not supported with --stats");
+    xb::error() << "Encryption is not supported with --stats";
     return false;
   }
   if (config.length() == 0) {
-    msg("xtrabackup: Error: Component configuration file is empty.\n");
+    xb::error() << "Component configuration file is empty.";
     return false;
   }
 
   rapidjson::Document config_json;
   config_json.Parse(config);
   if (config_json.HasParseError()) {
-    msg("xtrabackup: Error: Component configuration file is not a valid "
-        "JSON.\n");
+    xb::error() << "Component configuration file is not a valid "
+                << "JSON.";
     return false;
   }
+
   component_config_data_sb.Clear();
   rapidjson::Writer<rapidjson::StringBuffer> string_writer(
       component_config_data_sb);

--- a/storage/innobase/xtrabackup/src/msg.h
+++ b/storage/innobase/xtrabackup/src/msg.h
@@ -1,0 +1,64 @@
+/******************************************************
+Copyright (c) 2022 Percona LLC and/or its affiliates.
+
+Common declarations for XtraBackup.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#ifndef XB_MSG_H
+#define XB_MSG_H
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+
+static inline int msg(const char *fmt, ...)
+    __attribute__((format(printf, 1, 2)));
+static inline int msg(const char *fmt, ...) {
+  int result;
+  va_list args;
+
+  va_start(args, fmt);
+  result = vfprintf(stderr, fmt, args);
+  va_end(args);
+
+  return result;
+}
+
+static inline int msg_ts(const char *fmt, ...)
+    __attribute__((format(printf, 1, 2)));
+static inline int msg_ts(const char *fmt, ...) {
+  int result;
+  time_t t = time(NULL);
+  char date[100];
+  char *line;
+  va_list args;
+
+  strftime(date, sizeof(date), "%y%m%d %H:%M:%S", localtime(&t));
+
+  va_start(args, fmt);
+  result = vasprintf(&line, fmt, args);
+  va_end(args);
+
+  if (result != -1) {
+    result = fprintf(stderr, "%s %s", date, line);
+    free(line);
+  }
+
+  return result;
+}
+#endif

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "backup_mysql.h"
 #include "common.h"
 #include "os0event.h"
+#include "sql_thd_internal_api.h"
 #include "xb0xb.h"
 #include "xtrabackup.h"
 
@@ -49,7 +50,7 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
   auto err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
 
   if (err != DB_SUCCESS) {
-    msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+    xb::error() << "recv_find_max_checkpoint() failed.";
     return (false);
   }
 
@@ -67,14 +68,14 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
                  LOG_FILE_HDR_SIZE, log_hdr_buf, nullptr);
 
     if (err != DB_SUCCESS) {
-      msg("xtrabackup: Error: fil_io() failed.\n");
+      xb::error() << "fil_io() failed.";
       return (false);
     }
 
     err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
 
     if (err != DB_SUCCESS) {
-      msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+      xb::error() << "recv_find_max_checkpoint() failed.";
       return (false);
     }
 
@@ -102,7 +103,7 @@ bool Redo_Log_Reader::validate_redo_log_file() {
   auto err = recv_find_max_checkpoint(*log_sys, &max_cp_field);
 
   if (err != DB_SUCCESS) {
-    msg("xtrabackup: Error: recv_find_max_checkpoint() failed.\n");
+    xb::error() << "recv_find_max_checkpoint() failed.";
     return (false);
   }
   return (true);
@@ -188,7 +189,7 @@ ssize_t Redo_Log_Reader::read_logfile(bool is_last, bool *finished) {
                       &scanned_lsn, log_scanned_lsn, finished);
 
     if (size < 0) {
-      msg("xtrabackup: Error: read_logfile() failed.\n");
+      xb::error() << "read_logfile() failed.";
       return (-1);
     }
 
@@ -230,34 +231,30 @@ ssize_t Redo_Log_Reader::scan_log_recs(byte *buf, bool is_last, lsn_t start_lsn,
         break;
       }
 
-      msg("xtrabackup: error: log block numbers mismatch:\n"
-          "xtrabackup: error: expected log block no. %lu,"
-          " but got no. %lu from the log file.\n",
-          static_cast<ulong>(scanned_no), static_cast<ulong>(no));
+      xb::error() << "log block numbers mismatch:";
+      xb::error() << "expected log block no. " << scanned_no << ", but got no. "
+                  << no << " from the log file.";
 
       if ((no - scanned_no) % blocks_in_group == 0) {
-        msg("xtrabackup: error:"
-            " it looks like InnoDB log has wrapped"
-            " around before xtrabackup could"
-            " process all records due to either"
-            " log copying being too slow, or "
-            " log files being too small.\n");
+        xb::error() << " it looks like InnoDB log has wrapped"
+                       " around before xtrabackup could"
+                       " process all records due to either"
+                       " log copying being too slow, or "
+                       " log files being too small.";
       }
 
       return (-1);
 
     } else if (!checksum_is_ok) {
       /* Garbage or an incompletely written log block */
-      msg("xtrabackup: warning: Log block checksum mismatch"
-          " (block no %lu at lsn " LSN_PF
-          "): \n"
-          "expected %lu, calculated checksum %lu\n",
-          static_cast<ulong>(no), scanned_lsn,
-          static_cast<ulong>(log_block_get_checksum(log_block)),
-          static_cast<ulong>(log_block_calc_checksum(log_block)));
-      msg("xtrabackup: warning: this is possible when the "
-          "log block has not been fully written by the "
-          "server, will retry later.\n");
+      xb::warn() << "Log block checksum mismatch (block no " << no << " at lsn "
+                 << scanned_lsn << "): expected "
+                 << log_block_get_checksum(log_block)
+                 << ", calculated checksum "
+                 << log_block_calc_checksum(log_block);
+      xb::warn() << "this is possible when the "
+                    "log block has not been fully written by the "
+                    "server, will retry later.";
       *finished = true;
       break;
     }
@@ -336,8 +333,8 @@ bool Redo_Log_Parser::parse_log(const byte *buf, size_t len, lsn_t start_lsn,
       recv_sys->parse_start_lsn =
           scanned_lsn + log_block_get_first_rec_group(log_block);
 
-      msg("Starting to parse redo log at lsn = " LSN_PF "\n",
-          recv_sys->parse_start_lsn);
+      xb::info() << "Starting to parse redo log at lsn = "
+                 << recv_sys->parse_start_lsn;
 
       if (recv_sys->parse_start_lsn < recv_sys->checkpoint_lsn) {
         /* We start to parse log records even before
@@ -435,8 +432,8 @@ bool Redo_Log_Writer::create_logfile(const char *name) {
   log_file = ds_open(ds_redo, XB_LOG_FILENAME, &stat_info);
 
   if (log_file == NULL) {
-    msg("xtrabackup: error: failed to open the target stream for '%s'.\n",
-        XB_LOG_FILENAME);
+    xb::error() << "failed to open the target stream for "
+                << SQUOTE(XB_LOG_FILENAME);
     return (false);
   }
 
@@ -452,7 +449,7 @@ bool Redo_Log_Writer::write_header(byte *hdr) {
                        (LOG_HEADER_CREATOR + creator_size));
 
   if (ds_write(log_file, hdr, LOG_FILE_HDR_SIZE)) {
-    msg("xtrabackup: error: write to logfile failed\n");
+    xb::error() << "write to logfile failed";
     return (false);
   }
 
@@ -461,7 +458,7 @@ bool Redo_Log_Writer::write_header(byte *hdr) {
 
 bool Redo_Log_Writer::close_logfile() {
   if (ds_close(log_file) != 0) {
-    msg("xtrabackup: error: failed to close logfile\n");
+    xb::error() << "failed to close logfile";
     return (false);
   }
   return (true);
@@ -482,7 +479,7 @@ bool Redo_Log_Writer::write_buffer(byte *buf, size_t len) {
   }
 
   if (ds_write(log_file, write_buf, len)) {
-    msg("xtrabackup: Error: write to logfile failed\n");
+    xb::error() << "write to logfile failed";
     return (false);
   }
 
@@ -628,15 +625,13 @@ void Archived_Redo_Log_Monitor::skip_for_block(lsn_t lsn,
       if (redo_block_no == arch_block_no &&
           (redo_block_checksum == arch_block_checksum ||
            redo_block_len != arch_block_len)) {
-        msg("xtrabackup: Archived redo log has caught up\n");
+        xb::info() << "Archived redo log has caught up";
         reader.set_start_lsn(lsn - bytes_read);
         return;
       }
     }
     if (finished) {
-      msg_ts(
-          "xtrabackup: Finished reading archive, did not find a matching "
-          "block\n");
+      xb::info() << "Finished reading archive, did not find a matching block";
       return;
     }
   }
@@ -686,7 +681,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
   read_mysql_variables(mysql, "SHOW VARIABLES", vars, true);
 
   if (redo_log_archive_dirs == nullptr || *redo_log_archive_dirs == 0) {
-    msg("xtrabackup: Redo Log Archiving is not set up.\n");
+    xb::info() << "Redo Log Archiving is not set up.";
     free_mysql_variables(vars);
     mysql_close(mysql);
     my_thread_end();
@@ -696,7 +691,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
   parse_archive_dirs(redo_log_archive_dirs);
 
   if (archived_dirs.empty()) {
-    msg("xtrabackup: Redo Log Archiving is not set up.\n");
+    xb::info() << "Redo Log Archiving is not set up.";
     free_mysql_variables(vars);
     mysql_close(mysql);
     my_thread_end();
@@ -742,7 +737,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
   auto res = xb_mysql_query(mysql, start_query.c_str(), true, false);
 
   if (res == nullptr) {
-    msg("xtrabackup: Redo Log Archiving is not used.\n");
+    xb::info() << "Redo Log Archiving is not used.";
     mysql_close(mysql);
     my_thread_end();
     return;
@@ -750,14 +745,14 @@ void Archived_Redo_Log_Monitor::thread_func() {
 
   mysql_free_result(res);
 
-  msg("xtrabackup: Waiting for archive file '%s'\n", archive.filename.c_str());
+  xb::info() << "Waiting for archive file " << SQUOTE(archive.filename.c_str());
 
   /* wait for archive file to appear */
   while (!stopped) {
     bool exists;
     os_file_type_t type;
     if (!os_file_status(archive.filename.c_str(), &exists, &type)) {
-      msg("xtrabackup: cannot stat file '%s'\n", archive.filename.c_str());
+      xb::error() << "cannot stat file " << SQUOTE(archive.filename.c_str());
       break;
     }
     if (exists) {
@@ -771,7 +766,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
   if (!stopped) {
     file = my_open(archive.filename.c_str(), O_RDONLY, MYF(MY_WME));
     if (file < 0) {
-      msg("xtrabackup: error: cannot open '%s'\n", archive.filename.c_str());
+      xb::error() << "cannot open " << SQUOTE(archive.filename.c_str());
       mysql_close(mysql);
       my_thread_end();
       return;
@@ -784,7 +779,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
     while (hdr_len > 0 && !stopped) {
       size_t n_read = my_read(file, buf, hdr_len, MYF(MY_WME));
       if (n_read == MY_FILE_ERROR) {
-        msg("xtrabackup: cannot read from '%s'\n", archive.filename.c_str());
+        xb::error() << "cannot read from " << SQUOTE(archive.filename.c_str());
         mysql_close(mysql);
         my_thread_end();
         return;
@@ -804,7 +799,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
       while (hdr_len > 0 && !stopped) {
         size_t n_read = my_read(file, buf2, hdr_len, MYF(MY_WME));
         if (n_read == MY_FILE_ERROR) {
-          msg("xtrabackup: cannot read from '%s'\n", archive.filename.c_str());
+          xb::error() << "cannot read from " << archive.filename.c_str();
           mysql_close(mysql);
           my_thread_end();
           return;
@@ -819,7 +814,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
       while (hdr_len > 0 && !stopped) {
         size_t n_read = my_read(file, buf, hdr_len, MYF(MY_WME));
         if (n_read == MY_FILE_ERROR) {
-          msg("xtrabackup: cannot read from '%s'\n", archive.filename.c_str());
+          xb::error() << "cannot read from " << archive.filename.c_str();
           mysql_close(mysql);
           my_thread_end();
           return;
@@ -847,10 +842,9 @@ void Archived_Redo_Log_Monitor::thread_func() {
   }
 
   if (ready && !stopped) {
-    msg("xtrabackup: Redo Log Archive '%s' found. First log block is "
-        "%lu, checksum is %lu.\n",
-        archive.filename.c_str(), static_cast<ulong>(first_log_block_no),
-        static_cast<ulong>(first_log_block_checksum));
+    xb::info() << "Redo Log Archive " << SQUOTE(archive.filename.c_str())
+               << " found. First log block is " << first_log_block_no
+               << ", checksum is " << first_log_block_checksum;
     reader.set_fd(file);
   }
 
@@ -891,7 +885,7 @@ static dberr_t open_or_create_log_file(bool *log_file_created, ulint i,
   pfs_os_file_t file = os_file_create(0, name, OS_FILE_OPEN, OS_FILE_NORMAL,
                                       OS_LOG_FILE, true, &ret);
   if (!ret) {
-    msg("xtrabackup: error in opening %s\n", name);
+    xb::error() << "error in opening " << name;
 
     return (DB_ERROR);
   }
@@ -899,9 +893,9 @@ static dberr_t open_or_create_log_file(bool *log_file_created, ulint i,
   size = os_file_get_size(file);
 
   if (size != srv_log_file_size) {
-    msg("xtrabackup: Error: log file %s is of different size " UINT64PF
-        " bytes than specified in the .cnf file %llu bytes!\n",
-        name, size, srv_log_file_size * UNIV_PAGE_SIZE);
+    xb::error() << "log file " << name << " is of different size " << size
+                << " bytes than specified in the .cnf file "
+                << srv_log_file_size * UNIV_PAGE_SIZE << " bytes!";
 
     return (DB_ERROR);
   }
@@ -960,14 +954,13 @@ bool Redo_Log_Data_Manager::init() {
       log_opened = true;
     }
     if ((log_opened && log_created)) {
-      msg("xtrabackup: Error: all log files must be created at the same time.\n"
-          "xtrabackup: All log files must be created also in database "
-          "creation.\n"
-          "xtrabackup: If you want bigger or smaller log files, shut down the\n"
-          "xtrabackup: database and make sure there were no errors in "
-          "shutdown.\n"
-          "xtrabackup: Then delete the existing log files. Edit the .cnf file\n"
-          "xtrabackup: and start the database again.\n");
+      xb::error() << "all log files must be created at the same time.";
+      xb::error() << "All log files must be created also in database "
+                     "creation.";
+      xb::error() << "If you want bigger or smaller log files, shut down the"
+                     "database and make sure there were no errors in shutdown.";
+      xb::error() << "Then delete the existing log files. Edit the .cnf file"
+                     "and start the database again.";
 
       return (false);
     }
@@ -975,7 +968,7 @@ bool Redo_Log_Data_Manager::init() {
 
   /* log_file_created must not be TRUE, if online */
   if (log_file_created) {
-    msg("xtrabackup: Something wrong with source files...\n");
+    xb::error() << "Something wrong with source files...";
     exit(EXIT_FAILURE);
   }
 
@@ -1059,9 +1052,8 @@ void Redo_Log_Data_Manager::track_archived_log(lsn_t start_lsn, const byte *buf,
       auto checksum = log_block_get_checksum(ptr);
       if (no == archived_log_monitor.get_first_log_block_no() &&
           checksum == archived_log_monitor.get_first_log_block_checksum()) {
-        msg("xtrabackup: Switched to archived redo log starting with "
-            "LSN: " LSN_PF "\n",
-            start_lsn);
+        xb::info() << "Switched to archived redo log starting with LSN: "
+                   << start_lsn;
         archived_log_monitor.get_reader().set_start_lsn(start_lsn);
         archived_log_state = ARCHIVED_LOG_MATCHED;
       }
@@ -1131,6 +1123,8 @@ bool Redo_Log_Data_Manager::copy_once(bool is_last, bool *finished) {
 
 void Redo_Log_Data_Manager::copy_func() {
   my_thread_init();
+  /* create THD to get thread number in the error log */
+  THD *thd = create_thd(false, false, true, 0, 0);
 
   aborted = false;
 
@@ -1144,7 +1138,7 @@ void Redo_Log_Data_Manager::copy_func() {
     }
 
     if (finished) {
-      msg_ts(">> log scanned up to (" LSN_PF ")\n", reader.get_scanned_lsn());
+      xb::info() << ">> log scanned up to (" << reader.get_scanned_lsn() << ")";
 
       debug_sync_point("xtrabackup_copy_logfile_pause");
 
@@ -1157,6 +1151,7 @@ void Redo_Log_Data_Manager::copy_func() {
     error = true;
   }
 
+  destroy_thd(thd);
   my_thread_end();
 }
 
@@ -1189,9 +1184,9 @@ Redo_Log_Data_Manager::~Redo_Log_Data_Manager() { os_event_destroy(event); }
 
 bool Redo_Log_Data_Manager::stop_at(lsn_t lsn, lsn_t checkpoint_lsn) {
   last_checkpoint_lsn = checkpoint_lsn;
-  msg("xtrabackup: The latest check point (for incremental): '" LSN_PF "'\n",
-      last_checkpoint_lsn);
-  msg("xtrabackup: Stopping log copying thread at LSN " LSN_PF ".\n", lsn);
+  xb::info() << "The latest check point (for incremental): "
+             << SQUOTE(last_checkpoint_lsn);
+  xb::info() << "Stopping log copying thread at LSN " << lsn;
 
   stop_lsn = lsn;
   os_event_set(event);
@@ -1207,9 +1202,9 @@ bool Redo_Log_Data_Manager::stop_at(lsn_t lsn, lsn_t checkpoint_lsn) {
   scanned_lsn = reader.get_scanned_lsn();
 
   if (last_checkpoint_lsn > scanned_lsn) {
-    msg("xtrabackup: error: last checkpoint LSN (" LSN_PF
-        ") is larger than last copied LSN (" LSN_PF ").\n",
-        last_checkpoint_lsn, scanned_lsn);
+    xb::error() << "last checkpoint LSN (" << last_checkpoint_lsn
+                << ") is larger than last copied LSN (" << scanned_lsn << ").";
+
     return (false);
   }
 

--- a/storage/innobase/xtrabackup/src/space_map.cc
+++ b/storage/innobase/xtrabackup/src/space_map.cc
@@ -211,7 +211,7 @@ bool Tablespace_map::serialize(ds_ctxt_t *ds) const {
   const char *path = XBTS_FILE_NAME;
   ds_file_t *stream = ds_open(ds, path, &mystat);
   if (stream == NULL) {
-    msg("xtrabackup: Error: cannot open output stream for %s\n", path);
+    xb::error() << "cannot open output stream for " << path;
     return (false);
   }
 
@@ -267,7 +267,7 @@ bool Tablespace_map::deserialize(const std::string &dir) {
   std::ifstream f(path);
 
   if (f.fail()) {
-    msg("xtrabackup: Error: cannot open file '%s'\n", path.c_str());
+    xb::error() << "cannot open file " << SQUOTE(path.c_str());
     return (false);
   }
 
@@ -276,7 +276,7 @@ bool Tablespace_map::deserialize(const std::string &dir) {
   Document doc;
   doc.ParseStream(wrapper);
   if (doc.HasParseError()) {
-    msg("xtrabackup: JSON parse error in file '%s'\n", path.c_str());
+    xb::error() << "JSON parse error in file " << SQUOTE(path.c_str());
     return (false);
   }
 
@@ -284,9 +284,9 @@ bool Tablespace_map::deserialize(const std::string &dir) {
 
   int version = root["version"].GetInt();
   if (version > XBTS_FILE_VERSION) {
-    msg("xtrabackup: Error: wrong '%s' file version %d, maximum version"
-        "supported is %d",
-        XBTS_FILE_NAME, version, XBTS_FILE_VERSION);
+    xb::error() << "wrong " << SQUOTE(XBTS_FILE_NAME) << " file version "
+                << version << ", maximum version supported is "
+                << XBTS_FILE_VERSION;
     return (false);
   }
 

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysqld.h>
 
 #include "common.h"
+#include "msg.h"
 #include "xtrabackup.h"
 
 namespace xtrabackup {

--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 #include "dict0dict.h"
 #include "fil_cur.h"
+#include "msg.h"
 #include "xtrabackup.h"
 
 /************************************************************************

--- a/storage/innobase/xtrabackup/src/wsrep.cc
+++ b/storage/innobase/xtrabackup/src/wsrep.cc
@@ -178,21 +178,18 @@ void xb_write_galera_info(bool incremental_prepare)
 
   fp = fopen(XB_GALERA_INFO_FILENAME, "w");
   if (fp == NULL) {
-    msg("xtrabackup: error: "
-        "could not create " XB_GALERA_INFO_FILENAME ", errno = %d\n",
-        errno);
+    xb::error() << "could not create " << XB_GALERA_INFO_FILENAME
+                << ", errno = " << errno;
     exit(EXIT_FAILURE);
   }
 
   seqno = wsrep_xid_seqno(&xid);
 
-  msg("xtrabackup: Recovered WSREP position: %s:%lld\n", uuid_str,
-      (long long)seqno);
+  xb::info() << "Recovered WSREP position: " << uuid_str << ":" << seqno;
 
   if (fprintf(fp, "%s:%lld", uuid_str, (long long)seqno) < 0) {
-    msg("xtrabackup: error: "
-        "could not write to " XB_GALERA_INFO_FILENAME ", errno = %d\n",
-        errno);
+    xb::error() << "could not write to " << XB_GALERA_INFO_FILENAME
+                << ", errno = " << errno;
     exit(EXIT_FAILURE);
   }
 

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -32,6 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <iostream>
 
 #include "common.h"
+#include "msg.h"
 
 namespace xbcloud {
 

--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <iostream>
 #include "azure.h"
 #include "common.h"
+#include "msg.h"
 #include "s3.h"
 #include "swift.h"
 

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_sys.h>
 
 #include "common.h"
+#include "msg.h"
 
 #define AWS_DATE_HEADER "X-Amz-Date"
 #define AWS_CONTENT_SHA256_HEADER "X-Amz-Content-SHA256"

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -32,6 +32,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <rapidjson/writer.h>
 
 #include "common.h"
+#include "msg.h"
 
 namespace xbcloud {
 

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -42,6 +42,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include "crc_glue.h"
 
+#include "msg.h"
 #include "xbcloud/azure.h"
 #include "xbcloud/s3.h"
 #include "xbcloud/swift.h"

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "datasink.h"
 #include "ds_decrypt.h"
 #include "ds_encrypt.h"
+#include "msg.h"
 #include "xbcrypt_common.h"
 #include "xtrabackup_version.h"
 

--- a/storage/innobase/xtrabackup/src/xbcrypt_common.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt_common.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_thread_local.h>
 #include <mysql/service_mysql_alloc.h>
 #include "common.h"
+#include "msg.h"
 #include "xbcrypt.h"
 
 /* Encryption options */

--- a/storage/innobase/xtrabackup/src/xbcrypt_read.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt_read.cc
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_byteorder.h>
 #include <mysql/service_mysql_alloc.h>
 #include "crc_glue.h"
+#include "msg.h"
 #include "xbcrypt.h"
 
 struct xb_rcrypt_struct {

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "ds_decompress_lz4.h"
 #include "ds_decrypt.h"
 #include "file_utils.h"
+#include "msg.h"
 #include "template_utils.h"
 #include "xbcrypt_common.h"
 #include "xtrabackup_version.h"

--- a/storage/innobase/xtrabackup/src/xbstream_read.cc
+++ b/storage/innobase/xtrabackup/src/xbstream_read.cc
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <zlib.h>
 #include "common.h"
 #include "crc_glue.h"
+#include "msg.h"
 #include "xbstream.h"
 
 /* Allocate 1 MB for the payload buffer initially */

--- a/storage/innobase/xtrabackup/src/xbstream_write.cc
+++ b/storage/innobase/xtrabackup/src/xbstream_write.cc
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "common.h"
 #include "crc_glue.h"
 #include "datasink.h"
+#include "msg.h"
 #include "xbstream.h"
 
 /* Group writes smaller than this into a single chunk */

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -848,9 +848,9 @@ function grep_count()
 ####################################################
 function check_full_scan_inc_backup()
 {
-    local xb_performed_full_scan_inc_backup="xtrabackup: using the full scan for incremental backup"
-    local xb_performed_bitmap_backup="xtrabackup: using the changed page bitmap"
-    local xb_performed_pagetracking_inc_backup="xtrabackup: using the pagetracking"
+    local xb_performed_full_scan_inc_backup="using the full scan for incremental backup"
+    local xb_performed_bitmap_backup="using the changed page bitmap"
+    local xb_performed_pagetracking_inc_backup="using the pagetracking"
 
     if ! grep -q "$xb_performed_full_scan_inc_backup" $OUTFILE ;
     then
@@ -871,9 +871,9 @@ function check_full_scan_inc_backup()
 
 function check_bitmap_inc_backup()
 {
-    local xb_performed_full_scan_inc_backup="xtrabackup: using the full scan for incremental backup"
-    local xb_performed_bitmap_backup="xtrabackup: using the changed page bitmap"
-    local xb_performed_pagetracking_inc_backup="xtrabackup: using the pagetracking"
+    local xb_performed_full_scan_inc_backup="using the full scan for incremental backup"
+    local xb_performed_bitmap_backup="using the changed page bitmap"
+    local xb_performed_pagetracking_inc_backup="using the pagetracking"
 
     if ! grep -q "$xb_performed_bitmap_backup" $OUTFILE ;
     then
@@ -894,9 +894,9 @@ function check_bitmap_inc_backup()
 
 function check_pagetracking_inc_backup()
 {
-    local xb_performed_full_scan_inc_backup="xtrabackup: using the full scan for incremental backup"
-    local xb_performed_bitmap_backup="xtrabackup: using the changed page bitmap"
-    local xb_performed_pagetracking_inc_backup="xtrabackup: Using pagetracking feature for incremental backup"
+    local xb_performed_full_scan_inc_backup="using the full scan for incremental backup"
+    local xb_performed_bitmap_backup="using the changed page bitmap"
+    local xb_performed_pagetracking_inc_backup="Using pagetracking feature for incremental backup"
 
     if ! grep -q "$xb_performed_pagetracking_inc_backup" $OUTFILE ;
     then

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -1437,16 +1437,3 @@ function grep_general_log()
 
 # To avoid unbound variable error when no server have been started
 SRV_MYSQLD_IDS=
-
-
-# Adjust pxb plugin dir:
-if test -d $PWD/../../../../plugin_output_directory
-then
-  plugin_dir=$PWD/../../../../plugin_output_directory
-else
-  plugin_dir=$PWD/../../lib/plugin/
-fi
-
-XB_EXTRA_MY_CNF_OPTS="${XB_EXTRA_MY_CNF_OPTS:-""}
-xtrabackup-plugin-dir=${plugin_dir}
-"

--- a/storage/innobase/xtrabackup/test/inc/keyring_file.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_file.sh
@@ -10,8 +10,17 @@ if [ -z ${KEYRING_TYPE+x} ]; then
   KEYRING_TYPE="plugin"
 fi
 
+if test -d $PWD/../../../../plugin_output_directory
+then
+  plugin_dir=$PWD/../../../../plugin_output_directory
+else
+  plugin_dir=$PWD/../../lib/plugin/
+fi
 keyring_file=${TEST_VAR_ROOT}/keyring_file
 keyring_args="--keyring-file-data=${keyring_file}"
+XB_EXTRA_MY_CNF_OPTS="${XB_EXTRA_MY_CNF_OPTS:-""}
+xtrabackup-plugin-dir=${plugin_dir}
+"
 
 if [[ "${KEYRING_TYPE}" = "plugin" ]] || [[ "${KEYRING_TYPE}" = "both" ]]; then
   plugin_load=keyring_file.so

--- a/storage/innobase/xtrabackup/test/inc/keyring_vault.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_vault.sh
@@ -5,12 +5,22 @@
 . inc/common.sh
 
 plugin_load=keyring_vault.so
+if test -d $PWD/../../../../plugin_output_directory
+then
+  plugin_dir=$PWD/../../../../plugin_output_directory
+else
+  plugin_dir=$PWD/../../lib/plugin/
+fi
 keyring_vault_config=${TEST_VAR_ROOT}/keyring_vault_config
 keyring_args="--keyring-vault-config=${keyring_vault_config}"
 
 MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS:-""}
 early-plugin-load=${plugin_load}
 keyring-vault-config=${keyring_vault_config}
+"
+
+XB_EXTRA_MY_CNF_OPTS="${XB_EXTRA_MY_CNF_OPTS:-""}
+xtrabackup-plugin-dir=${plugin_dir}
 "
 
 VAULT_URL="${VAULT_URL:-https://vault.public-ci.percona.com:8200}"

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_file_component.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_file_component.sh
@@ -23,7 +23,7 @@ EOF
 
 xtrabackup --backup --target-dir=$topdir/backup1 \
 --component-keyring-file-config=${MYSQLD_DATADIR}/component_keyring_file.cnf 2>&1 | tee $topdir/pxb.log
-grep_count "xtrabackup: Warning: \-\-component-keyring-file-config will be ignored for \-\-backup operation" $topdir/pxb.log 1
+grep_count "\-\-component-keyring-file-config will be ignored for \-\-backup operation" $topdir/pxb.log 1
 
 cp -r $topdir/backup1 $topdir/backup2
 record_db_state test

--- a/storage/innobase/xtrabackup/test/t/bug1222062.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1222062.sh
@@ -8,4 +8,4 @@ mkdir $topdir/backup
 
 xtrabackup --backup --close-files --target-dir=$topdir/backup
 
-grep "xtrabackup: warning: close-files specified" $OUTFILE
+grep "close-files specified" $OUTFILE

--- a/storage/innobase/xtrabackup/test/t/bug1533542.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1533542.sh
@@ -13,4 +13,4 @@ vlog "Starting backup"
 run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup tmp-dir
 
 # Should failed with error
-grep -q "xtrabackup: Error: unknown argument: 'tmp-dir'" $OUTFILE
+grep -q "unknown argument: 'tmp-dir'" $OUTFILE

--- a/storage/innobase/xtrabackup/test/t/bug1566228.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1566228.sh
@@ -11,4 +11,4 @@ xtrabackup --prepare --target-dir=$topdir/backup
 run_cmd_expect_failure ${XB_BIN} --defaults-file= --defaults-group=mysqld.2 \
 	  --no-version-check --move-back --force-non-empty-directories \
 	  --target-dir=$topdir/backup 2>&1 | \
-	  grep "Error: datadir must be specified"
+	  grep "datadir must be specified"

--- a/storage/innobase/xtrabackup/test/t/bug1691093.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1691093.sh
@@ -25,4 +25,4 @@ xtrabackup --prepare --apply-log-only \
     --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta \
     2>&1 | tee $topdir/pxb.log
 
-run_cmd grep 'xtrabackup: warning.*--throttle' $topdir/pxb.log
+run_cmd grep '.*--throttle' $topdir/pxb.log

--- a/storage/innobase/xtrabackup/test/t/bug1706582.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1706582.sh
@@ -8,5 +8,5 @@ vlog "Full backup"
 
 run_cmd_expect_failure xtrabackup --backup --lock-ddl --lock-ddl-per-table \
     --target-dir=$topdir/data/full  2>&1 | \
-        grep "Error: --lock-ddl and --lock-ddl-per-table are mutually exclusive"
+        grep "\-\-lock-ddl and --lock-ddl-per-table are mutually exclusive"
 

--- a/storage/innobase/xtrabackup/test/t/bug369913.sh
+++ b/storage/innobase/xtrabackup/test/t/bug369913.sh
@@ -6,5 +6,5 @@ start_server
 
 xtrabackup --backup --target-dir=$topdir/backup
 
-grep -q "xtrabackup: Generating a list of tablespaces" $OUTFILE \
+grep -q "Generating a list of tablespaces" $OUTFILE \
     || die "Could not find \"Generating a list of tablespaces\" message"

--- a/storage/innobase/xtrabackup/test/t/bug606981.sh
+++ b/storage/innobase/xtrabackup/test/t/bug606981.sh
@@ -20,7 +20,7 @@ xtrabackup --backup --stream=xbstream --target-dir=$topdir/backup > $topdir/back
 stop_server
 
 # See if xtrabackup was using O_DIRECT
-if ! grep -q "xtrabackup: using O_DIRECT" $OUTFILE ;
+if ! grep -q "using O_DIRECT" $OUTFILE ;
 then
   vlog "xtrabackup was not using O_DIRECT for the input file."
   exit -1

--- a/storage/innobase/xtrabackup/test/t/parallel_copyback.sh
+++ b/storage/innobase/xtrabackup/test/t/parallel_copyback.sh
@@ -14,7 +14,7 @@ xtrabackup --prepare --target-dir=$topdir/backup
 xtrabackup --copy-back --parallel=10 --target-dir=$topdir/backup \
 	2>&1 | tee $topdir/pxb.log
 
-run_cmd grep -q "xtrabackup: Starting 10 threads for parallel data files transfer" $topdir/pxb.log
+run_cmd grep -q "Starting 10 threads for parallel data files transfer" $topdir/pxb.log
 threads_count=$(grep -Eo '\[[0-9]+\] Copying' $topdir/pxb.log | sort | uniq | wc -l)
 vlog "Involved threads count: $threads_count"
 if [ $threads_count -eq 1 ]

--- a/storage/innobase/xtrabackup/test/t/pxb-1493.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1493.sh
@@ -26,7 +26,7 @@ if [ -z "$err" ] ; then
     die "xtrabackup did not report error (--myvariable)"
 fi
 
-err=$(${XB_BIN} ${XB_ARGS} --skip-strict --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "WARNING: unknown option")
+err=$(${XB_BIN} ${XB_ARGS} --skip-strict --backup --skip-myoption --target-dir=$topdir/backup 2>&1 | grep "unknown option")
 if [ -z "$err" ] ; then
     die "xtrabackup did not report warning (--myoption)"
 fi

--- a/storage/innobase/xtrabackup/test/t/pxb-1862.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1862.sh
@@ -23,4 +23,4 @@ xtrabackup --prepare --incremental-dir=$topdir/inc --target-dir=$topdir/backup
 run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --prepare --incremental-dir=$topdir/inc \
 		       --target-dir=$topdir/backup1
 
-grep -q "xtrabackup: error: xtrabackup_logfile was already used to '--prepare'" $OUTFILE || die "error message not found!"
+grep -q "xtrabackup_logfile was already used to '--prepare'" $OUTFILE || die "error message not found!"


### PR DESCRIPTION
PXB-2670 : Use new logging mechanism in xtrabackup

https://jira.percona.com/browse/PXB-2670

Problems:
---------
1. Inconsistent logging of messages with timestamps.
   Error messages logged using msg_ts() log timestamps,
   using msg() doesn't log timestamp

2. Some messages are logged with a timestamp but don't have xtrabackup prefix

3. Error or Info messages from InnoDB modules are logged
   without any prefix

4. Some messages from xtrabackup source files are logged
   without any prefixes

5. Some messages from server modules are logged in UTC timestamp
   and are inconsistent with PXB timestamp logging. PXB uses
   local timezone

6. Developer has to use the right format specifiers (%s, %d, %u, %lu, %llu)
   etc in msg() functions. Not very convenient.

Fix:
----
1. For PXB sources

Introduce c++ style formatting messages. ie using
<< operator and avoid printf specifier

Introduced xb::info(), xb::warn(), xb::error(), xb::fatal()
and xb::fatal_or_error()

msg() should be only used with xbcrypt, xbstream. This is
because they are not linked to MySQL server logging modules

2. Allow logging of messages from InnoDB modules that use
   ib::info(), ib::warn(), ib::error(), ib::fatal() etc

3. Log all messages from LogEvent() framework in local
   timezone (opt_log_timestamps=1)

4. Other minor fixes, for example "Done.." doesn't tell the
   file copying/moving that is completed. We now log 
   "Done: Copying/Moving file <filename>..."