### PR TITLE
PXB-2422 - xbstream extracts subdirectories

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -171,6 +171,7 @@ TARGET_LINK_LIBRARIES(xbstream
 # xbcrypt binary
 ########################################################################
 MYSQL_ADD_EXECUTABLE(xbcrypt
+  file_utils.c
   xbcrypt.c
   xbcrypt_common.c
   xbcrypt_read.c

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -56,6 +56,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sstream>
 #include <algorithm>
 #include "fil_cur.h"
+#include "file_utils.h"
 #include "xtrabackup.h"
 #include "common.h"
 #include "backup_copy.h"
@@ -127,15 +128,6 @@ struct datadir_thread_ctxt_t {
 	os_thread_id_t		id;
 	bool			ret;
 };
-
-
-/************************************************************************
-Retirn true if character if file separator */
-bool
-is_path_separator(char c)
-{
-	return is_directory_separator(c);
-}
 
 
 /************************************************************************
@@ -621,42 +613,6 @@ ends_with(const char *str, const char *suffix)
 	size_t str_len = strlen(str);
 	return(str_len >= suffix_len
 	       && strcmp(str + str_len - suffix_len, suffix) == 0);
-}
-
-/************************************************************************
-Create directories recursively.
-@return 0 if directories created successfully. */
-static
-int
-mkdirp(const char *pathname, int Flags, myf MyFlags)
-{
-	char parent[PATH_MAX], *p;
-
-	/* make a parent directory path */
-	strncpy(parent, pathname, sizeof(parent));
-	parent[sizeof(parent) - 1] = 0;
-
-	for (p = parent + strlen(parent);
-	    !is_path_separator(*p) && p != parent; p--);
-
-	*p = 0;
-
-	/* try to make parent directory */
-	if (p != parent && mkdirp(parent, Flags, MyFlags) != 0) {
-		return(-1);
-	}
-
-	/* make this one if parent has been made */
-	if (my_mkdir(pathname, Flags, MyFlags) == 0) {
-		return(0);
-	}
-
-	/* if it already exists that is fine */
-	if (errno == EEXIST) {
-		return(0);
-	}
-
-	return(-1);
 }
 
 /************************************************************************

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -47,8 +47,6 @@ void
 version_check();
 #endif
 bool
-is_path_separator(char);
-bool
 directory_exists(const char *dir, bool create);
 
 #endif

--- a/storage/innobase/xtrabackup/src/ds_local.c
+++ b/storage/innobase/xtrabackup/src/ds_local.c
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_thread_local.h>
 #include "common.h"
 #include "datasink.h"
+#include "file_utils.h"
 
 typedef struct {
 	File fd;
@@ -84,7 +85,7 @@ local_open(ds_ctxt_t *ctxt, const char *path,
 
 	/* Create the directory if needed */
 	dirname_part(dirpath, fullpath, &dirpath_len);
-	if (my_mkdir(dirpath, 0777, MYF(0)) < 0 && my_errno() != EEXIST) {
+	if (mkdirp(dirpath, 0777, MYF(0)) < 0) {
 		char errbuf[MYSYS_STRERROR_SIZE];
 		my_error(EE_CANT_MKDIR, MYF(ME_BELL),
 			 dirpath, my_errno(), my_strerror(errbuf,

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -19,10 +19,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #ifndef FILE_UTILS_H
 #define FILE_UTILS_H
 
+#include "my_global.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Return a safer suffix of FILE_NAME, or "." if it has no safer
    suffix.  Check for fully specified file names and other atrocities.
    Warn the user if we do not return NAME. */
 /* Based on gnu tar */
 const char *safer_name_suffix(char const *file_name, int *prefix_len_out);
+
+int is_path_separator(char);
+
+int mkdirp(const char* pathname, int Flags, myf MyFlags);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/storage/innobase/xtrabackup/src/innobackupex.cc
+++ b/storage/innobase/xtrabackup/src/innobackupex.cc
@@ -63,6 +63,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "xb0xb.h"
 #include "xbstream.h"
 #include "fil_cur.h"
+#include "file_utils.h"
 #include "write_filt.h"
 #include "backup_copy.h"
 #include "xbcrypt_common.h"

--- a/storage/innobase/xtrabackup/test/t/pxb-2371.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2371.sh
@@ -21,7 +21,6 @@ echo "a" > $file
 ## Run
 run_cmd xbstream -v -c $file > $file_xb
 rm -f $file
-mkdir -p $dir_dst/$(dirname $file)  # xbstream doesn't create parent directories
 run_cmd xbstream -v -x -C $dir_dst < $file_xb
 
 ## Check: The file was extracted in the relative path

--- a/storage/innobase/xtrabackup/test/t/pxb-2422.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2422.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#
+# PXB-2422: --Bug: Extract sub-directories
+#
+
+. inc/common.sh
+
+dir_src="$TMPDIR/subdir"
+file="$dir_src/a.txt"
+dir_dst="$TMPDIR/dst"
+file_xb="$TMPDIR/test.xb"
+
+# Test 1: xbstream extracts files in sub-directories
+
+## Set up
+rm -rf $dir_src $dir_dst $file_xb
+mkdir -p $dir_src
+echo "a" > $file
+mkdir -p $dir_dst
+
+## Run
+run_cmd xbstream -v -c $file > $file_xb
+rm -rf $dir_src
+run_cmd xbstream -v -x -C $dir_dst < $file_xb
+
+## Check
+run_cmd_expect_failure ls -l $file
+run_cmd ls -l $dir_dst/$file
+
+## Cleanup
+rm -rf $dir_src $dir_dst $file_xb


### PR DESCRIPTION
*Problem*:

When a stream is created with a file contained in a directory inside or another directory, the extraction fails.

```
~/src/pxb$ make create
echo "a" >> /home/x/a.csv
~/src/pxb/bld-pxb-8.0/runtime_output_directory/xbstream -v -c /home/x/a.csv > a.xb
rm /home/x/a.csv
/home/x/src/pxb/bld-pxb-8.0/runtime_output_directory/xbstream: removing leading '/'.
/home/x/a.csv

~/src/pxb$ make extract
xbstream: Can't create directory './home/x/' (OS errno 2 - No such file or directory)
/home/x/src/pxb/bld-pxb-8.0/runtime_output_directory/xbstream: failed to create file.
exit code: 1
```

*Solution*:

xbstream extract operations create the subdirectories the files are
contained in.
