### PR TITLE
Fix CMake error installing manpages

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -25,55 +25,11 @@ FILE(GLOB MAN1 *.1)
 FILE(GLOB MAN1_NDB ndb*.1)
 FILE(GLOB MAN8 *.8)
 FILE(GLOB MAN8_NDB ndb*.8)
+
 IF(MAN1_NDB AND NOT WITH_NDBCLUSTER)
   LIST(REMOVE_ITEM MAN1 ${MAN1_NDB})
 ENDIF()
-
-SET(MAN1_NDB
-  ndb_blob_tool.1
-  ndb_config.1
-  ndb_cpcd.1
-  ndb_delete_all.1
-  ndb_desc.1
-  ndb_drop_index.1
-  ndb_drop_table.1
-  ndb_error_reporter.1
-  ndb_import.1
-  ndb_index_stat.1
-  ndb_mgm.1
-  ndb_move_data.1
-  ndb_perror.1
-  ndb_print_backup_file.1
-  ndb_print_file.1
-  ndb_print_frag_file.1
-  ndb_print_schema_file.1
-  ndb_print_sys_file.1
-  ndb_redo_log_reader.1
-  ndb_restore.1
-  ndb_select_all.1
-  ndb_select_count.1
-  ndb_show_tables.1
-  ndb_size.pl.1
-  ndb_top.1
-  ndb_waiter.1
-  ndbinfo_select_all.1
-)
-SET(MAN1_ROUTER
-  mysqlrouter.1
-  mysqlrouter_passwd.1
-  mysqlrouter_plugin_info.1
-)
-SET(MAN8
-  mysqld.8
-  )
-SET(MAN8_NDB
-  ndb_mgmd.8
-  ndbd.8
-  ndbmtd.8
-)
-
 INSTALL(FILES ${MAN1} DESTINATION ${INSTALL_MANDIR}/man1 COMPONENT ManPages)
-INSTALL(FILES ${MAN8} DESTINATION ${INSTALL_MANDIR}/man8 COMPONENT ManPages)
 
 IF(MAN8_NDB AND NOT WITH_NDBCLUSTER)
   LIST(REMOVE_ITEM MAN8 ${MAN8_NDB})


### PR DESCRIPTION
This effectively reapplies c27e9fb56b5445a8c942b94e33e9cbb484a429f3, which was partially lost in a merge conflict in 8.0.26.

Without this fix, I get the following error:

```
  CMake Error at man/cmake_install.cmake:41 (file):
    file INSTALL cannot find
    "/tmp/percona-xtrabackup-20220222-15656-rwr5bc/percona-xtrabackup-8.0.27-19/man/mysqld.8":
    No such file or directory.
  Call Stack (most recent call first):
    cmake_install.cmake:90 (include)
```