### PR TITLE
Fixed 8.0.29 INSTANT corruption

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1,6 +1,6 @@
 /******************************************************
 hot backup tool for InnoDB
-(c) 2009-2021 Percona LLC and/or its affiliates
+(c) 2009-2022 Percona LLC and/or its affiliates
 Originally Created 3/3/2009 Yasufumi Kinoshita
 Written by Alexey Kopytov, Aleksandr Kuzminsky, Stewart Smith, Vadim Tkachenko,
 Yasufumi Kinoshita, Ignacio Nin and Baron Schwartz.
@@ -2356,4 +2356,42 @@ void check_dump_innodb_buffer_pool(MYSQL *connection) {
              original_innodb_buffer_pool_dump_pct);
     xb_mysql_query(mysql_connection, change_bp_dump_pct_query, false);
   }
+}
+
+/* print tables that have INSTANT ADD/DROP column row version
+ * @param[in]   connection  MySQL connection handler
+ * @return true if tables with row versions > 0 */
+bool print_instant_versioned_tables(MYSQL *connection) {
+  /* PS not affected by INSTANT issues. Upstream only affected on 8.0.29+ */
+  if (server_flavor == FLAVOR_PERCONA_SERVER || mysql_server_version < 80029)
+    return false;
+
+  bool ret = false;
+  my_ulonglong rows_count = 0;
+  MYSQL_RES *result =
+      xb_mysql_query(connection,
+                     "SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLES WHERE "
+                     "TOTAL_ROW_VERSIONS > 0",
+                     true, true);
+
+  if (result) {
+    rows_count = mysql_num_rows(result);
+    if (rows_count > 0) {
+      MYSQL_ROW row;
+      ret = true;
+      xb::error()
+          << "Found tables with row versions due to INSTANT ADD/DROP columns";
+      xb::error()
+          << "This feature is not stable and will cause backup corruption.";
+      xb::error() << "Tables found:";
+      while ((row = mysql_fetch_row(result)) != NULL) {
+        xb::error() << row[0];
+      }
+      xb::error()
+          << "Please run OPTIMIZE TABLE or ALTER TABLE ALGORITHM=COPY on "
+             "all listed tables to fix this issue.";
+    }
+    mysql_free_result(result);
+  }
+  return ret;
 }

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2021 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2022 Percona LLC and/or its affiliates.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -267,5 +267,9 @@ void dump_innodb_buffer_pool(MYSQL *connection);
 
 void check_dump_innodb_buffer_pool(MYSQL *connection);
 
