### PR TITLE
Fixed PXB-2810 (Panic when AIO initialization failed)

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3551,16 +3551,21 @@ static void xtrabackup_destroy_datasinks(void) {
 
 /************************************************************************
 Initializes the I/O and tablespace cache subsystems. */
-static void xb_fil_io_init(void)
+static bool xb_fil_io_init(void)
 /*================*/
 {
   srv_n_file_io_threads = srv_n_read_io_threads;
 
-  os_aio_init(srv_n_read_io_threads, srv_n_write_io_threads);
+  if (!os_aio_init(srv_n_read_io_threads, srv_n_write_io_threads)) {
+    xb::error() << "Cannot initialize AIO sub-system.";
+    return false;
+  }
 
   fil_init(LONG_MAX);
 
   fsp_init();
+
+  return true;
 }
 
 /****************************************************************************
@@ -3634,7 +3639,11 @@ ulint xb_data_files_init(void)
 /*====================*/
 {
   os_create_block_cache();
-  xb_fil_io_init();
+
+  if (!xb_fil_io_init()) {
+    return DB_IO_ERROR;
+  }
+
   undo_spaces_init();
 
   return (xb_load_tablespaces());
@@ -4265,7 +4274,9 @@ void xtrabackup_backup_func(void) {
 
   os_create_block_cache();
 
-  xb_fil_io_init();
+  if (!xb_fil_io_init()) {
+    exit(EXIT_FAILURE);
+  }
 
   Redo_Log_Data_Manager redo_mgr;
 


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2810

Problem:
xb_fil_io_init does not return an error when os_aio_init fail to
initialize causing the backup to crash.

Fix:
Adjust xb_fil_io_init and function depending on it to properly handle
initialization errors.

Thanks to Yan Huang for the patch.

Closes #1346 