### PR TITLE
Pxb 8.0 2906 Failed query errors in backup for wsrep_sync_wait and group

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -189,13 +189,14 @@ xb_mysql_connect()
 	xb_mysql_query(connection, "SET NAMES utf8",
 		       false, true);
 
-	if (xb_mysql_numrows(connection, "SELECT @@wsrep_sync_wait", false) >
-				0) {
-		xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false,
-				true);
-	}
+        if (xb_mysql_numrows(connection,
+                             "SHOW GLOBAL VARIABLES LIKE 'wsrep_sync_wait'",
+                             false) > 0) {
+          xb_mysql_query(connection, "SET SESSION wsrep_sync_wait=0", false,
+                         true);
+        }
 
-	return(connection);
+        return(connection);
 }
 
 /*********************************************************************//**


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2906

Changed SELECT @@variable to SHOW GLOBAL variable to avoid errors in backup logs