### PR TITLE
Implemented PXB-2866 Make PXB 8.0.30 be able to backup 8.0.29 (and pr…

### DIFF
--- a/storage/innobase/include/log0pre_8_0_30.h
+++ b/storage/innobase/include/log0pre_8_0_30.h
@@ -125,6 +125,14 @@ bool files_validate_format(const Log_files_context &files_ctx,
                            const ut::vector<Log_file_id_and_header> &files,
                            Log_format &format);
 
+#ifdef XTRABACKUP
+/** Find the latest checkpoint in ib_logfile0.
+@param[in]      file_handle     handle for ib_logfile0 log file
+@param[in/out]  checkpoint      the latest checkpoint found (if any)
+@return true if any checkpoint has been found */
+bool recv_find_max_checkpoint(Log_file_handle &file_handle,
+                              Checkpoint_header &chkp_header);
+#endif  // XTRABACKUP
 }  // namespace log_pre_8_0_30
 
 #endif /* log0pre_8_0_30_h */

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -31,6 +31,7 @@ extern bool opt_page_tracking;
 extern char *xtrabackup_incremental;
 extern lsn_t incremental_start_checkpoint_lsn;
 extern lsn_t xtrabackup_start_checkpoint;
+extern Log_format xtrabackup_original_log_format;
 extern bool use_dumped_tablespace_keys;
 
 extern std::vector<ulint> invalid_encrypted_tablespace_ids;

--- a/storage/innobase/log/log0files_finder.cc
+++ b/storage/innobase/log/log0files_finder.cc
@@ -396,8 +396,14 @@ Log_files_find_result log_files_find_and_analyze(
                                            LOG_HEADER_FLAG_FILE_FULL),
                 encryption_metadata);
     } else {
+#ifdef XTRABACKUP
+      files.add(file_sizes[i].m_id, file_sizes[i].m_size_in_bytes,
+                file_headers[i].m_header.m_start_lsn, true,
+                encryption_metadata);
+#else
       files.add(file_sizes[i].m_id, file_sizes[i].m_size_in_bytes, 0, true,
                 encryption_metadata);
+#endif  // XTRABACKUP
     }
   }
 

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1546,7 +1546,8 @@ static dberr_t log_sys_handle_creator(log_t &log) {
                      "read-only mode!";
       return DB_ERROR;
     }
-  } else if (!str_starts_with(creator_name, "MySQL ")) {
+  } else if (!str_starts_with(creator_name, "MySQL ") &&
+             !str_starts_with(creator_name, "xtrabkup ")) {
     ib::warn(ER_IB_MSG_LOG_FILES_CREATED_BY_UNKNOWN_CREATOR,
              creator_name.c_str());
   }

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1546,8 +1546,7 @@ static dberr_t log_sys_handle_creator(log_t &log) {
                      "read-only mode!";
       return DB_ERROR;
     }
-  } else if (!str_starts_with(creator_name, "MySQL ") &&
-             !str_starts_with(creator_name, "xtrabkup ")) {
+  } else if (!str_starts_with(creator_name, "MySQL ")) {
     ib::warn(ER_IB_MSG_LOG_FILES_CREATED_BY_UNKNOWN_CREATOR,
              creator_name.c_str());
   }

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1138,7 +1138,9 @@ static
       return;
     }
 
