### PR TITLE
PXB-2702 Backup fails when undo truncation log is present

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -25,6 +25,7 @@ extern bool innodb_log_checksums_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern bool opt_lock_ddl_per_table;
+extern bool opt_lock_ddl;
 extern bool redo_catchup_completed;
 extern bool opt_page_tracking;
 extern char *xtrabackup_incremental;

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1051,6 +1051,10 @@ bool is_active_truncate_log_present(space_id_t space_num) {
   truncate action was complete. */
 
   if (os_file_exists(log_file_name)) {
+#ifdef XTRABACKUP
+    if (srv_backup_mode) return (true);
+#endif
+
     bool ret;
     pfs_os_file_t handle = os_file_create_simple_no_error_handling(
         innodb_log_file_key, log_file_name, OS_FILE_OPEN, OS_FILE_READ_WRITE,


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2702

Problem:
Backup fails if there is left over undo truncation(_truc.log) file
present in server data/undo directory.

Analysis:
Due to some bugs in MySQL truncation process does not complete,
leaving MySQL instance alive, but with undo truncation logs present.
PXB during backup tries to fix that by invoking srv_undo_tablespace_fixup_num
on server data/undo directory.

Fix:
PXB should not create undo file on server at any circumstances.
Avoid creating any undo file on server during backup.
PXB backup fails if undo truncation happens during backup

Thank you Dmitry Smal for your contribution for initial patch.