### PR TITLE
Fixed PXB-2844 (Adjust logic to detect multi-threaded slave)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -493,7 +493,7 @@ bool get_mysql_vars(MYSQL *connection) {
   }
 
   if (slave_parallel_workers_var != NULL &&
-      atoi(slave_parallel_workers_var) > 0) {
+      atoi(slave_parallel_workers_var) > 1) {
     have_multi_threaded_slave = true;
   }
 


### PR DESCRIPTION
Adjust logic to detect multi-threaded slave

Problem:
MySQL 8.0.30 deprecated setting slave_parallel_workers or
replica_parallel_workers to 0. Setting those variables to 1 has the same
effect (replication is single threaded).
PXB code to detect multithreaded was enabling MTS validation in case
parallel workes was equal to 1.

Fix:
Adjust the validation to only enable MTS if slave_parallel_workers or
replica_parallel_workers are higher than 1.