### PR TITLE
Implemented PXB-1818 - Provide a new flag to improve performance by a…

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2013,7 +2013,11 @@ ulonglong buf_pool_adjust_chunk_unit(ulonglong size) {
 
 /** Resize the buffer pool based on srv_buf_pool_size from
 srv_buf_pool_old_size. */
-static void buf_pool_resize() {
+#ifndef XTRABACKUP
+static
+#endif
+    void
+    buf_pool_resize() {
   buf_pool_t *buf_pool;
   ulint new_instance_size;
   bool warning = false;
@@ -2043,7 +2047,10 @@ static void buf_pool_resize() {
     ut_ad(UT_LIST_GET_LEN(buf_pool->withdraw) == 0);
 
     buf_flush_list_mutex_enter(buf_pool);
+#ifndef XTRABACKUP
     ut_ad(buf_pool->flush_rbt == nullptr);
+#endif
+
     buf_flush_list_mutex_exit(buf_pool);
 #endif
 

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -4617,9 +4617,9 @@ void dict_close(void) {
   therefore we don't delete the individual elements. */
   hash_table_free(dict_sys->table_id_hash);
 
-#ifndef UNIV_HOTBACKUP
+#if !defined(UNIV_HOTBACKUP) && !defined(XTRABACKUP)
   dict_ind_free();
-#endif /* !UNIV_HOTBACKUP */
+#endif /* !UNIV_HOTBACKUP && !XTRABACKUP */
 
   dict_sys_mutex_exit();
   dict_sys_mutex_free();

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -2581,4 +2581,7 @@ inline const page_zip_des_t *buf_block_get_page_zip(
 }
 #include "buf0buf.ic"
 
+#ifdef XTRABACKUP
+void buf_pool_resize();
+#endif
 #endif /* !buf0buf_h */

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -84,7 +84,6 @@ namespace xtrabackup {
 namespace utils {
 unsigned long free_memory();
 unsigned long total_memory();
-uint free_memory_pct();
 }  // namespace utils
 }  // namespace xtrabackup
 #endif

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -34,6 +34,8 @@ extern bool use_dumped_tablespace_keys;
 
 extern std::vector<ulint> invalid_encrypted_tablespace_ids;
 
+extern uint xtrabackup_use_free_memory_pct;
+extern bool xtrabackup_use_free_memory_pct_set;
 /** Fetch tablespace key from "xtrabackup_keys".
 @param[in]	space_id	tablespace id
 @param[out]	key		fetched tablespace key
@@ -77,4 +79,12 @@ bool check_if_skip_table(
 
 extern bool xtrabackup_stats;
 #define SQUOTE(str) "'" << str << "'"
+
+namespace xtrabackup {
+namespace utils {
+unsigned long free_memory();
+unsigned long total_memory();
+uint free_memory_pct();
+}  // namespace utils
+}  // namespace xtrabackup
 #endif

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -129,6 +129,12 @@ TARGET_LINK_LIBRARIES(xtrabackup
   crc
   )
 
+IF(NOT APPLE)
+  TARGET_LINK_LIBRARIES(xtrabackup
+    procps
+    )
+ENDIF()
+
  # We depend on protobuf because of the mysqlx plugin and replication.
  IF(UNIX_INSTALL_RPATH_ORIGIN_PRIV_LIBDIR)
    ADD_INSTALL_RPATH_FOR_PROTOBUF(xtrabackup)

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -124,11 +124,9 @@ unsigned long free_memory() {
 }
 
 unsigned long total_memory() {
-  unsigned long free_mem = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
-  return free_mem;
+  unsigned long total_mem = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+  return total_mem;
 }
-
-uint free_memory_pct() { return 0; }
 
 #else
 unsigned long free_memory() {
@@ -139,13 +137,6 @@ unsigned long free_memory() {
 unsigned long total_memory() {
   meminfo();
   return kb_main_total * 1024;
-}
-
-uint free_memory_pct() {
-  unsigned long free = free_memory();
-  unsigned long total = total_memory();
-
-  return (uint)(free * 100 / total);
 }
 #endif
 }  // namespace utils

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -159,6 +159,9 @@ bool xtrabackup_export = FALSE;
 bool xtrabackup_apply_log_only = FALSE;
 
 longlong xtrabackup_use_memory = 100 * 1024 * 1024L;
+uint xtrabackup_use_free_memory_pct = 50;
+bool xtrabackup_use_free_memory_pct_set = false;
+
 bool xtrabackup_create_ib_logfile = FALSE;
 
 long xtrabackup_throttle = 0; /* 0:unlimited */
@@ -567,6 +570,7 @@ enum options_xtrabackup {
   OPT_XTRA_APPLY_LOG_ONLY,
   OPT_XTRA_PRINT_PARAM,
   OPT_XTRA_USE_MEMORY,
+  OPT_XTRA_USE_FREE_MEMORY_PCT,
   OPT_XTRA_THROTTLE,
   OPT_XTRA_LOG_COPY_INTERVAL,
   OPT_XTRA_INCREMENTAL,
@@ -759,6 +763,13 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_use_memory, (G_PTR *)&xtrabackup_use_memory, 0,
      GET_LL, REQUIRED_ARG, 100 * 1024 * 1024L, 1024 * 1024L, LLONG_MAX, 0,
      1024 * 1024L, 0},
+    {"use-free-memory-pct", OPT_XTRA_USE_FREE_MEMORY_PCT,
+     "This option specifies the percentage of free memory to be used by"
+     " buffer pool at --prepare stage (default is 50%). ",
+     (G_PTR *)&xtrabackup_use_free_memory_pct,
+     (G_PTR *)&xtrabackup_use_free_memory_pct, 0, GET_UINT, REQUIRED_ARG, 50, 0,
+     100, 0, 1, 0},
+
     {"throttle", OPT_XTRA_THROTTLE,
      "limit count of IO operations (pairs of read&write) per second to IOS "
      "values (for '--backup')",
@@ -1842,6 +1853,9 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
       break;
     case OPT_XTRA_ENCRYPT_KEY:
       hide_option(argument, &xtrabackup_encrypt_key);
+      break;
+    case OPT_XTRA_USE_FREE_MEMORY_PCT:
+      xtrabackup_use_free_memory_pct_set = true;
       break;
 
 #include "sslopt-case.h"

--- a/storage/innobase/xtrabackup/test/t/pxb-1818_use_free_memory_at_prepare.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1818_use_free_memory_at_prepare.sh
@@ -1,0 +1,138 @@
+#
+# PXB-1818 - use free memory at prepare
+#
+require_debug_sync
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb-log-file-size=250M
+innodb-flush-log-at-trx-commit=0
+"
+start_server
+
+mkdir $topdir/backup
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.pxb_1818 (ID INT PRIMARY KEY AUTO_INCREMENT, name char(255));"
+
+function insert_data()
+{
+  while true;
+  do
+    $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.pxb_1818 VALUES (NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),
+    (NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a'),(NULL, 'a');"
+  done
+}
+
+insert_data &
+insert_pid=$!
+
+insert_data &
+insert_pid2=$!
+
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="data_copy_thread_func" &
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+start_lsn=`innodb_lsn`
+current_lsn=`innodb_lsn`
+
+#wait to have more than 130Mb of records
+vlog "waiting to have 130Mb of redo log"
+i=0
+while [ $(($current_lsn - $start_lsn)) -lt "136314880" ] ; do
+  if ((i % 10 == 0)); then
+    vlog "Current Redo log size: $(($current_lsn - $start_lsn)) bytes"
+  fi
+  sleep 1
+  current_lsn=`innodb_lsn`
+  ((i=i+1))
+done
+
+kill -SIGKILL ${insert_pid} ${insert_pid2}
+record_db_state test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+cp -R ${topdir}/backup ${topdir}/backup2
+
+
+vlog "Test #1 not setting use-free-memory-pct"
+xtrabackup --prepare --target-dir=$topdir/backup
+
+if grep -q "Increasing the buffer pool to" $OUTFILE ;
+then
+    vlog "xtrabackup did resized BP at --prepare."
+    exit -1
+fi
+
+if grep -q "Not increasing Buffer Pool as it will exceed" $OUTFILE ;
+then
+    vlog "xtrabackup sould not have attempted to increase buffer pool."
+    exit -1
+fi
+
+stop_server
+rm -rf $mysql_datadir
+xtrabackup --move-back --target-dir=$topdir/backup
+start_server
+
+verify_db_state test
+
+rm -rf $topdir/backup
+cp -R ${topdir}/backup2 ${topdir}/backup
+
+vlog "Test #2 resize buffer pool"
+xtrabackup --prepare --target-dir=$topdir/backup --use-free-memory-pct=100
+
+if ! grep -q "Increasing the buffer pool to" $OUTFILE ;
+then
+    vlog "xtrabackup did not resized BP at --prepare."
+    exit -1
+fi
+stop_server
+rm -rf $mysql_datadir
+xtrabackup --move-back --target-dir=$topdir/backup
+start_server
+
+verify_db_state test
+
+
+vlog "Test #3 do not resize buffer pool"
+xtrabackup --prepare --target-dir=$topdir/backup2 --use-free-memory-pct=0
+
+if ! grep -q "Not increasing Buffer Pool as it will exceed 0% of free memory" $OUTFILE ;
+then
+    vlog "xtrabackup sould have failed to increase buffer pool."
+    exit -1
+fi
+
+stop_server
+rm -rf $mysql_datadir
+xtrabackup --move-back --target-dir=$topdir/backup2
+start_server
+
+verify_db_state test


### PR DESCRIPTION
…uto-tuning the value for --use-memory

https://jira.percona.com/browse/PXB-1818

Implementation:
For this implementation we keep resizing the buffer pool at prepare as
the parsed redo log records fill the buffer pool until we have enough
memory to hold all parsed records or we exceed the limit percentage of
free memory we can consume. A resize means we double the buffer pool
size. On each resize we also double the frames available to load
database pages.

Added a new flag to control the percentage of free memory we can
consume. It's important to note that we check the available
memory each time we are about to resize the buffer pool. To be on the
safe side, we don't consider the amount of memory we already hold on
buffer pool. For example:
If we have a BP of 1G we will go to 2G, if we selected
--use-free-memory-pct=50 to not pass 50% of free memory, this will
require at least 4G free of memory for this resize, not taking into
consideration that we already hold 1G.