### PR TITLE
Fixed PXB-2717 - skip kmip test with no kmip server is up

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/keyring_kmip.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_kmip.sh
@@ -51,3 +51,9 @@ function cleanup_keyring()
 {
   echo "place holder" > /dev/null
 }
+
+function ping_kmip()
+{
+  echo test | socat - TCP4:${KMIP_SERVER_ADDR}:${KMIP_SERVER_PORT} || \
+  return 1
+}

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_kmip_component.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_kmip_component.sh
@@ -1,12 +1,13 @@
 #
 # Component keyring file specific variables
 #
+. inc/keyring_common.sh
+. inc/keyring_kmip.sh
+ping_kmip || skip_test "Keyring kmip requires KMIP Server configured"
 is_xtradb || skip_test "Keyring kmip requires Percona Server"
 require_server_version_higher_than 8.0.26
 
 KEYRING_TYPE="component"
-. inc/keyring_common.sh
-. inc/keyring_kmip.sh
 configure_server_with_component
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2717

Problem:
Current KMIP tests only validate if we are running on PS, however, we
are not validating if a KMIP server is up and running.
Doing it properly is hard as it will require external clients to be
compiled/installed on docker images.

Fix:
Added a ping method that at least validate that we can stablish a TCP
connection to ${KMIP_SERVER_ADDR}:${KMIP_SERVER_PORT}.