### PR TITLE
Fixed PXB-2874 (Issue on --generate-new-master-key)

### DIFF
--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -25,10 +25,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #else
 #include <proc/sysinfo.h>
 #endif
-
+#include <boost/uuid/uuid.hpp>             // uuid class
+#include <boost/uuid/uuid_generators.hpp>  // generators
+#include <boost/uuid/uuid_io.hpp>          // streaming operators etc.
+#include <sstream>
 #include "common.h"
 #include "msg.h"
 #include "xtrabackup.h"
+
+static boost::uuids::random_generator gen = boost::uuids::random_generator();
 
 namespace xtrabackup {
 namespace utils {
@@ -145,6 +150,13 @@ unsigned long host_free_memory() {
   return kb_main_available * 1024;
 }
 #endif
+
+std::string generate_uuid() {
+  boost::uuids::uuid uuid = gen();
+  std::ostringstream uuid_ss;
+  uuid_ss << uuid;
+  return uuid_ss.str();
+}
 
 }  // namespace utils
 }  // namespace xtrabackup

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -46,6 +46,10 @@ unsigned long get_version_number(std::string version_str);
 
 unsigned long host_total_memory();
 unsigned long host_free_memory();
+
+/** Generates uuid
+@return uuid string */
+std::string generate_uuid();
 }  // namespace utils
 }  // namespace xtrabackup
 #endif  // XTRABACKUP_UTILS_H

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -6986,28 +6986,6 @@ static void innodb_free_param() {
   ibt::srv_temp_dir = srv_temp_dir;
 }
 
-/**************************************************************************
-Store current master key ID.
-@return 'false' on error. */
-static bool store_master_key_id(
-    /*==============*/
-    const char *filename) /*!< in: output file name */
-{
-  FILE *fp;
-
-  fp = fopen(filename, "w");
-
-  if (!fp) {
-    xb::error() << "failed to open " << SQUOTE(filename);
-    return (false);
-  }
-
-  fprintf(fp, "%u", Encryption::get_master_key_id());
-  fclose(fp);
-
-  return (true);
-}
-
 static void read_metadata() {
   char metadata_path[FN_REFLEN];
 
@@ -7316,10 +7294,6 @@ skip_check:
 
     destroy_internal_thd(thd);
     my_thread_end();
-  }
-
-  if (!store_master_key_id("xtrabackup_master_key_id")) {
-    exit(EXIT_FAILURE);
   }
 
   /* Check whether the log is applied enough or not. */


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2874

Problem:
When PXB generates a new master key on --copy/move-back we are always reseting the master key id back to 1.

Fix:
Adjusted --generate-new-master-key code to always generate a new MK using a different server uuid.