### PR TITLE
PXB-2809 wsrep_sync_wait<>0 causes Lock wait timeout exceeded; try re…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -189,6 +189,12 @@ xb_mysql_connect()
 	xb_mysql_query(connection, "SET NAMES utf8",
 		       false, true);
 
+	if (xb_mysql_numrows(connection, "SELECT @@wsrep_sync_wait", false) >
+				0) {
+		xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false,
+				true);
+	}
+
 	return(connection);
 }
 


### PR DESCRIPTION
…starting transaction

https://jira.percona.com/browse/PXB-2809

Problem:
wsrep_sync_wait<>0 causes Lock wait timeout exceeded; try restarting
transaction

Fix:
SET SESSION wsrep_sync_wait=0 right after connection to PXC