### PR TITLE
PXB-2702: skip undo tablespace fixup during backup

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1121,10 +1121,12 @@ static dberr_t srv_undo_tablespaces_open(bool backup_mode) {
   for (space_id_t num = 1; num <= FSP_MAX_UNDO_TABLESPACES; ++num) {
     /* Check if this undo tablespace was in the process of being truncated.
     If so, recreate it and add it to the construction list. */
-    dberr_t err = srv_undo_tablespace_fixup_num(num);
-    if (err != DB_SUCCESS) {
-      undo::spaces->x_unlock();
-      return (err);
+    if (!backup_mode) {
+      dberr_t err = srv_undo_tablespace_fixup_num(num);
+      if (err != DB_SUCCESS) {
+        undo::spaces->x_unlock();
+        return (err);
+      }
     }
 
     err = srv_undo_tablespace_open_by_num(num);


### PR DESCRIPTION
Possible fix for: https://jira.percona.com/browse/PXB-2702

Reason: backup tool should not change tablespace files under any circumstances.