### PR TITLE
Implemented PXB-2710 - Predict memory for --prepare

### DIFF
--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -1115,6 +1115,23 @@ static inline ulint buf_pool_size_align(ulint size) {
   }
 }
 
+#ifdef XTRABACKUP
+/** Calculate aligned buffer pool size based on srv_buf_pool_chunk_unit,
+if needed we round it down.
+@param[in]	size	size in bytes
+@return	aligned size */
+static inline ulint buf_pool_size_align_down(ulint size) {
+  const ulint m = srv_buf_pool_instances * srv_buf_pool_chunk_unit;
+  size = std::max(size, srv_buf_pool_min_size);
+
+  if (size % m == 0) {
+    return (size);
+  } else {
+    return ((size / m - 1) * m);
+  }
+}
+#endif
+
 /** Return how many more pages must be added to the withdraw list to reach the
 withdraw target of the currently ongoing buffer pool resize.
 @param[in]      buf_pool        buffer pool instance

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -29,7 +29,7 @@ extern bool redo_catchup_completed;
 extern bool opt_page_tracking;
 extern char *xtrabackup_incremental;
 extern lsn_t incremental_start_checkpoint_lsn;
-
+extern lsn_t xtrabackup_start_checkpoint;
 extern bool use_dumped_tablespace_keys;
 
 extern std::vector<ulint> invalid_encrypted_tablespace_ids;
@@ -76,5 +76,15 @@ bool check_if_skip_table(
     const char *name); /*!< in: path to the table */
 
 extern bool xtrabackup_stats;
+
+/** Amount of memory calculated at --backup for recovery hash records */
+extern size_t redo_memory;
+
+/** Number of total frames that will be required for prepare */
+extern ulint redo_frames;
+
+/** This variables holds the result of all conditions that must be set in order
+to enable predict memory functionality */
+extern bool predict_memory;
 #define SQUOTE(str) "'" << str << "'"
 #endif

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -129,6 +129,12 @@ TARGET_LINK_LIBRARIES(xtrabackup
   crc
   )
 
+IF(NOT APPLE)
+  TARGET_LINK_LIBRARIES(xtrabackup
+    procps
+    )
+ENDIF()
+
  # We depend on protobuf because of the mysqlx plugin and replication.
  IF(UNIX_INSTALL_RPATH_ORIGIN_PRIV_LIBDIR)
    ADD_INSTALL_RPATH_FOR_PROTOBUF(xtrabackup)

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1009,6 +1009,7 @@ bool Redo_Log_Data_Manager::start() {
 
   start_checkpoint_lsn = reader.get_start_checkpoint_lsn();
   last_checkpoint_lsn = start_checkpoint_lsn;
+  xtrabackup_start_checkpoint = start_checkpoint_lsn;
   stop_lsn = 0;
 
   if (opt_lock_ddl_per_table) {

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -19,6 +19,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_default.h>
 #include <mysqld.h>
 
+#ifdef __APPLE__
+#include <mach/mach_host.h>
+#include <sys/sysctl.h>
+#else
+#include <proc/sysinfo.h>
+#endif
+
 #include "common.h"
 #include "msg.h"
 #include "xtrabackup.h"
@@ -99,6 +106,45 @@ unsigned long get_version_number(std::string version_str) {
     version = stoi(version_str.substr(minor_p + 1));
   return major * 10000 + minor * 100 + version;
 }
+
+#ifdef __APPLE__
+unsigned long host_total_memory() {
+  unsigned long total_mem = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGESIZE);
+  return total_mem;
+}
+
+unsigned long host_free_memory() {
+  unsigned long total_mem = host_total_memory();
+  int64_t used_mem;
+  vm_size_t page_size;
+  mach_msg_type_number_t count;
+  vm_statistics_data_t vm_stats;
+
+  // Get used memory
+  mach_port_t host = mach_host_self();
+  count = sizeof(vm_stats) / sizeof(natural_t);
+  if (KERN_SUCCESS == host_page_size(host, &page_size) &&
+      KERN_SUCCESS ==
+          host_statistics(host, HOST_VM_INFO, (host_info_t)&vm_stats, &count)) {
+    used_mem = ((int64_t)vm_stats.active_count + (int64_t)vm_stats.wire_count) *
+               (int64_t)page_size;
+
+    ut_a(total_mem >= (unsigned long)used_mem);
+    return total_mem - (unsigned long)used_mem;
+  }
+  return 0;
+}
+#else
+unsigned long host_total_memory() {
+  meminfo();
+  return kb_main_total * 1024;
+}
+
+unsigned long host_free_memory() {
+  meminfo();
+  return kb_main_available * 1024;
+}
+#endif
 
 }  // namespace utils
 }  // namespace xtrabackup

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -44,6 +44,8 @@ bool read_server_uuid();
 @return version_number like 80022 */
 unsigned long get_version_number(std::string version_str);
 
+unsigned long host_total_memory();
+unsigned long host_free_memory();
 }  // namespace utils
 }  // namespace xtrabackup
 #endif  // XTRABACKUP_UTILS_H