-    if (!file.contains(checkpoint_in_file.m_checkpoint_lsn)) {
+    if (IF_XB(log.m_files_ctx.m_files_ruleset >
+              Log_files_ruleset::PRE_8_0_30) &&
+        !file.contains(checkpoint_in_file.m_checkpoint_lsn)) {
       const auto file_path = file_handle.file_path();
       ib::error(ER_IB_MSG_RECOVERY_CHECKPOINT_OUTSIDE_LOG_FILE,
                 ulonglong{checkpoint_in_file.m_checkpoint_lsn},

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1671,6 +1671,9 @@ void log_status_get(MYSQL *conn) {
   ut_ad(!have_unsafe_ddl_tables || tables_locked || instance_locked ||
         opt_no_lock || opt_lock_ddl_per_table);
 
+  if (xtrabackup_register_redo_log_consumer)
+    redo_log_consumer_can_advance.store(false);
+
   const char *query =
       "SELECT server_uuid, local, replication, "
       "storage_engines FROM performance_schema.log_status";

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -151,7 +151,10 @@ static bool reopen_log_files(lsn_t desired_lsn) {
   log.m_files = std::move(files);
   auto file = log.m_files.find(desired_lsn);
   if (file == log.m_files.end()) return false;
-  log_encryption_read(log, *file);
+  if (log_encryption_read(log, *file) != DB_SUCCESS) {
+    xb::error() << "log_encryption_read failed on file ID " << file->m_id;
+    return (false);
+  };
 
   return true;
 }
@@ -984,7 +987,10 @@ bool Redo_Log_Data_Manager::init() {
     xb::error() << " Cannot find file with checkpoint " << checkpoint_lsn;
     return (false);
   }
-  log_encryption_read(*log_sys, *file);
+  if (log_encryption_read(*log_sys, *file) != DB_SUCCESS) {
+    xb::error() << "log_encryption_read failed on file ID " << file->m_id;
+    return (false);
+  };
 
   ut_a(log_sys != nullptr);
 

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -65,11 +65,8 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
   /* Redo log file header is never encrypted. */
   Encryption_metadata unused_encryption_metadata;
 
-  Log_files_context log_files_ctx =
-      Log_files_context{srv_log_group_home_dir, Log_files_ruleset::CURRENT};
-
   auto file_handle =
-      Log_file::open(log_files_ctx, checkpoint.m_checkpoint_file_id,
+      Log_file::open(log_sys->m_files_ctx, checkpoint.m_checkpoint_file_id,
                      Log_file_access_mode::READ_ONLY,
                      unused_encryption_metadata, Log_file_type::NORMAL);
 
@@ -103,17 +100,13 @@ lsn_t Redo_Log_Reader::get_start_checkpoint_lsn() const {
 }
 
 bool Redo_Log_Reader::is_error() const { return (m_error); }
-/* scan redo log files form server directory and update log.m_files */
-static bool reopen_log_files() {
-  log_t &log = *log_sys;
-  Log_files_context log_files_ctx =
-      Log_files_context{srv_log_group_home_dir, Log_files_ruleset::CURRENT};
 
-  std::string subdir_path;
-  bool found_files_in_subdir{false};
-  auto err = log_sys_check_directory(log_files_ctx, subdir_path,
-                                     found_files_in_subdir);
-  log.m_files_ctx = std::move(log_files_ctx);
+/** scan redo log files form server directory and update log.m_files.
+@param[in,out]  desired_lsn             LSN that triggered file reopening.
+@return true if re-open was sucessful */
+
+static bool reopen_log_files(lsn_t desired_lsn) {
+  log_t &log = *log_sys;
 
   Log_files_dict files{log.m_files_ctx};
   Log_format format;
@@ -132,12 +125,10 @@ static bool reopen_log_files() {
   log.m_log_flags = log_flags;
   log.m_log_uuid = log_uuid;
   log.m_files = std::move(files);
-  auto file = log.m_files.front();
-  log_encryption_read(log, file);
+  auto file = log.m_files.find(desired_lsn);
+  if (file == log.m_files.end()) return false;
+  log_encryption_read(log, *file);
 
-  if (err != DB_SUCCESS) {
-    ut_ad(0);
-  }
   return true;
 }
 
@@ -147,7 +138,7 @@ lsn_t Redo_Log_Reader::read_log_seg(log_t &log, byte *buf, lsn_t start_lsn,
 
   // update the in-memory structure log files by scanning
   if (log.m_files.find(start_lsn) == log.m_files.end()) {
-    if (!reopen_log_files()) {
+    if (!reopen_log_files(start_lsn)) {
       // file not found
       m_error = true;
       return 0;
@@ -1187,7 +1178,10 @@ bool Redo_Log_Data_Manager::stop_at(lsn_t lsn, lsn_t checkpoint_lsn) {
 
   /* to ensure redo logs are not disabled during the backup, reopen the log
   files to read HEADER */
-  reopen_log_files();
+  if (!reopen_log_files(lsn)) {
+    xb::error() << "Cannot find file with LSN " << lsn;
+    return (false);
+  }
   log_crash_safe_validate(*log_sys);
 
   scanned_lsn = reader.get_scanned_lsn();

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -103,7 +103,10 @@ class Redo_Log_Reader {
                             const lsn_t end_lsn);
 
   /** checkpoint LSN at the backup start. */
-  lsn_t checkpoint_lsn_start{0};
+  static lsn_t checkpoint_lsn_start;
+
+  /** offset of checkpoint_lsn_start */
+  static os_offset_t checkpoint_offset_start;
 
   /** checkpoint number at the backup start. */
   lsn_t checkpoint_no_start{0};

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -199,6 +199,7 @@ char *xtrabackup_tables_exclude = NULL;
 lsn_t xtrabackup_start_checkpoint;
 
 bool xtrabackup_register_redo_log_consumer = false;
+std::atomic<bool> redo_log_consumer_can_advance = false;
 
 typedef std::list<xb_regex_t> regex_list_t;
 static regex_list_t regex_include_list;
@@ -506,7 +507,7 @@ extern TYPELIB innodb_flush_method_typelib;
 #include "sslopt-vars.h"
 
 bool redo_catchup_completed = false;
-Log_format original_log_format;
+Log_format xtrabackup_original_log_format;
 extern struct rand_struct sql_rand;
 extern mysql_mutex_t LOCK_sql_rand;
 
@@ -5135,7 +5136,7 @@ retry:
   }
 
   log_format = (Log_format)mach_read_from_4(log_buf + LOG_HEADER_FORMAT);
-  original_log_format = log_format;
+  xtrabackup_original_log_format = log_format;
   if (log_format == Log_format::VERSION_8_0_28 ||
       log_format == Log_format::VERSION_8_0_19) {
     // We interpret v4 & v5 as v6 by writting proper start lsn header later in
@@ -6217,7 +6218,8 @@ static bool xtrabackup_replace_log_file(const char *redo_path,
   memset(log_buf + LOG_HEADER_CREATOR, ' ', 4);
 
   /* restore original log format */
-  mach_write_to_4(log_buf + LOG_HEADER_FORMAT, to_int(original_log_format));
+  mach_write_to_4(log_buf + LOG_HEADER_FORMAT,
+                  to_int(xtrabackup_original_log_format));
   success = os_file_write(write_request, src_path, src_file, log_buf, 0,
                           LOG_FILE_HDR_SIZE);
   if (!success) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -224,6 +224,7 @@ extern bool ssl_mode_set_explicitly;
 extern int set_client_ssl_options(MYSQL *mysql);
 
 extern bool xtrabackup_register_redo_log_consumer;
+extern std::atomic<bool> redo_log_consumer_can_advance;
 
 enum binlog_info_enum {
   BINLOG_INFO_OFF,

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -14,7 +14,7 @@ function compare_files() {
 dir1=$1
 dir2=$2
 
-ign_list="(innodb_temp|xtrabackup_binlog_pos_innodb|dblwr|innodb_redo)"
+ign_list="(innodb_temp|xtrabackup_binlog_pos_innodb|dblwr|innodb_redo|ib_logfile)"
 
 # files that present in the backup directory, but not present in the datadir
 diff -u <( ( ( cd $dir1; find . | grep -Ev $ign_list )

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -79,7 +79,7 @@ EOF
 # files that present in the datadir, but not present in the backup
 diff -B -u <( ( ( cd $dir1; find . | grep -Ev $ign_list )
                 ( cd $dir1; find . | grep -Ev $ign_list )
-                ( cd $dir2; find . | grep -Ev "innodb_temp|dblwr|innodb_redo" ) ) | sort | uniq -u ) - <<EOF
+                ( cd $dir2; find . | grep -Ev "innodb_temp|dblwr|innodb_redo|ib_logfile" ) ) | sort | uniq -u ) - <<EOF
 ./auto.cnf
 ./ca-key.pem
 ./ca.pem

--- a/storage/innobase/xtrabackup/test/t/bug1414221.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1414221.sh
@@ -24,3 +24,18 @@ sed -i -e 's/to_lsn = [0-9]*$/to_lsn = 999999999/' \
 vlog "Preparing backup"
 run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
+
+rm -rf ${full_backup_dir}
+
+############################################################################
+# After 8.0.30 running a backup against pre-8.0.30 will skip last block
+# as we are writting LOG_BLOCK_EPOCH_NO instead of LOG_BLOCK_CHECKPOINT_NO
+# If checkpoint falls within the last block, pxb is incorrectly skipping
+# the block
+############################################################################
+
+innodb_wait_for_flush_all
+${MYSQL} ${MYSQL_ARGS} test -e "CREATE TABLE t (a INT) engine=InnoDB"
+${MYSQL} ${MYSQL_ARGS} test -e "INSERT INTO t (a) VALUES (1), (2), (3)"
+xtrabackup --backup --throttle=40 --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir

--- a/storage/innobase/xtrabackup/test/t/pxb-2710-predict_memory.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2710-predict_memory.sh
@@ -6,8 +6,13 @@ require_debug_pxb_version
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb-flush-log-at-trx-commit=0
 sync-binlog=0
-innodb-redo-log-capacity=512M
 "
+if is_server_version_higher_than 8.0.29
+then
+  MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS:-""}
+  innodb-redo-log-capacity=512M
+  "
+fi
 start_server
 backupdir="${topdir}/full"
 backupdir2="${topdir}/full2"
@@ -56,6 +61,13 @@ done
 
 #stop inserting data
 kill -SIGKILL ${insert_pid}
+
+# avoid race condition when we trx is running and backup get it without it been
+# completed, having to roll it back and when we record db state it is completed.
+while mysql -e 'SHOW PROCESSLIST' | grep 'INSERT INTO pxb_2710 SELECT NULL FROM pxb_2710 LIMIT 10000' ; do
+  vlog "waiting for INSERT to complete"
+  sleep 1;
+done
 
 # resume and wait for backup to complete
 vlog "Resuming xtrabackup"

--- a/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
@@ -11,6 +11,8 @@ load_dbase_schema sakila
 load_dbase_data sakila
 mkdir $topdir/backup
 
+#avoid log wrap before we do the first scan
+innodb_wait_for_flush_all
 run_cmd_expect_failure $XB_BIN $XB_ARGS --datadir=$mysql_datadir --backup \
     --lock-ddl=false --innodb_log_file_size=4M --target-dir=$topdir/backup \
     --debug-sync="xtrabackup_copy_logfile_pause" &


### PR DESCRIPTION
…ior) server

https://jira.percona.com/browse/PXB-2866

Adjusted redo log logic to populate start and end lsn of old redo log layout.
Changed redo_log.cc to use log_sys->m_files_ctx instead of creating a new Log_files_context each time. log_sys->m_files_ctx will already have the correct Log_files_ruleset (CURRENT or PRE_8_0_30) that can be used to identify if we are dealing with ib_logfile or #ib_redo layout.

Fixed --prepare warning about redo been created by unknown creator.