### PR TITLE
Fixed PXB-2517 - Check if files-from is successfully closed before rsync

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1156,7 +1156,11 @@ bool backup_files(const char *from, bool prep_mode) {
       rsync_list.insert("ib_lru_dump");
     }
 
-    fclose(rsync_tmpfile);
+    fflush(rsync_tmpfile);
+    if (fclose(rsync_tmpfile) != 0) {
+      xb::error() << "can't close file " << rsync_tmpfile_name;
+      return (false);
+    }
     rsync_tmpfile = NULL;
 
     cmd << "rsync -t . --files-from=" << rsync_tmpfile_name << " "


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2517

Issue
When hard disks ard under heavy workload, `fclose() ` of
`xtrabackup_rsyncfiles_pass` may fail.
And the content of any unwritten output buffer will be lost.
So `rsync` will fail due to incomplete `--files-from` or synchronize
incomplete file list.

Solution
Call fflush before flcose and check if files-from is successfully
closed before rsync.

Thanks to Garen Chan for the patch.

Closes #1100 