### PR TITLE
Pxb 8.0 2809 wsrep_sync_wait<>0 causes Lock wait timeout exceeded; try restarting transaction

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -189,6 +189,12 @@ xb_mysql_connect()
 	xb_mysql_query(connection, "SET NAMES utf8",
 		       false, true);
 
+	if (xb_mysql_numrows(connection, "SELECT @@wsrep_sync_wait", false) >
+				0) {
+		xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false,
+				true);
+	}
+
 	return(connection);
 }
 
@@ -1134,8 +1140,12 @@ lock_tables_maybe(MYSQL *connection, int timeout, int retry_count)
 	}
 
 	if (have_galera_enabled) {
-		xb_mysql_query(connection,
-				"SET SESSION wsrep_causal_reads=0", false);
+		if (xb_mysql_numrows(connection, "SELECT @@wsrep_causal_reads",
+					false) > 0) {
+			xb_mysql_query(connection,
+				"SET SESSION wsrep_causal_reads=0",
+				false);
+		}
 	}
 
 	xb_mysql_query(connection, "FLUSH TABLES WITH READ LOCK", false);


### PR DESCRIPTION
 The wsrep_causal_reads parameter was already deprecated in
    MySQL-wsrep 5.5.42-25.12.
    so use wsrep_sync_wait=0 to avoid lock wait timeout.

    Also for 8.0 GR,PXB now sets group-replication-consistency=EVENTUAL
    to avoid possible time out

    Thanks to Frank Well for providing initial patch