### PR TITLE
Include cloning submodule into build instructions

### DIFF
--- a/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
+++ b/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
@@ -13,6 +13,7 @@ branch that you want to install, such as **8.0**.
 
   $ git clone https://github.com/percona/percona-xtrabackup.git
   $ cd percona-xtrabackup
+  $ git submodule update --init --recursive
   $ git checkout 8.0
 
 .. _pxb.source-code.installing/prerequesite:

--- a/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
+++ b/storage/innobase/xtrabackup/doc/source/installation/compiling_xtrabackup.rst
@@ -13,8 +13,8 @@ branch that you want to install, such as **8.0**.
 
   $ git clone https://github.com/percona/percona-xtrabackup.git
   $ cd percona-xtrabackup
-  $ git submodule update --init --recursive
   $ git checkout 8.0
+  $ git submodule update --init --recursive
 
 .. _pxb.source-code.installing/prerequesite:
 


### PR DESCRIPTION
The 8.0 build fails without cloning submodules:

```
root@be73c2384673:/compile_xtrabackup/percona-xtrabackup/build# cmake .. -DWITH_NUMA=1 -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/boost -DWITH_NUMA=1 -DCMAKE_INSTALL_PREFIX=/compile_xtrabackup/percona-xtrabackup/build
-- Running cmake version 3.13.4
-- Found Git: /usr/bin/git (found version "2.20.1")
-- CMAKE_MODULE_PATH is /compile_xtrabackup/percona-xtrabackup/cmake
-- MySQL 8.0.27
-- Xtrabackup 8.0.27-19
-- Source directory /compile_xtrabackup/percona-xtrabackup
-- Binary directory /compile_xtrabackup/percona-xtrabackup/build
-- CMAKE_GENERATOR: Unix Makefiles
-- SIZEOF_VOIDP 8
-- Packaging as: percona-xtrabackup-8.0.27-Linux-x86_64
-- Local boost dir /boost/boost_1_73_0
-- Local boost zip /boost/boost_1_73_0.tar.bz2
-- Found /boost/boost_1_73_0/boost/version.hpp
-- BOOST_VERSION_NUMBER is #define BOOST_VERSION 107300
-- BOOST_INCLUDE_DIR /boost/boost_1_73_0
-- ZLIB_VERSION (bundled) is 1.2.11
-- ZSTD_LEGACY_SUPPORT not defined!
-- ZSTD_VERSION (bundled) is 1.5.0
-- The openssl command does not support zlib
-- OPENSSL_INCLUDE_DIR = /usr/include
-- OPENSSL_LIBRARY = /usr/lib/x86_64-linux-gnu/libssl.so
-- CRYPTO_LIBRARY = /usr/lib/x86_64-linux-gnu/libcrypto.so
-- OPENSSL_MAJOR_VERSION = 1
-- OPENSSL_MINOR_VERSION = 01
-- OPENSSL_FIX_VERSION = 01
-- SSL_LIBRARIES = /usr/lib/x86_64-linux-gnu/libssl.so;/usr/lib/x86_64-linux-gnu/libcrypto.so;dl
-- KERBEROS path is none, disabling kerberos support.
-- HAVE_KRB5_KRB5_H
-- KERBEROS_LIBRARIES
CMake Warning at cmake/sasl.cmake:264 (MESSAGE):
  Could not find SASL
Call Stack (most recent call first):
  CMakeLists.txt:1641 (MYSQL_CHECK_SASL)


CMake Warning at cmake/ldap.cmake:158 (MESSAGE):
  Could not find LDAP
Call Stack (most recent call first):
  CMakeLists.txt:1645 (MYSQL_CHECK_LDAP)


-- AWK_EXECUTABLE is /usr/bin/awk
-- Found Git: /usr/bin/git
-- LIBEVENT_VERSION_STRING 2.1.11-stable
-- LIBEVENT_VERSION (bundled) 2.1.11
-- ICU_MAJOR_VERSION = 65
-- ICU_INCLUDE_DIRS /compile_xtrabackup/percona-xtrabackup/extra/icu/source/common;/compile_xtrabackup/percona-xtrabackup/extra/icu/source/stubdata;/compile_xtrabackup/percona-xtrabackup/extra/icu/source/i18n
-- ICU_LIBRARIES icui18n;icuuc;icustubdata
-- PROTOBUF_VERSION_NUMBER is #define GOOGLE_PROTOBUF_VERSION 3011004
-- PROTOBUF_VERSION (bundled) is 3.11.4
-- PROTOBUF_INCLUDE_DIR /compile_xtrabackup/percona-xtrabackup/extra/protobuf/protobuf-3.11.4/src
-- PROTOBUF_LIBRARY libprotobuf
-- PROTOBUF_LITE_LIBRARY libprotobuf-lite
-- PROTOBUF_PROTOC_EXECUTABLE protoc
-- CURL version: 7.64
-- CURL_LIBRARY = /usr/lib/x86_64-linux-gnu/libcurl.so
-- CURL_INCLUDE_DIR = /usr/include/x86_64-linux-gnu
-- RAPIDJSON_INCLUDE_DIR /compile_xtrabackup/percona-xtrabackup/extra/rapidjson/include
-- RAPIDJSON_MAJOR_VERSION is 1
-- RAPIDJSON_MINOR_VERSION is 1
CMake Warning at cmake/fido2.cmake:28 (MESSAGE):
  Cannot find development libraries.  You need to install the required
  packages:

    Debian/Ubuntu:              apt install libudev-dev
    RedHat/Fedora/Oracle Linux: yum install libudev-devel
    SuSE:                       zypper install libudev-devel

Call Stack (most recent call first):
  CMakeLists.txt:1833 (WARN_MISSING_SYSTEM_UDEV)


-- CMAKE_MODULE_LINKER_FLAGS_DEBUG  -Wl,-rpath,'$ORIGIN/../../private'
-- CMAKE_SHARED_LINKER_FLAGS_DEBUG  -Wl,-rpath,'$ORIGIN/../../private'
CMake Error at CMakeLists.txt:1857 (ADD_SUBDIRECTORY):
  The source directory

    /compile_xtrabackup/percona-xtrabackup/extra/libkmip

  does not contain a CMakeLists.txt file.


-- Found Unix DNS SRV APIs
-- Skipping the LDAP client authentication plugin
-- Skipping FIDO client authentication plugin.
-- Skipping the KERBEROS client authentication plugin.
-- Skipping the OCI authentication client plugin.
-- Library mysqlclient depends on OSLIBS -lpthread;m;rt;/usr/lib/x86_64-linux-gnu/libssl.so;/usr/lib/x86_64-linux-gnu/libcrypto.so;dl
-- MERGE_CONVENIENCE_LIBRARIES TARGET mysqlclient
-- MERGE_CONVENIENCE_LIBRARIES LIBS clientlib;mytime;strings;vio;mysys;zlib;zstd
-- CURL version: 7.64
-- CURL_LIBRARY = /usr/lib/x86_64-linux-gnu/libcurl.so
-- CURL_INCLUDE_DIR = /usr/include/x86_64-linux-gnu
-- Found libev: /usr/lib/x86_64-linux-gnu/libev.so
-- libev libraries found at: /usr/lib/x86_64-linux-gnu/libev.so
-- libev includes found at: /usr/include
-- Building keyring_vault plugin
CMake Warning at cmake/compile_flags.cmake:36 (MESSAGE):
  -DMYSQL_CLIENT should be in COMPILE_DEFINITIONS not COMPILE_FLAGS
Call Stack (most recent call first):
  storage/innobase/xtrabackup/src/CMakeLists.txt:73 (ADD_COMPILE_FLAGS)


-- BISON outputs /compile_xtrabackup/percona-xtrabackup/build/sql/sql_yacc.cc;/compile_xtrabackup/percona-xtrabackup/build/sql/sql_yacc.h
-- BISON outputs /compile_xtrabackup/percona-xtrabackup/build/sql/sql_hints.yy.cc;/compile_xtrabackup/percona-xtrabackup/build/sql/sql_hints.yy.h
-- CONFIG_CLIENT_LIBS -lpthread -ldl -lssl -lcrypto -lresolv -lm -lrt
-- CONFIG_LIBS_PRIVATE -lpthread -ldl -lresolv -lm -lrt
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
-- CMAKE_BUILD_TYPE: RelWithDebInfo
-- COMPILE_DEFINITIONS: _GNU_SOURCE;_FILE_OFFSET_BITS=64;XTRABACKUP;RAPIDJSON_NO_SIZETYPEDEFINE;RAPIDJSON_SCHEMA_USE_INTERNALREGEX=0;RAPIDJSON_SCHEMA_USE_STDREGEX=1;HAVE_CONFIG_H;__STDC_LIMIT_MACROS;__STDC_FORMAT_MACROS;_USE_MATH_DEFINES;LZ4_DISABLE_DEPRECATE_WARNINGS;HAVE_TLSv13
-- CMAKE_C_FLAGS: -fno-omit-frame-pointer -ftls-model=initial-exec -g -O2 -fdebug-prefix-map=/compile_xtrabackup/percona-xtrabackup/build=. -fstack-protector-strong -Wformat -Werror=format-security   -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Wwrite-strings -Wjump-misses-init -Wstringop-truncation -Wmissing-include-dirs
-- CMAKE_CXX_FLAGS: -std=c++17 -fno-omit-frame-pointer -ftls-model=initial-exec -g -O2 -fdebug-prefix-map=/compile_xtrabackup/percona-xtrabackup/build=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute -Woverloaded-virtual -Wcast-qual -Wimplicit-fallthrough=5 -Wstringop-truncation -Wmissing-include-dirs -Wextra-semi -Wlogical-op
-- CMAKE_CXX_FLAGS_DEBUG: -DSAFE_MUTEX -DENABLED_DEBUG_SYNC -g
-- CMAKE_CXX_FLAGS_RELWITHDEBINFO: -ffunction-sections -fdata-sections -O2 -g -DNDEBUG
-- CMAKE_CXX_FLAGS_RELEASE: -ffunction-sections -fdata-sections -O3 -DNDEBUG
-- CMAKE_CXX_FLAGS_MINSIZEREL: -ffunction-sections -fdata-sections -Os -DNDEBUG
-- CMAKE_C_LINK_FLAGS:  -fuse-ld=gold -Wl,--gc-sections
-- CMAKE_CXX_LINK_FLAGS:  -fuse-ld=gold -Wl,--gc-sections
-- CMAKE_EXE_LINKER_FLAGS -Wl,-z,relro
-- CMAKE_MODULE_LINKER_FLAGS -Wl,-z,relro
-- CMAKE_SHARED_LINKER_FLAGS -Wl,-z,relro
-- Configuring incomplete, errors occurred!
See also "/compile_xtrabackup/percona-xtrabackup/build/CMakeFiles/CMakeOutput.log".
See also "/compile_xtrabackup/percona-xtrabackup/build/CMakeFiles/CMakeError.log".
```

Notice this line:

```
CMake Error at CMakeLists.txt:1857 (ADD_SUBDIRECTORY):
  The source directory

    /compile_xtrabackup/percona-xtrabackup/extra/libkmip

  does not contain a CMakeLists.txt file.
```

After running `git submodule update --init --recursive`, `libkmip` gets cloned and has a `CMakeLists.txt`. 

