### PR TITLE
PXB-2264 Auto increment information is removed after partial restore …

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2546,13 +2546,20 @@ struct metadata_applier {
   @param[in]      table   table to visit */
   void operator()(dict_table_t *table) const {
     ut_ad(dict_sys->dynamic_metadata != nullptr);
+#ifndef XTRABACKUP
     uint64_t autoinc = table->autoinc;
+#endif /* XTRABACKUP */
     dict_table_load_dynamic_metadata(table);
     /* For those tables which were not opened by
     ha_innobase::open() and not initialized by
     innobase_initialize_autoinc(), the next counter should be
     advanced properly */
+#ifdef XTRABACKUP
+    /* PXB doesn't open tables via ha_innobase::open() */
+    if (table->autoinc != ~0ULL) {
+#else
     if (autoinc != table->autoinc && table->autoinc != ~0ULL) {
+#endif /* XTRABACKUP */
       ++table->autoinc;
     }
   }


### PR DESCRIPTION
…of a table

https://jira.percona.com/browse/PXB-2264

Problem:
If a table has next auto incremental value 2 then the table exported
through PXB has next auto incremental value 1 instead of 2.

Analysis:
To get the next autoinc, PXB fetches the current autoinc value from DD tables
and increase it by 1. Also it intialize the autoinc value as 1. There is a
addition check to not increase the autoinc when DD autoinc is same as current
table autoinc. This means autoinc is already correctected by metadata applier
through open table.
Subject table has autoinc in  1 in DD table and it is also initialize with value 1
So PXB do not increase the counter and with export this value is set as 1.

Fix:
PXB intialize autoinc_persisted with 0. So Increase the counter
if autoinc persisisted is not same as autoinc presisted from DD tables.