### PR TITLE
PXB-2697: Apple build fix

### DIFF
--- a/components/keyrings/keyring_file/CMakeLists.txt
+++ b/components/keyrings/keyring_file/CMakeLists.txt
@@ -90,3 +90,8 @@ MYSQL_ADD_COMPONENT(keyring_file
   LINK_LIBRARIES ${KEYRING_FILE_LIBRARIES}
   MODULE_ONLY
 )
+IF(APPLE)
+  SET_TARGET_PROPERTIES(component_keyring_file PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup")
+ENDIF()
+

--- a/components/keyrings/keyring_kmip/CMakeLists.txt
+++ b/components/keyrings/keyring_kmip/CMakeLists.txt
@@ -83,3 +83,8 @@ MYSQL_ADD_COMPONENT(keyring_kmip
   LINK_LIBRARIES ${KEYRING_KMIP_LIBRARIES}
   MODULE_ONLY
 )
+IF(APPLE)
+  SET_TARGET_PROPERTIES(component_keyring_kmip PROPERTIES
+    LINK_FLAGS "-undefined dynamic_lookup")
+ENDIF()
+


### PR DESCRIPTION
Issue: undefined symbols aren't allowed on OSX modules by default.

Fix: instruct the linker to allow it.
(cherry picked from commit 37d503b35cb579b638bebbd42987082aa645ad6d)