### PR TITLE
Fixed PXB-2928 - Xtrabackup crashes with signal 11 when taking a backup

### DIFF
--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -59,6 +59,11 @@ struct recv_addr_t;
  * pagetracking*/
 extern std::unordered_set<space_id_t> full_scan_tables;
 
+/* count of tablespaces that will require full table scan. This is calculated
+ * after full_scan_tables is fully populated and should never changed. */
+
+extern size_t full_scan_tables_count;
+
 namespace xtrabackup {
 struct recv_sys_t {
   struct mem_block_t {

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -57,7 +57,7 @@ struct recv_addr_t;
 #ifdef XTRABACKUP
 /** map of tablespace_id, that would be full scan during backup with
  * pagetracking*/
-extern std::map<space_id_t, bool> full_scan_tables;
+extern std::unordered_set<space_id_t> full_scan_tables;
 
 namespace xtrabackup {
 struct recv_sys_t {

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -111,6 +111,8 @@ This set is populated by the redo first scan phase (by a single thread) and
 after the initial parsing is over, we only use it for reads. Hence, it is not
 required to protect with mutex. */
 std::unordered_set<space_id_t> full_scan_tables;
+
+size_t full_scan_tables_count = 0;
 #endif /* XTRABACKUP */
 
 #ifdef UNIV_HOTBACKUP

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -105,8 +105,12 @@ rolling back incomplete transactions. */
 volatile bool recv_recovery_on;
 volatile lsn_t backup_redo_log_flushed_lsn;
 #ifdef XTRABACKUP
-/** map of space_id, that would be full scan during backup with pagetracking */
-std::map<space_id_t, bool> full_scan_tables;
+/* List of tablespaces that should be copied fully. Even if page tracking is
+active, the tablespaces in this list will be fully copied to backup directory.
+This set is populated by the redo first scan phase (by a single thread) and
+after the initial parsing is over, we only use it for reads. Hence, it is not
+required to protect with mutex. */
+std::unordered_set<space_id_t> full_scan_tables;
 #endif /* XTRABACKUP */
 
 #ifdef UNIV_HOTBACKUP
@@ -1843,7 +1847,7 @@ static byte *recv_parse_or_apply_log_rec_body(
           // re-copying the datafiles.
           if (opt_page_tracking && xtrabackup_incremental != nullptr &&
               recv_sys->recovered_lsn > incremental_start_checkpoint_lsn) {
-            full_scan_tables[space_id] = true;
+            full_scan_tables.insert(space_id);
           }
           /* offline backup */
           xb::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
@@ -1888,7 +1892,7 @@ static byte *recv_parse_or_apply_log_rec_body(
           tablespace. */
           if (opt_page_tracking && xtrabackup_incremental != nullptr &&
               recv_sys->recovered_lsn > incremental_start_checkpoint_lsn) {
-            full_scan_tables[space_id] = true;
+            full_scan_tables.insert(space_id);
           }
 #endif /* XTRABACKUP */
 

--- a/storage/innobase/xtrabackup/src/read_filt.cc
+++ b/storage/innobase/xtrabackup/src/read_filt.cc
@@ -252,7 +252,7 @@ static void rf_page_tracking_get_next_batch(xb_fil_cur_t *cursor,
   we do full scan full_scan_tables is populated during the first scan of redo */
 
   if (ctxt->space_id == dict_sys_t::s_dict_space_id ||
-      full_scan_tables[ctxt->space_id] == true) {
+      full_scan_tables.find(ctxt->space_id) != full_scan_tables.end()) {
     *read_batch_start = ctxt->offset;
     if (ctxt->offset >= ctxt->data_file_size) {
       *read_batch_len = 0;

--- a/storage/innobase/xtrabackup/src/read_filt.cc
+++ b/storage/innobase/xtrabackup/src/read_filt.cc
@@ -253,6 +253,7 @@ static void rf_page_tracking_get_next_batch(xb_fil_cur_t *cursor,
 
   if (ctxt->space_id == dict_sys_t::s_dict_space_id ||
       full_scan_tables.find(ctxt->space_id) != full_scan_tables.end()) {
+    ut_ad(full_scan_tables_count == full_scan_tables.size());
     *read_batch_start = ctxt->offset;
     if (ctxt->offset >= ctxt->data_file_size) {
       *read_batch_len = 0;
@@ -260,6 +261,7 @@ static void rf_page_tracking_get_next_batch(xb_fil_cur_t *cursor,
     }
     *read_batch_len = ctxt->data_file_size - ctxt->offset;
   } else {
+    ut_ad(full_scan_tables_count == full_scan_tables.size());
     /* if no page changed for given space return */
     if (!changed_page_tracking->count(ctxt->space_id)) {
 #ifdef UNIV_DEBUG

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1237,6 +1237,7 @@ bool Redo_Log_Data_Manager::start() {
    * in any situation (with or without --lock-ddl-per-table).
    */
   redo_catchup_completed = true;
+  full_scan_tables_count = full_scan_tables.size();
 
   if (opt_lock_ddl) {
     ut_ad(reader.get_scanned_lsn() >= backup_redo_log_flushed_lsn);


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2928

Problem:
When page tracking is used, we need to build a list of tables that will
require to be fully copied. For this list we use a std::map during the
initial scan of redo logs, which is guaranteed to be single thread and
later use the operator[] to check if a given space id needs to be fully
copied. The access to this map is done in multiple threads but since
all threads only read from it this was assumed to be thread safe.
However, std::map::operator[] will create the accessed key if it does
not exists. This will lead to copy threads populating the map which can
lead to crash.

Fix:
Adjusted the map to use std::unordered_set as we only need the space_id.
This set is populated by the redo first scan phase (by a single thread)
and after the initial parsing is over, we only use it for reads. Hence,
it is not required to protect with mutex.
Lookup is done by find() operator which does not modify the content of
the set and only access for reading.