### PR TITLE
Fixed PXB-1676 (Redo log size in error message is incorrect)

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -895,7 +895,7 @@ static dberr_t open_or_create_log_file(bool *log_file_created, ulint i,
   if (size != srv_log_file_size) {
     xb::error() << "log file " << name << " is of different size " << size
                 << " bytes than specified in the .cnf file "
-                << srv_log_file_size * UNIV_PAGE_SIZE << " bytes!";
+                << srv_log_file_size << " bytes!";
 
     return (DB_ERROR);
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-1676

Problem:
Message displaying missmatch on redo log size is incorrectly calculating
redo log size. Variable srv_log_file_size already containg the log size
in bytes and not in pages, meaning we don't need to multiply by
UNIV_PAGE_SIZE.

Fix:
Adjusted message to show srv_log_file_size bytes.