### PR TITLE
Fixed PXB 2714 Memory leak on keyring component.

### DIFF
--- a/components/keyrings/common/data/global_default_mr.h
+++ b/components/keyrings/common/data/global_default_mr.h
@@ -19,7 +19,7 @@
 
 inline ::boost::container::pmr::memory_resource
     * ::boost::container::pmr::get_default_resource() BOOST_NOEXCEPT {
-  psi_memory_resource *global_default_mr = new psi_memory_resource{};
+  static psi_memory_resource *global_default_mr = new psi_memory_resource{};
   return global_default_mr;
 }
 

--- a/components/libminchassis/dynamic_loader_scheme_file.cc
+++ b/components/libminchassis/dynamic_loader_scheme_file.cc
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #include <mysql/components/services/mysql_runtime_error_service.h>
 #include <mysql/components/services/mysql_rwlock.h>
 #include <mysqld_error.h>
-
+#include "my_config.h"
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -215,7 +215,12 @@ DEFINE_BOOL_METHOD(mysql_dynamic_loader_scheme_file_imp::unload,
     mysql_unload_plugin(it->first.c_str());
 
     /* Close library and delete entry from libraries list. */
+#if !defined(HAVE_VALGRIND) && !defined(HAVE_ASAN)
+    /*
+     * Avoid closing components under ASAN / Valgrind in order to get
+     * meaningfull leak report */
     dlclose(it->second);
+#endif
     object_files_list.erase(it);
     return false;
   } catch (...) {

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -622,7 +622,12 @@ static inline void free_plugin_mem(st_plugin_dl *p) {
     PSI_SYSTEM_CALL(unload_plugin)
     (std::string(p->dl.str, p->dl.length).c_str());
 #endif
+#if !defined(HAVE_VALGRIND) && !defined(HAVE_ASAN)
+    /*
+     * Avoid closing components under ASAN / Valgrind in order to get
+     * meaningfull leak report */
     dlclose(p->handle);
+#endif
   }
   my_free(p->dl.str);
   if (p->version != MYSQL_PLUGIN_INTERFACE_VERSION) my_free(p->plugins);

--- a/storage/innobase/xtrabackup/test/asan.supp
+++ b/storage/innobase/xtrabackup/test/asan.supp
@@ -1,0 +1,2 @@
+# Placeholder file to list suppression on ASAN.
+#leak:regexp

--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -330,6 +330,21 @@ XTRABACKUP_BASEDIR
     export PERCONA_VERSION_CHECK_URL=https://stage-v.percona.com
 }
 
+########################################################################
+# Configura ASAN suppress list
+########################################################################
+function config_asan()
+{
+  IS_ASAN=$(ldd $XB_BIN | grep asan | wc -l)
+  if [[ $IS_ASAN != 0 ]];
+  then
+    LSAN_OPTIONS=suppressions=${PWD}/asan.supp
+    export LSAN_OPTIONS
+    echo "This is ASAN build"
+  fi
+}
+
+
 # Configure mysql to read local component files if created by test cases.
 function config_local_components()
 {
@@ -938,6 +953,8 @@ then
     echo "get_version_info failed. See $OUTFILE for details."
     exit -1
 fi
+
+config_asan
 
 if is_server_version_higher_than 8.0.23
 then


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2714

get_default_mr in keyring_common created a new instance of the default
memory resource every time the funciton was called instead of using a
single static instance.

This commit fixes this by making it a static variable.

Cherry-pick from percona/percona-server@da96718

Added the ability to add ASAN suppressions on PXB MTR
Adjusted plugin and component code to not close dynamic linked libraries
otherwise ASAN report will no be able to display symbols.