### PR TITLE
8.0 Fixed PXB-2711 - Libgcrypt initialization warnings for xtrabackup

### DIFF
--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -29,6 +29,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "backup_mysql.h"
 #include "common.h"
 #include "kdf.h"
+#include "xbcrypt_common.h"
 
 #include <map>
 
@@ -559,6 +560,7 @@ xb_tablespace_keys_load_one(const char *dir, const char *transition_key,
 		transition_key_len = ENCRYPTION_KEY_LEN;
 	}
 
+	xb_libgcrypt_init();
 	ret = xb_derive_key(transition_key, transition_key_len,
 			salt, sizeof(salt), sizeof(derived_key), derived_key);
 
@@ -741,6 +743,7 @@ xb_tablespace_keys_dump(ds_ctxt_t *ds_ctxt, const char *transition_key,
 		transition_key_len = ENCRYPTION_KEY_LEN;
 	}
 
+	xb_libgcrypt_init();
 	bool ret = xb_derive_key(transition_key, transition_key_len,
 			salt, sizeof(salt), sizeof(derived_key), derived_key);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2711

Libgcrypt initialization warnings for xtrabackup

Problem:
Version of libgcrypt used on centos7 requires proper Libgcrypt
initialization, otherwise warnings will be issued at syslog.
We currently use centos7 for tarballs and relink linked libraries to
copies we provide unde lib/private.
This causes the warning to appear on centos7 and all OS's using the
tarball.

Fix:
Properly initiate libgcrypt before derive keys.
