### PR TITLE
PXB-8.0-2740 PXB displays the encryption key when the backup is decrypted…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2189,9 +2189,7 @@ decrypt_decompress_file(const char *filepath, uint thread_n)
  	if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {
  		cmd << " | xbcrypt --decrypt --encrypt-algo="
  		    << xtrabackup_encrypt_algo_names[opt_decrypt_algo];
- 		if (xtrabackup_encrypt_key) {
- 			cmd << " --encrypt-key=" << xtrabackup_encrypt_key;
- 		} else {
+ 		if (xtrabackup_encrypt_key == NULL) {
  			cmd << " --encrypt-key-file="
  			    << xtrabackup_encrypt_key_file;
  		}
@@ -2303,6 +2301,10 @@ decrypt_decompress()
 	it = datadir_iter_new(".", false);
 
 	ut_a(xtrabackup_parallel >= 0);
+
+	if (xtrabackup_encrypt_key) {
+		setenv("XBCRYPT_ENCRYPTION_KEY", xtrabackup_encrypt_key, 1);
+	}
 
 	ret = run_data_threads(it, decrypt_decompress_thread_func,
 		xtrabackup_parallel ? xtrabackup_parallel : 1,

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -67,6 +67,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "utils.h"
 #include "xb0xb.h"
 
+#include <cstdlib>
 #include "backup_copy.h"
 #include "backup_mysql.h"
 #include "keyring_components.h"
@@ -2584,9 +2585,7 @@ bool decrypt_decompress_file(const char *filepath, uint thread_n) {
   if (ends_with(filepath, ".xbcrypt") && opt_decrypt) {
     cmd << " | xbcrypt --decrypt --encrypt-algo="
         << xtrabackup_encrypt_algo_names[opt_decrypt_algo];
-    if (xtrabackup_encrypt_key) {
-      cmd << " --encrypt-key=" << xtrabackup_encrypt_key;
-    } else {
+    if (xtrabackup_encrypt_key == nullptr) {
       cmd << " --encrypt-key-file=" << xtrabackup_encrypt_key_file;
     }
     dest_filepath[strlen(dest_filepath) - 8] = 0;
@@ -2686,6 +2685,10 @@ bool decrypt_decompress() {
   ds_data = ds_create(".", DS_TYPE_LOCAL);
 
   ut_a(xtrabackup_parallel >= 0);
+
+  if (xtrabackup_encrypt_key) {
+    setenv("XBCRYPT_ENCRYPTION_KEY", xtrabackup_encrypt_key, 1);
+  }
 
   ret = run_data_threads(".", decrypt_decompress_thread_func,
                          xtrabackup_parallel, "decrypt and decompress");

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql/service_mysql_alloc.h>
 #include <signal.h>
 #include <typelib.h>
-#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <set>
@@ -525,12 +524,6 @@ static bool get_one_option(int optid,
 
 static const char *load_default_groups[] = {"xbcloud", 0};
 
-static void get_env_value(char *&var, const char *env) {
-  char *val;
-  if (var == nullptr && (val = getenv(env)) != nullptr) {
-    var = my_strdup(PSI_NOT_INSTRUMENTED, val, MYF(MY_FAE));
-  }
-}
 
 static void get_env_args() {
   get_env_value(opt_swift_auth_url, "OS_AUTH_URL");

--- a/storage/innobase/xtrabackup/src/xbcrypt.c
+++ b/storage/innobase/xtrabackup/src/xbcrypt.c
@@ -165,6 +165,14 @@ main(int argc, char **argv)
 
 	crc_init();
 
+	/* Get the env value XBCRYPT_ENCRYPTION_KEY */
+	if (opt_encrypt_key == NULL) {
+	  char *val;
+	  if ((val = getenv("XBCRYPT_ENCRYPTION_KEY")) != NULL) {
+	    opt_encrypt_key = my_strdup(PSI_NOT_INSTRUMENTED, val, MYF(MY_FAE));
+	  }
+	}
+
 	if (opt_input_file) {
 		MY_STAT 	input_file_stat;
 
@@ -266,6 +274,7 @@ cleanup:
 	}
 
 	my_cleanup_options(my_long_options);
+	my_free(opt_encrypt_key);
 
 	my_end(0);
 

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -148,6 +148,9 @@ int main(int argc, char **argv) {
   if (get_options(&argc, &argv)) {
     goto cleanup;
   }
+  if (opt_encrypt_key == nullptr) {
+    get_env_value(opt_encrypt_key, "XBCRYPT_ENCRYPTION_KEY");
+  }
 
   xb_libgcrypt_init();
 
@@ -249,6 +252,7 @@ cleanup:
   }
 
   my_cleanup_options(my_long_options);
+  my_free(opt_encrypt_key);
 
   my_end(0);
 

--- a/storage/innobase/xtrabackup/src/xbcrypt_common.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt_common.cc
@@ -305,3 +305,10 @@ gcry_error_t xb_crypt_encrypt(gcry_cipher_hd_t cipher_handle, const uchar *from,
 
   return 0;
 }
+
+void get_env_value(char *&var, const char *env) {
+  char *val;
+  if (var == nullptr && (val = getenv(env)) != nullptr) {
+    var = my_strdup(PSI_NOT_INSTRUMENTED, val, MYF(MY_FAE));
+  }
+}

--- a/storage/innobase/xtrabackup/src/xbcrypt_common.h
+++ b/storage/innobase/xtrabackup/src/xbcrypt_common.h
@@ -72,6 +72,9 @@ gcry_error_t xb_crypt_encrypt(gcry_cipher_hd_t cipher_handle, const uchar *from,
                               size_t from_len, uchar *to, size_t *to_len,
                               uchar *iv);
 
+/* Get the enviorment variable env value into var */
+void get_env_value(char *&var, const char *env);
+
 #ifdef __cplusplus
 }
 #endif

--- a/storage/innobase/xtrabackup/test/t/check_for_passwords.sh
+++ b/storage/innobase/xtrabackup/test/t/check_for_passwords.sh
@@ -13,8 +13,8 @@ secure-file-priv=$TEST_VAR_ROOT
 vlog "Preparing server"
 start_server
 mysql -e "CREATE USER pxb@localhost IDENTIFIED BY '$password_string'"
-mysql -e "GRANT ALL ON *.* TO pxb@localhost"
 ### create table in MyISAM to let backup wait until there is pending update
+mysql -e "GRANT ALL ON *.* TO pxb@localhost "
 mysql -e "CREATE TABLE t1(i int) engine=MYISAM" test
 mysql -e "INSERT INTO t1 values(1)" test
 mkdir -p $topdir/backup
@@ -28,9 +28,8 @@ function grep_in_datadir_ps() {
   ### PXB will do FLUSH TABLES on MyISAM tables which requires access
   ### to the table and waits for the running update on MyISAM to finish.
   mysql -e "SELECT SLEEP(1000) from t1 for update " test &
-
   while ! mysql -e 'SHOW PROCESSLIST' | grep 'SELECT SLEEP' ; do
-    sleep 1;
+      sleep 1;
   done
 
   $XB_BIN $XB_ARGS --backup -u pxb $additional_options \
@@ -55,8 +54,47 @@ function grep_in_datadir_ps() {
 
   ###kill running mysql query on MyISAM table to let backup resume
   vlog "killing mysql query"
+  ## sleep is to ensure time equation works fine
+  sleep 1
   kill_query_pattern "time > 0 && INFO like '%SLEEP%'"
 
+  run_cmd wait $job_pid
+
+  vlog "check for $password_string string in directory $topdir"
+  if grep -rq $password_string $topdir/backup
+  then
+     grep -r $password_string $topdir/backup
+     die "found $password_string string in $topdir/backup "
+  fi
+  rm -rf $topdir/backup
+}
+
+##grep for encryption key while decrypting
+function grep_in_datadir_ps_decrypt() {
+
+  additional_options=$1
+
+  xtrabackup --backup $additional_options --target-dir=$topdir/backup
+
+  $XB_BIN $XB_ARGS --decrypt=AES256 $additional_options \
+  --target-dir=$topdir/backup \
+       2> >( tee $topdir/pxb_2740.log)&
+  job_pid=$!
+  wait_for_file_to_generated $topdir/pxb_2740.log
+
+  echo "backup pid is $job_pid"
+
+  #sleep is to ensure password string is removed from ps
+  while ! grep -q 'decrypting' $topdir/pxb_2740.log
+  do
+	  sleep 1;
+  done
+
+  vlog "check for $password_string string in ps with $job_pid "
+  if ps -ef | grep $job_pid | grep "xbcrypt.*$password_string" | grep -v grep
+  then
+     die "found $password_string string in ps output"
+  fi
   run_cmd wait $job_pid
 
   vlog "check for $password_string string in directory $topdir"
@@ -95,3 +133,7 @@ grep_in_datadir_ps "--password=$password_string"
 
 vlog "check for encryption string in data directory"
 grep_in_datadir_ps "--password=$password_string --encrypt=AES256 --encrypt-key=r______$password_string"
+
+vlog "check for encryption string during decryption"
+grep_in_datadir_ps_decrypt " --encrypt=AES256 --encrypt-key=r______$password_string"
+


### PR DESCRIPTION
… and decompressed

https://jira.percona.com/browse/PXB-2740

Problem:
PXB displays the encryption key when the backup is decrypted and decompressed

Analysis:
PXB uses system function to call xbcrypt with encryption password to decrypt
the password. system function creates sub process. password is only
removed by sub process . The main process shows the encrypted password
in ps

Fix:
set the enviorment variable XBCRYPT_ENCRYPTION_PASSWORD in pxb and use
that variable inside xbcrypt