+/* print tables that have INSTANT ADD/DROP column row version
+ * @param[in]   connection  MySQL connection handler
+ * @return true if tables with row versions > 0 */
+bool print_instant_versioned_tables(MYSQL *connection);
 extern log_status_t log_status;
 #endif

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -4083,6 +4083,8 @@ void xtrabackup_backup_func(void) {
 
   init_mysql_environment();
 
+  if (print_instant_versioned_tables(mysql_connection)) exit(EXIT_FAILURE);
+
   if (opt_dump_innodb_buffer_pool) {
     dump_innodb_buffer_pool(mysql_connection);
   }

--- a/storage/innobase/xtrabackup/test/t/instant_columns.sh
+++ b/storage/innobase/xtrabackup/test/t/instant_columns.sh
@@ -1,0 +1,121 @@
+require_debug_server
+require_server_version_higher_than 8.0.28
+is_server_version_higher_than 8.0.29 && die "This test should be modified after 8.0.30"
+# run instant tests.
+# pass 1 as first parameter if we are expected to abort the backup
+function run_instant_test()
+{
+  expect_failure=$1
+  backup_folder=${topdir}/backup
+  mkdir ${backup_folder}
+  start_server
+
+  # Test 1 - corruption after INSTANT DROP COLUMN
+  echo "
+CREATE TABLE t1 (
+col1 VARCHAR(10) NOT NULL,
+col2 char(13),
+col3 char(10),
+col4 char(10),
+col5 char(10),
+col6 varchar(13),
+PRIMARY KEY (col1)
+) ENGINE=InnoDB;
+INSERT INTO t1  VALUES ('4545', '22', '52', '53','54', '56');
+ALTER TABLE t1 DROP COLUMN col2, DROP COLUMN col3, DROP COLUMN col4, DROP COLUMN col5, LOCK=DEFAULT, ALGORITHM=INSTANT;
+SET GLOBAL innodb_buf_flush_list_now=ON;
+SET GLOBAL innodb_log_checkpoint_now=ON;
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=true;
+UPDATE t1 SET col6 = '57' WHERE col1 = '4545';" | $MYSQL $MYSQL_ARGS -Ns test
+
+  if [[ "${expect_failure}" -eq 1 ]];
+  then
+    run_cmd_expect_failure xtrabackup --backup --target-dir=${backup_folder} 2>&1 | tee $topdir/pxb.log
+    grep "Found tables with row versions due to INSTANT ADD/DROP columns" $topdir/pxb.log || die "missing error message"
+    rm $topdir/pxb.log
+  else
+    xtrabackup --backup --target-dir=${backup_folder}
+    xtrabackup --prepare --target-dir=${backup_folder}
+    echo "SET GLOBAL innodb_checkpoint_disabled=false;
+    SET GLOBAL innodb_page_cleaner_disabled_debug=false;" | $MYSQL $MYSQL_ARGS -Ns
+    checksum1=`checksum_table test t1`
+    stop_server
+    rm -rf ${mysql_datadir}
+    xtrabackup --move-back --target-dir=${backup_folder}
+    start_server
+    checksum2=`checksum_table test t1`
+    $MYSQL $MYSQL_ARGS -s -e "select * from t1;" test
+
+    vlog "Old checksum: $checksum1"
+    vlog "New checksum: $checksum2"
+
+    if [ "$checksum1" != "$checksum2" ]; then
+    vlog "Checksums do not match"
+    exit -1
+    fi
+  fi
+  rm -rf ${backup_folder}
+  echo "DROP TABLE t1" | $MYSQL $MYSQL_ARGS -Ns test
+
+  # Test 2 - combine ADD/DROP in single ALTER
+echo "CREATE TABLE t1 (
+  col1 VARCHAR(10) NOT NULL,
+  col2 char(13),
+  col3 char(13),
+  col5 char(13),
+  col6 char(13),
+  col7 char(13),
+  col8 char(10),
+  col9 char(10),
+  PRIMARY KEY (col1)
+) ENGINE=InnoDB;
+
+INSERT INTO t1  VALUES ('1', '22', '33', '55', '66', '77', '88', '99');
+ALTER TABLE t1 ADD COLUMN col4 char(5) AFTER col3, DROP COLUMN col7, LOCK=DEFAULT, ALGORITHM=INSTANT;
+UPDATE t1 SET col4 = '44' WHERE col1 = '1';
+
+SET GLOBAL innodb_buf_flush_list_now=ON;
+SET GLOBAL innodb_log_checkpoint_now=ON;
+
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=true;
+UPDATE t1 SET col4 = '4', col6='6', col8='8' WHERE col1 = '1';" | $MYSQL $MYSQL_ARGS -Ns test
+
+if [[ "${expect_failure}" -eq 1 ]];
+then
+  run_cmd_expect_failure xtrabackup --backup --target-dir=${backup_folder} 2>&1 | tee $topdir/pxb.log
+  grep "Found tables with row versions due to INSTANT ADD/DROP columns" $topdir/pxb.log || die "missing error message"
+  rm $topdir/pxb.log
+else
+  xtrabackup --backup --target-dir=${backup_folder}
+  xtrabackup --prepare --target-dir=${backup_folder}
+  echo "SET GLOBAL innodb_checkpoint_disabled=false;
+  SET GLOBAL innodb_page_cleaner_disabled_debug=false;" | $MYSQL $MYSQL_ARGS -Ns
+  checksum1=`checksum_table test t1`
+  stop_server
+  rm -rf ${mysql_datadir}
+  xtrabackup --move-back --target-dir=${backup_folder}
+  start_server
+  checksum2=`checksum_table test t1`
+  $MYSQL $MYSQL_ARGS -s -e "select * from t1;" test
+
+  vlog "Old checksum: $checksum1"
+  vlog "New checksum: $checksum2"
+
+  if [ "$checksum1" != "$checksum2" ]; then
+  vlog "Checksums do not match"
+  exit -1
+  fi
+fi
+rm -rf ${backup_folder}
+echo "DROP TABLE t1" | $MYSQL $MYSQL_ARGS -Ns test
+}
+
+vlog "XTRADB: ${XTRADB_VERSION}"
+if is_xtradb;
+then
+  run_instant_test 0
+else
+  run_instant_test 1
+fi


### PR DESCRIPTION
New ALTER TABLE ADD/DROP COLUMN ALGORITHM=INSTANT currently has a
mismatch between logical and physical position of columns metadata and
row values written into redo log, making it impossible to reconstruct
data at crash recovery (--prepare).
For PS we have fixed the issue, however users using upstream MySQL
version 8.0.29 still have this issue.
We adjusted backup function to bail-out in case we find tables with
row version and instructed users to run alter/optimize table to fix it.