### PR TITLE
Fixed PXB-2649 - compilation issues on gcc 10

### DIFF
--- a/cmake/build_configurations/compiler_options.cmake
+++ b/cmake/build_configurations/compiler_options.cmake
@@ -43,7 +43,10 @@ IF(UNIX)
 
   # Default GCC flags
   IF(CMAKE_COMPILER_IS_GNUCC)
-    SET(COMMON_C_FLAGS "-fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_C_FLAGS "-fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0) # gcc-9 or older
+      STRING(APPEND COMMON_C_FLAGS " -fabi-version=2")
+    ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       STRING_PREPEND(COMMON_C_FLAGS "-fno-inline ")
@@ -68,7 +71,10 @@ IF(UNIX)
     ENDIF()
   ENDIF()
   IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET(COMMON_CXX_FLAGS               "-fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_CXX_FLAGS               "-fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)  # gcc-9 or older
+      STRING(APPEND COMMON_CXX_FLAGS " -fabi-version=2")
+    ENDIF()
     # GCC 6 has C++14 as default, set it explicitly to the old default.
     EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GXX_VERSION)

--- a/storage/innobase/xtrabackup/src/ds_tmpfile.c
+++ b/storage/innobase/xtrabackup/src/ds_tmpfile.c
@@ -55,7 +55,7 @@ datasink_t datasink_tmpfile = {
 	&tmpfile_deinit
 };
 
-MY_TMPDIR mysql_tmpdir_list;
+MY_TMPDIR mysql_tmpdir_list_t;
 
 static ds_ctxt_t *
 tmpfile_init(const char *root)
@@ -93,7 +93,7 @@ tmpfile_open(ds_ctxt_t *ctxt, const char *path,
 
 	/* Create a temporary file in tmpdir. The file will be automatically
 	removed on close. Code copied from mysql_tmpfile(). */
-	fd = create_temp_file(tmp_path, my_tmpdir(&mysql_tmpdir_list),
+	fd = create_temp_file(tmp_path, my_tmpdir(&mysql_tmpdir_list_t),
 			      "xbtemp",
 #ifdef __WIN__
 			      O_BINARY | O_TRUNC | O_SEQUENTIAL |

--- a/storage/innobase/xtrabackup/src/xbstream.c
+++ b/storage/innobase/xtrabackup/src/xbstream.c
@@ -58,7 +58,6 @@ datasink_t datasink_xbstream;
 datasink_t datasink_compress;
 datasink_t datasink_tmpfile;
 datasink_t datasink_encrypt;
-datasink_t datasink_buffer;
 
 static run_mode_t	opt_mode;
 static char *		opt_directory = NULL;


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2649

Issue 1:

In file included from /usr/include/c++/10/memory:83,
                 from /work/pxb/src/2.4/storage/innobase/xtrabackup/src/xbcloud/http.h:29,
                 from /work/pxb/src/2.4/storage/innobase/xtrabackup/src/xbcloud/http.cc:21:
/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘constexpr std::unique_ptr<_Tp, _Dp>::unique_ptr() [with _Del = std::default_delete<xbcloud::S3_signer>; <template-parameter-2-2> = void; _Tp = xbcloud::S3_signer; _Dp = std::default_delete<xbcloud::S3_signer>]’:
/work/pxb/src/2.4/storage/innobase/xtrabackup/src/xbcloud/s3.h:177:32:   required from here
/usr/include/c++/10/bits/unique_ptr.h:270:9: error: no matching function for call to ‘std::__uniq_ptr_data<xbcloud::S3_signer, std::default_delete<xbcloud::S3_signer>, true, true>::__uniq_ptr_data()’
  270 |  : _M_t()
      |         ^
/usr/include/c++/10/bits/unique_ptr.h:210:40: note: candidate: ‘std::__uniq_ptr_data<xbcloud::S3_signer, std::default_delete<xbcloud::S3_signer>, true, true>::__uniq_ptr_data(std::__uniq_ptr_impl<xbcloud::S3_signer, std::default_delete<xbcloud::S3_signer> >::pointer) [inherited from std::__uniq_ptr_impl<xbcloud::S3_signer, std::default_delete<xbcloud::S3_signer> >]’
  210 |       using __uniq_ptr_impl<_Tp, _Dp>::__uniq_ptr_impl;
      |                                        ^~~~~~~~~~~~~~~

Fix:
Adjusted cmake/build_configurations/compiler_options.cmake to remove
fabi-version if gcc version higher than 9.

Issue 2:
/usr/bin/ld: CMakeFiles/xbstream.dir/xbstream.c.o:/work/pxb/src/2.4/storage/innobase/xtrabackup/src/xbstream.c:61: multiple definition of `datasink_buffer'; CMakeFiles/xbstream.dir/ds_buffer.c.o:(.data.rel.local+0x0): first defined here

Fix:
Removed duplicate declaration.

Issue 3:
/usr/bin/ld: ../../../../archive_output_directory/libmysqld.a(lib_sql.cc.o):(.bss+0x2940): multiple definition of `mysql_tmpdir_list'; CMakeFiles/xtrabackup.dir/ds_tmpfile.c.o:/work/pxb/src/2.4/storage/innobase/xtrabackup/src/ds_tmpfile.c:58: first defined here

Fix:
Renamed mysql_tmpdir_list.