### PR TITLE
Fixed PXB-2840 (Create bucket does not work with regional endpoint)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -391,6 +391,15 @@ Http_buffer S3_client::download_object(const std::string &bucket,
 bool S3_client::create_bucket(const std::string &name) {
   Http_request req(Http_request::PUT, protocol, hostname(name),
                    bucketname(name) + "/");
+
+  if (default_s3_region != region) {
+    req.append_payload(
+        "<CreateBucketConfiguration "
+        "xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/"
+        "\"><LocationConstraint>");
+    req.append_payload(region);
+    req.append_payload("</LocationConstraint></CreateBucketConfiguration>");
+  }
   signer->sign_request(hostname(name), name, req, time(0));
 
   Http_response resp;

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -29,6 +29,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 namespace xbcloud {
 
+static char *default_s3_region __attribute__((unused)) = (char *)"us-east-1";
+
 class S3_response {
  private:
   bool error_{false};

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1247,7 +1247,8 @@ int main(int argc, char **argv) {
     container_name = opt_swift_container;
 
   } else if (opt_storage == S3) {
-    std::string region = opt_s3_region != nullptr ? opt_s3_region : "us-east-1";
+    std::string region =
+        opt_s3_region != nullptr ? opt_s3_region : default_s3_region;
     std::string access_key =
         opt_s3_access_key != nullptr ? opt_s3_access_key : "";
     std::string secret_key =


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2840

Problem:
When specifying a non existing bucket, xbcloud will attempt to create
it. If we are using a non-default region (--s3-region=...) xbcould will
be using a regional endpoint (either by computing it or via
-s3-endpoint= parameter). Non default endpoint requires location
constraint to be set at bucket creation:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html#API_CreateBucket_RequestBody

Fix:
Adjust S3_client::create_bucket to properly set LocationConstraint on
API request.

Thanks to Jason Zareski for the patch.

Closes #882 