### PR TITLE
Fixed PXB-2673 - Rocksdb backup fails

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -58,6 +58,10 @@ struct log_status_t {
   lsn_t lsn_checkpoint;
   std::vector<replication_channel_status_t> channels;
   std::vector<rocksdb_wal_t> rocksdb_wal_files;
+  void clear() {
+    channels.clear();
+    rocksdb_wal_files.clear();
+  }
 };
 
 struct mysql_variable {
@@ -132,7 +136,6 @@ class Myrocks_checkpoint {
 };
 
 struct Backup_context {
-  log_status_t log_status;
   Myrocks_checkpoint myrocks_checkpoint;
   std::unordered_set<std::string> rocksdb_files;
 };
@@ -192,10 +195,10 @@ void unlock_all(MYSQL *connection);
 
 bool write_current_binlog_file(MYSQL *connection);
 
-/** Read binary log position and InnoDB LSN from p_s.log_status.
+/** Read binary log position, InnoDB LSN and other storage engine information
+from p_s.log_status and update global log_status variable.
 @param[in]   conn         mysql connection handle */
-const log_status_t &log_status_get(MYSQL *conn);
-
+void log_status_get(MYSQL *conn);
 
 /*********************************************************************/ /**
  Retrieves MySQL binlog position and
@@ -259,4 +262,5 @@ void dump_innodb_buffer_pool(MYSQL *connection);
 
 void check_dump_innodb_buffer_pool(MYSQL *connection);
 
+extern log_status_t log_status;
 #endif

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -59,6 +59,11 @@ struct log_status_t {
   std::vector<replication_channel_status_t> channels;
   std::vector<rocksdb_wal_t> rocksdb_wal_files;
   void clear() {
+    filename = "";
+    position = 0;
+    gtid_executed = "";
+    lsn = 0;
+    lsn_checkpoint = 0;
     channels.clear();
     rocksdb_wal_files.clear();
   }

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4341,8 +4341,7 @@ void xtrabackup_backup_func(void) {
     std::this_thread::sleep_for(std::chrono::seconds(opt_debug_sleep_before_unlock));
   }
 
-  if (!redo_mgr.stop_at(backup_ctxt.log_status.lsn,
-                        backup_ctxt.log_status.lsn_checkpoint)) {
+  if (!redo_mgr.stop_at(log_status.lsn, log_status.lsn_checkpoint)) {
     exit(EXIT_FAILURE);
   }
   if (redo_mgr.is_error()) {

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/log_status.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/log_status.sh
@@ -1,0 +1,29 @@
+#
+# PXB-2673 - Rocksdb backup fails if log_status_get is called more than one.
+#
+
+require_rocksdb
+require_debug_pxb_version
+
+start_server
+init_rocksdb
+
+mysql -e "INSTALL COMPONENT \"file://component_mysqlbackup\""
+mysql -e "CREATE TABLE t_logstatus (a INT AUTO_INCREMENT PRIMARY KEY) ENGINE=ROCKSDB" test
+mysql -e "INSERT INTO t_logstatus (a) VALUES (1), (2), (3)" test
+
+function insert_row()
+{
+  (while true ; do
+    echo "INSERT INTO t_logstatus () VALUES ();"
+    sleep 1;
+  done) | mysql test
+}
+
+insert_row &
+INSERT_PID=$!
+
+full_backup_dir=$topdir/full_backup
+xtrabackup --backup --page-tracking  --debug=d,page_tracking_checkpoint_behind --target-dir=$full_backup_dir
+
+kill -SIGKILL ${INSERT_PID}


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2673

Problem:
After the introduction of Page tracking component, PXB might require to
query log_status table more than once in case InnoDB has not passed page
tracking start checkpoint.
Inside backup_mysql module, we have a global variable log_status, which
is defined by the struct log_status_t. This struct currently has two
vectors, one for replication channels and one for rocksdb files. When
parsing log_status rows for those two members, we use push_back method,
which causes the the data to be appended instead of replaced.
As a result, PXB was trying to copy the same file more than once making
the backup to fail.
Modules backup_copy and backup_mysql where both instantiating a variable
with the same name (log_status), which was a bit confusing.

Fix:
Removed log_status variable from backup_copy to make the code easier to
read, as this is redundant to context.log_status.
Added a clear method to log_status_t to remove entries from both
vectors. This new method is called before adding more data to log_status
global variable.