### PR TITLE
PXB-1331 fix compatibility issue on Galera 4 (MySQL 8)

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1091,7 +1091,12 @@ bool lock_tables_ftwrl(MYSQL *connection) {
   }
 
   if (have_galera_enabled) {
-    xb_mysql_query(connection, "SET SESSION wsrep_causal_reads=0", false);
+    /* Deprecated since MySQL-wsrep 5.5.42-25.12 and removed in 8.0 */
+    if (server_flavor == FLAVOR_MYSQL && mysql_server_version >= 80000) {
+      xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false);
+    } else {
+      xb_mysql_query(connection, "SET SESSION wsrep_causal_reads=0", false);
+    }
   }
 
   xb_mysql_query(connection, "FLUSH TABLES WITH READ LOCK", false);


### PR DESCRIPTION
Hi Percona team! :wave: 

This PR fixes the long-standing issue [PXB-1331](https://jira.percona.com/browse/PXB-1331). This is necessary to make xtrabackup work properly on Galera 4 (MySQL 8).

The [wsrep_causal_reads](https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-causal-reads) parameter was already deprecated in MySQL-wsrep 5.5.42-25.12. This fix is simple: just replace it with [wsrep_sync_wait](https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-sync-wait).

This PR was tested on the following software releases:
mysql-wsrep-8.0-8.0.28-26.10.el7.x86_64
percona-xtrabackup-80-8.0.29-22.1.el7.x86_64

Without this patch the following error may be shown during a SST:

```
2022-09-02T21:44:04.395958+02:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH NO_WRITE_TO_BINLOG TABLES...
2022-09-02T21:44:04.545438+02:00 0 [Note] [MY-011825] [Xtrabackup] Executing FLUSH TABLES WITH READ LOCK...
2022-09-02T21:44:04.546972+02:00 0 [ERROR] [MY-011825] [Xtrabackup] failed to execute query 'SET SESSION wsrep_causal_reads=0' : 1193 (HY000) Unknown system variable 'wsrep_causal_reads'
```

Thanks
- Frank