### PR TITLE
Fixed PXB-2715 validate decompression path

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -65,4 +65,5 @@ xb_fetch_tablespace_key(ulint space_id, byte *key, byte *iv);
 }
 #endif
 
+#define SQUOTE(str) "'" << str << "'"
 #endif

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2219,10 +2219,16 @@ bool
 decrypt_decompress_file(const char *filepath, uint thread_n)
 {
 	std::stringstream cmd, message;
-	char *dest_filepath = strdup(filepath);
+	char buf[FN_LEN];
 	bool needs_action = false;
 
-	cmd << "cat " << filepath;
+        if (escape_string_for_mysql(&my_charset_utf8mb4_general_ci, buf, 0,
+                                    filepath, strlen(filepath)) == (size_t)-1) {
+          msg_ts("[%02u] Error escaping file: %s\n", thread_n, filepath);
+          return false;
+        }
+        char *dest_filepath = strdup(buf);
+	cmd << "cat " << SQUOTE(buf);
 
  	if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {
  		cmd << " | xbcrypt --decrypt --encrypt-algo="
@@ -2251,7 +2257,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  		needs_action = true;
  	}
 
- 	cmd << " > " << dest_filepath;
+	cmd << " > " << SQUOTE(dest_filepath);
  	message << " " << filepath;
 
  	free(dest_filepath);


### PR DESCRIPTION
Problem:
While decompressing a backup, we pass filepath and dest_filepath to
system call without any validation.

Fix:
Quote those path's in order to make it more secure.