### PR TITLE
PERCONA_SCHEMA.xtrabackup_history CHARACTER SET

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1887,7 +1887,7 @@ bool write_xtrabackup_info(MYSQL *connection) {
                  "compact ENUM('Y', 'N') DEFAULT NULL,"
                  "compressed ENUM('Y', 'N') DEFAULT NULL,"
                  "encrypted ENUM('Y', 'N') DEFAULT NULL"
-                 ") CHARACTER SET utf8 ENGINE=innodb",
+                 ") CHARACTER SET utf8mb4 ENGINE=innodb",
                  false);
 
   /* Upgrade from previous versions */
@@ -1895,6 +1895,10 @@ bool write_xtrabackup_info(MYSQL *connection) {
                  "ALTER TABLE PERCONA_SCHEMA.xtrabackup_history MODIFY COLUMN "
                  "binlog_pos TEXT DEFAULT NULL",
                  false);
+  xb_mysql_query(connection,
+                 "ALTER TABLE PERCONA_SCHEMA.xtrabackup_history CONVERT TO "
+                 "CHARACTER SET utf8mb4",
+                 false);  
 
   stmt = mysql_stmt_init(connection);
 


### PR DESCRIPTION
xtrabackup_history is using "utf8".

With "utf8" being an alias and Oracle modifying back and forward this alias to utf8mb3, utf8mb4, I think it makes sense to use the full charset name. 

We also should use "utf8mb4" as a future-proof option and convert existing tables.