### PR TITLE
PXB-2761 Fix compilation error due to loop-variable creates a copy from its type

### DIFF
--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -758,7 +758,7 @@ bool xb_tablespace_keys_dump(ds_ctxt_t *ds_ctxt, const char *transition_key,
     }
   }
 
-  for (const auto entry : encryption_info) {
+  for (const auto &entry : encryption_info) {
     if (!xb_tablespace_keys_write_single(stream, derived_key, entry.first,
                                          entry.second.key, entry.second.iv)) {
       xb::error() << "Error writing " << XTRABACKUP_KEYS_FILE


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2761

* Fixes compilation error [in GCC 11+ because of new error flag: `-Wrange-loop-construct`, is now enabled in `-Wall`. ](https://gcc.gnu.org/gcc-11/changes.html#cxx)
* Compiler encouragingly recommends using a [`reference type to prevent copying`](https://gcc.gnu.org/onlinedocs/gcc-11.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wrange-loop-construct).