### PR TITLE
postfixes for PXB-2721 - Amazon KMS key management component

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1817,17 +1817,18 @@ bool binlog_file_location::find_binlog(const std::string &dir,
 bool copy_incremental_over_full() {
   const char *ext_list[] = {"MYD", "MYI", "MAD", "MAI", "MRG", "ARM",
                             "ARZ", "CSM", "CSV", "opt", "sdi", nullptr};
-  const char *sup_files[] = {"xtrabackup_binlog_info",
-                             "xtrabackup_galera_info",
-                             "xtrabackup_slave_info",
-                             "xtrabackup_info",
-                             "xtrabackup_keys",
-                             "xtrabackup_tablespaces",
-                             "xtrabackup_component_keyring_file.cnf",
-                             "xtrabackup_component_keyring_kmip.cnf",
-                             "xtrabackup_component_keyring_kms.cnf",
-                             "ib_lru_dump",
-                             nullptr};
+  const char *sup_files[] = {
+      "xtrabackup_binlog_info",
+      "xtrabackup_galera_info",
+      "xtrabackup_slave_info",
+      "xtrabackup_info",
+      "xtrabackup_keys",
+      "xtrabackup_tablespaces",
+      xtrabackup::components::XTRABACKUP_KEYRING_FILE_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_KMIP_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_KMS_CONFIG,
+      "ib_lru_dump",
+      nullptr};
   bool ret = true;
   char path[FN_REFLEN];
   int i;
@@ -2025,21 +2026,22 @@ bool should_skip_file_on_copy_back(const char *filepath) {
   char c_tmp;
   int i_tmp;
 
-  const char *ext_list[] = {"backup-my.cnf",
-                            "xtrabackup_logfile",
-                            "xtrabackup_binary",
-                            "xtrabackup_binlog_info",
-                            "xtrabackup_checkpoints",
-                            "xtrabackup_tablespaces",
-                            "xtrabackup_component_keyring_file.cnf",
-                            "xtrabackup_component_keyring_kmip.cnf",
-                            "xtrabackup_component_keyring_kms.cnf",
-                            ".qp",
-                            ".lz4",
-                            ".pmap",
-                            ".tmp",
-                            ".xbcrypt",
-                            NULL};
+  const char *ext_list[] = {
+      "backup-my.cnf",
+      "xtrabackup_logfile",
+      "xtrabackup_binary",
+      "xtrabackup_binlog_info",
+      "xtrabackup_checkpoints",
+      "xtrabackup_tablespaces",
+      xtrabackup::components::XTRABACKUP_KEYRING_FILE_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_KMIP_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_KMS_CONFIG,
+      ".qp",
+      ".lz4",
+      ".pmap",
+      ".tmp",
+      ".xbcrypt",
+      NULL};
 
   filename = base_name(filepath);
 

--- a/storage/innobase/xtrabackup/src/keyring_components.h
+++ b/storage/innobase/xtrabackup/src/keyring_components.h
@@ -24,6 +24,9 @@ namespace components {
 /** Data types */
 extern bool keyring_component_initialized;
 extern std::string component_config_path;
+extern const char *XTRABACKUP_KEYRING_FILE_CONFIG;
+extern const char *XTRABACKUP_KEYRING_KMIP_CONFIG;
+extern const char *XTRABACKUP_KEYRING_KMS_CONFIG;
 
 /** @Return name of component config file */
 const char *xb_component_config_file();

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1296,7 +1296,7 @@ struct my_option xb_client_options[] = {
     {"component-keyring-file-config", OPT_COMPONENT_KEYRING_FILE_CONFIG,
      "Path to load keyring component config. Used for --prepare, --move-back,"
      " --copy-back and --stats. (Deprecated, please use "
-     "--keyring-component-config instead)",
+     "--component-keyring-config instead)",
      &opt_component_keyring_file_config, &opt_component_keyring_file_config, 0,
      GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
@@ -7962,7 +7962,8 @@ int main(int argc, char **argv) {
                   << "Please use --component-keyring-config.";
       exit(EXIT_FAILURE);
     }
-    strcpy(opt_component_keyring_config, opt_component_keyring_file_config);
+    opt_component_keyring_config =
+        static_cast<char *>(opt_component_keyring_file_config);
   }
 
 #ifndef __WIN__


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2721

Adjust a crash by copying opt_component_keyring_file_config to nullptr
opt_component_keyring_config.

Fixed --help to reflect correct keyring component parameter

Adjusted copy-back to not copy component cnf files.