### PR TITLE
PXB-2681 PXB gets stuck during incremental backup prepare of encrypte…

### DIFF
--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -53,8 +53,9 @@ class PersistentTableMetadata;
 struct recv_addr_t;
 
 #ifdef XTRABACKUP
-/** map of tablespace_id, that experienced an inplace DDL during a backup op */
-extern std::map<space_id_t, bool> index_load_map;
+/** map of tablespace_id, that would be full scan during backup with
+ * pagetracking*/
+extern std::map<space_id_t, bool> full_scan_tables;
 
 namespace xtrabackup {
 struct recv_sys_t {

--- a/storage/innobase/xtrabackup/src/read_filt.cc
+++ b/storage/innobase/xtrabackup/src/read_filt.cc
@@ -248,11 +248,11 @@ static void rf_page_tracking_get_next_batch(xb_fil_cur_t *cursor,
    * We read all pages by setting read_batch_len to the size of file */
 
   /* if inplace DDLs that generated MLOG_INDEX_LOAD happened on the table after
-  the checkpoint LSN we do full scan on that table. index_load_map is populated
-  during the first scan of redo */
+  the checkpoint LSN or if tablepace encryption is changed after checkpoint LSN
+  we do full scan full_scan_tables is populated during the first scan of redo */
 
   if (ctxt->space_id == dict_sys_t::s_dict_space_id ||
-      index_load_map[ctxt->space_id] == true) {
+      full_scan_tables[ctxt->space_id] == true) {
     *read_batch_start = ctxt->offset;
     if (ctxt->offset >= ctxt->data_file_size) {
       *read_batch_len = 0;

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
@@ -1,0 +1,61 @@
+############################################################################
+#PXB-2681 PXB crashes with alter encryption='n' happens after the checkpoint
+############################################################################
+
+. inc/common.sh
+. inc/keyring_file.sh
+
+require_debug_server
+
+start_server
+
+vlog "take incremental backup"
+mysql test <<EOF
+CREATE TABLE t1 (i serial) KEY_BLOCK_SIZE=2 ENCRYPTION='Y';
+CREATE TABLESPACE tab02k_e ADD DATAFILE 'tab02k_e.ibd'  FILE_BLOCK_SIZE 02k ENCRYPTION='Y';
+CREATE TABLE t2 (i serial) KEY_BLOCK_SIZE=2 TABLESPACE tab02k_e ENCRYPTION='Y';
+INSERT INTO t2 VALUES(null);
+CREATE TABLE t3 (i serial) KEY_BLOCK_SIZE=2 ENCRYPTION='Y';
+INSTALL COMPONENT "file://component_mysqlbackup";
+SELECT mysqlbackup_page_track_set(1);
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+EOF
+
+xtrabackup --backup --target-dir=$topdir/backup --page-tracking  --transition-key=123
+
+vlog "run alter table"
+
+mysql test <<EOF
+ALTER TABLE t1 ENCRYPTION 'N';
+ALTER TABLESPACE tab02k_e ENCRYPTION 'N';
+ALTER TABLE t3 ENCRYPTION 'N';
+EOF
+
+vlog "take incremental backup"
+xtrabackup --backup --target-dir=$topdir/inc --page-tracking --incremental-basedir=$topdir/backup --transition-key=123
+
+record_db_state test
+
+vlog "restore"
+stop_server
+rm -r $mysql_datadir
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup --transition-key=123
+
+xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc --transition-key=123
+
+vlog "copy back"
+xtrabackup --copy-back --target-dir=$topdir/backup --transition-key=123 \
+               --generate-new-master-key --datadir=$mysql_datadir
+
+start_server
+
+vlog "validate tablespace and table data tablespace"
+verify_db_state test
+mysql test <<EOF
+CREATE TABLE t4 (i serial) KEY_BLOCK_SIZE=2 TABLESPACE tab02k_e;
+INSERT INTO t4 VALUES(null);
+INSERT INTO t2 VALUES(null);
+INSERT INTO t3 VALUES(null);
+EOF


### PR DESCRIPTION
…d tables

https://jira.percona.com/browse/PXB-2681

Problem:
With pagetracking, PXB crashes during prepare of incremental backup if alter
encryption tablespace='y' happens after the checkpoint.

Analysis:
If modifed pages due to change in encryption are not checkpoint, then the list
of those pages would not be available with the page tracking, and it relies on
redo to apply those changes to the tablespace. The redo apply on page 0 reset
the in-memory encryption, and because of that, remaining pages could not be
decrypted as it doesn't have encryption information.

Fix:
ALTER tablespace encryption='y' DDL forcefully flushes all the pages to disk at
the end. If this alter happens after the checkpoint, PXB scans complete ibd to
know the modified pages. So it doesn't need to apply redo on page 0 as it has
copied the page