### PR TITLE
PXB-2738 xbcloud error Upload failed: backup is incomplete

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -865,17 +865,21 @@ bool xbcloud_put(Object_store *store, const std::string &container,
   xtrabackup_tablespaces.00000000000000000000) is uploaded to cloud storage to
   determine successful xbcloud "put" operation. */
   std::string last_file_prefix = backup_name + "/xtrabackup_tablespaces";
+  auto last_file_size = last_file_prefix.size();
   bool file_found = false;
-
-  if (!object_list.empty()) {
-    auto cur_file = object_list.back();
-    auto last_file_size = last_file_prefix.size();
-    if (cur_file.size() >= last_file_size &&
-        cur_file.substr(0, last_file_size).compare(last_file_prefix) == 0)
+  for (auto cur_file = object_list.rbegin(); cur_file != object_list.rend();
+       cur_file++) {
+    if (cur_file->size() >= last_file_size &&
+        cur_file->substr(0, last_file_size).compare(last_file_prefix) == 0) {
       file_found = true;
+      break;
+    }
   }
   if (!file_found) {
-    msg_ts("%s: Upload failed: backup is incomplete.\n", my_progname);
+    msg_ts(
+        "%s: Upload failed: backup is incomplete.\nBackup doesn't contain "
+        "last file with prefix xtrabackup_tablespaces in the cloud storage\n",
+        my_progname);
     return false;
   }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2738

Problem:
Xbcloud complains that xtrabackup_tablespace is not uploaded and backup
is incomplete. xtrabackup_tablespace is the last file generated by PXB

Analysis:
To ensure backup is uploaded, xbcloud checks for xtrabackup_tablespace
is uploaded successfully.

When the timestamp of xtrabackup_tablespace and some other file is same,
xbcloud list file operation can return last file as other file
instead of xtrabackup_tablespace.

Fix:
Loop through all the files uploaded by xbcloud to ensure xtrabackup_tablespace
is uploaded.