--- a/storage/innobase/xtrabackup/test/t/pxb-2710-predict_memory.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2710-predict_memory.sh
@@ -1,0 +1,125 @@
+# PXB-2710 - Predict memory at --prepare
+
+. inc/common.sh
+require_debug_pxb_version
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb-flush-log-at-trx-commit=0
+sync-binlog=0
+"
+start_server
+backupdir="${topdir}/full"
+backupdir2="${topdir}/full2"
+pid_file=${backupdir}/xtrabackup_debug_sync
+logfile="${topdir}/xtrabackup.out"
+logfile2="${topdir}/xtrabackup2.out"
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+CREATE TABLE pxb_2710(a INT PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+INSERT INTO pxb_2710 VALUES (NULL);
+EOF
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=${backupdir} --debug-sync=xtrabackup_pause_after_redo_catchup &
+job_pid=$!
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+
+# generate some data and check if it has reached 128M
+vlog "Starting to generate some data ..."
+
+# make sure we have a SQL that creates a lot of new pages
+( while true ; do
+    mysql -e "INSERT INTO pxb_2710 SELECT NULL FROM pxb_2710 LIMIT 10000" test
+done ) 2>/dev/null &
+insert_pid=$!
+
+start_lsn=`innodb_lsn`
+i=0
+while true ; do
+  new_lsn=`innodb_lsn`
+  current_redo_size=$((${new_lsn} - ${start_lsn}))
+  if [[ "${current_redo_size}" -gt "41943040" ]];
+  then
+    break
+  fi
+  i=$((${i}+1))
+  # print log every 30 seconds
+  if [[ "$((${i} % 3 ))" -eq "0" ]];
+  then
+    vlog "Populating database with some data, current size: ${current_redo_size}"
+  fi
+  sleep 10
+done
+
+#stop inserting data
+kill -SIGKILL ${insert_pid}
+
+# resume and wait for backup to complete
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir
+
+vlog "Making a copy of backup dir"
+cp -R ${backupdir} ${backupdir2}
+
+
+# memory calculations to avoid false positves
+redo_memory=$(grep 'redo_memory' ${backupdir}/xtrabackup_checkpoints | awk '{print $3}') #bytes
+redo_frames=$(grep 'redo_frames' ${backupdir}/xtrabackup_checkpoints | awk '{print $3}') #pages
+total_memory=$((redo_memory + (redo_frames * 16384))) #bytes
+
+free_memory=$(cat /proc/meminfo | grep 'MemAvailable' | awk '{print $2}') #kb
+free_memory_bytes=$((free_memory * 1024)) #bytes
+free_memory_1_pct=$((free_memory_bytes  * 1 / 100)) #bytes
+free_memory_99_pct=$((free_memory_bytes  * 99 / 100)) #bytes
+
+if [[ "${free_memory_99_pct}" -lt "${total_memory}" ]];
+then
+  vlog "Skipping full memory workload test as 99% of free memory is lower than required by pxb"
+else
+  vlog "Preparing backup with --use-free-memory-pct=99"
+  xtrabackup --prepare --use-free-memory-pct=99 --target-dir=${backupdir} 2> ${logfile}
+
+  if grep -q "Required memory will exceed free memory configuration" ${logfile}
+  then
+    die "Xtrabackup should not have exceed free memory."
+  fi
+
+  if ! grep -q "Setting free frames to ${redo_frames}" ${logfile}
+  then
+    die "Xtrabackup should have adjusted frames to ${redo_frames}."
+  fi
+  xtrabackup --copy-back --target-dir=${backupdir}
+  start_server
+  run_cmd verify_db_state test
+  stop_server
+  rm -rf $mysql_datadir
+fi
+
+if [[ "${free_memory_1_pct}" -gt "${total_memory}" ]];
+then
+  vlog "Adjusting redo_memory to a very high value so it exceed 1% of memory"
+  # 100G
+  sed -i -e '/redo_memory =/ s/= .*/= 107374182400/' ${backupdir2}/xtrabackup_checkpoints
+fi
+
+vlog "Preparing backup with --use-free-memory-pct=1"
+xtrabackup --prepare --use-free-memory-pct=1 --target-dir=${backupdir2} 2> ${logfile2}
+
+if ! grep -q "Required memory will exceed Free memory configuration" ${logfile2}
+then
+    die "Xtrabackup should have exceed free memory."
+fi
+xtrabackup --copy-back --target-dir=${backupdir2}
+start_server
+run_cmd verify_db_state test
+stop_server
+rm -rf $mysql_datadir
+
+


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2710

Description:
Implemented a new functionality to predict memory required to --prepare
a backup.
The logic inherits the calculation done at recv_add_to_hash_table and
populate a new struct that controls the memory will be required.
This information is then saved to xtrabackup_checkpoints file and read
at --prepare to predict the memory.
Memory requirements is split into two buckets:
  1. Memory required for recv_add_to_hash_table.
  2. Memory required for free frames.

A new variable has been introduced --use-free-memory-pc (defatul 50)
that controls the amount of free memory we will be able to use at
--prepare.