### PR TITLE
Fixed PXB-2858 Prepare of full and incremental backup uses the same a…

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -79,10 +79,10 @@ bool check_if_skip_table(
 extern bool xtrabackup_stats;
 
 /** Amount of memory calculated at --backup for recovery hash records */
-extern size_t redo_memory;
+extern size_t real_redo_memory;
 
 /** Number of total frames that will be required for prepare */
-extern ulint redo_frames;
+extern ulint real_redo_frames;
 
 /** This variables holds the result of all conditions that must be set in order
 to enable estimate memory functionality */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -629,10 +629,10 @@ void recv_sys_init() {
 
 #ifdef XTRABACKUP
   if (estimate_memory) {
-    if (srv_buf_pool_curr_size >= (long long)redo_memory) {
-      if (recv_n_pool_free_frames < redo_frames) {
-        xb::info() << "Setting free frames to " << redo_frames;
-        recv_n_pool_free_frames = redo_frames;
+    if (srv_buf_pool_curr_size >= (long long)real_redo_memory) {
+      if (recv_n_pool_free_frames < real_redo_frames) {
+        xb::info() << "Setting free frames to " << real_redo_frames;
+        recv_n_pool_free_frames = real_redo_frames;
       }
     } else {
       recv_n_pool_free_frames = 0;
@@ -711,7 +711,7 @@ static void recv_sys_empty_hash() {
 
 #ifdef XTRABACKUP
 
-  if (estimate_memory && srv_buf_pool_curr_size < (long long)redo_memory) {
+  if (estimate_memory && srv_buf_pool_curr_size < (long long)real_redo_memory) {
     recv_n_pool_free_frames = 0;
   }
   if (pxb_recv_sys->spaces == nullptr) return;
@@ -2815,7 +2815,7 @@ static void recv_add_to_hash_table(mlog_id_t type, space_id_t space_id,
      * batch, we adjust recv_n_pool_free_frames as we parse each single record.
      * This way we have room to hold all required pages on this batch.
      */
-    if (estimate_memory && recv_n_pool_free_frames != redo_frames) {
+    if (estimate_memory && recv_n_pool_free_frames != real_redo_frames) {
       recv_n_pool_free_frames++;
       max_mem =
           UNIV_PAGE_SIZE * (buf_pool_get_n_pages() -

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2124,6 +2124,8 @@ static bool innodb_init_param(void) {
                     xtrabackup_use_free_memory_pct != 0;
 
   if (estimate_memory) {
+    ut_ad(real_redo_frames != UINT64_MAX);
+
     ulint free_memory_total = xtrabackup::utils::host_free_memory();
     ulint free_memory_usable =
         (free_memory_total * xtrabackup_use_free_memory_pct) / 100;
@@ -2151,9 +2153,9 @@ static bool innodb_init_param(void) {
       }
       xb::info() << "Setting buffer pool to: " << xtrabackup_use_memory;
     }
-    if ((long)redo_frames > innobase_open_files) {
-      xb::info() << "Setting innobase_open_files to: " << redo_frames;
-      innobase_open_files = (long)redo_frames;
+    if ((long)real_redo_frames > innobase_open_files) {
+      xb::info() << "Setting innobase_open_files to: " << real_redo_frames;
+      innobase_open_files = (long)real_redo_frames;
     }
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -264,7 +264,7 @@ ulonglong xtrabackup_encrypt_chunk_size = 0;
 size_t redo_memory = 0;
 ulint redo_frames = 0;
 size_t real_redo_memory = 0;
-ulint real_redo_frames = 0;
+ulint real_redo_frames = UINT64_MAX;
 
 ulint xtrabackup_rebuild_threads = 1;
 


### PR DESCRIPTION
…mount of buffer pool memory with memory estimation

https://jira.percona.com/browse/PXB-2858

Problem:
When preparing incremental backups, we call read_metadata twice. First time we read metadata file from incremental dir, but second time we read it from target-dir (full base backup). The second call was replacing redo_memory & redo_frames variable.

Fix:
Adjusted code to use a variable that gets populated conditionally in case we are doing a prepare on full or inc directory.