### PR TITLE
 PXB-2925 Redo start_lsn doesn't match with redo file start LSN

### DIFF
--- a/storage/innobase/include/log0files_dict.h
+++ b/storage/innobase/include/log0files_dict.h
@@ -144,6 +144,14 @@ class Log_files_dict {
   @param[in]  file_id         id of the log file */
   void set_incomplete(Log_file_id file_id);
 
+#ifdef XTRABACKUP
+  /** Changes start_lsn of the file. Updates m_end_lsn accordingly.
+  @param[in]  file_id         id of the log file
+  @param[in]  start_lsn       new_start_lsn
+  */
+  void set_lsn(Log_file_id file_id, lsn_t start_lsn);
+#endif
+
   /** Changes size of the file. Updates m_end_lsn accordingly.
   @param[in]  file_id         id of the log file
   @param[in]  new_size        new size (expressed in bytes) */

--- a/storage/innobase/include/log0files_io.h
+++ b/storage/innobase/include/log0files_io.h
@@ -562,6 +562,24 @@ inline uint32_t log_block_convert_lsn_to_hdr_no(lsn_t lsn) {
          static_cast<uint32_t>(lsn / OS_FILE_LOG_BLOCK_SIZE % LOG_BLOCK_MAX_NO);
 }
 
+#ifdef XTRABACKUP
+/** Convert block header number to LSN
+@param[in] header_num		log_block_number
+@param[in] start_lsn		the current start_LSN set in system
+@return LSN number */
+inline lsn_t log_block_convert_hdr_to_lsn_no(uint32_t header_num,
+                                             lsn_t start_lsn) {
+  ut_ad(header_num <= LOG_BLOCK_MAX_NO);
+
+  uint32_t round_off =
+      static_cast<uint32_t>(start_lsn / OS_FILE_LOG_BLOCK_SIZE /
+                            LOG_BLOCK_MAX_NO) +
+      1;
+  return header_num * OS_FILE_LOG_BLOCK_SIZE * round_off -
+         OS_FILE_LOG_BLOCK_SIZE;
+}
+#endif /* XTRABACKUP */
+
 /** Calculates the checksum for a log block.
 @param[in]	log_block	log block
 @return checksum */

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -32,6 +32,7 @@ extern char *xtrabackup_incremental;
 extern lsn_t incremental_start_checkpoint_lsn;
 extern lsn_t xtrabackup_start_checkpoint;
 extern bool use_dumped_tablespace_keys;
+extern unsigned long xb_backup_version;
 extern bool xb_generated_redo;
 
 extern std::vector<ulint> invalid_encrypted_tablespace_ids;

--- a/storage/innobase/log/log0files_dict.cc
+++ b/storage/innobase/log/log0files_dict.cc
@@ -148,6 +148,22 @@ void Log_files_dict::set_incomplete(Log_file_id file_id) {
   it->second.m_full = false;
 }
 
+#ifdef XTRABACKUP
+void Log_files_dict::set_lsn(Log_file_id file_id, lsn_t start_lsn) {
+  const auto it = m_files_by_id.find(file_id);
+  ut_a(it != m_files_by_id.end());
+  auto &meta_info = it->second;
+
+  meta_info.m_start_lsn =
+      ut_uint64_align_down(start_lsn, OS_FILE_LOG_BLOCK_SIZE);
+  ut_a(meta_info.m_start_lsn > 0);
+
+  const bool success = log_file_compute_end_lsn(
+      meta_info.m_start_lsn, meta_info.m_size_in_bytes, meta_info.m_end_lsn);
+  ut_a(success);
+}
+#endif  // XTRABACKUP
+
 void Log_files_dict::set_size(Log_file_id file_id, os_offset_t new_size) {
   const auto it = m_files_by_id.find(file_id);
   ut_a(it != m_files_by_id.end());

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -92,6 +92,8 @@ char tool_args[2048];
 /* mysql flavor and version */
 mysql_flavor_t server_flavor = FLAVOR_UNKNOWN;
 unsigned long mysql_server_version = 0;
+/* the version of xtrabackup used during the backup */
+unsigned long xb_backup_version = 0;
 
 /* server capabilities */
 bool have_changed_page_bitmaps = false;

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -81,8 +81,11 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
     log_scanned_lsn = checkpoint.m_checkpoint_lsn;
     checkpoint_lsn_start = checkpoint.m_checkpoint_lsn;
 
+    debug_sync_point("stop_before_copy_log_hdr");
+
     /* Copy the header into log_hdr_buf */
     file_handle.read(0, LOG_FILE_HDR_SIZE, log_hdr_buf);
+
   } else {
     const auto logfile0 = log_sys->m_files.file(0);
     auto file_handle = logfile0->open(Log_file_access_mode::READ_ONLY);
@@ -100,9 +103,13 @@ bool Redo_Log_Reader::find_start_checkpoint_lsn() {
     checkpoint_lsn_start = chkp_header.m_checkpoint_lsn;
     checkpoint_offset_start = chkp_header.m_checkpoint_offset;
 
+    debug_sync_point("stop_before_copy_log_hdr");
+
     /* Copy the header into log_hdr_buf */
     file_handle.read(0, LOG_FILE_HDR_SIZE, log_hdr_buf);
   }
+  /* update the headers to store the current checkpoint LSN */
+  update_log_temp_checkpoint(log_hdr_buf, checkpoint_lsn_start);
 
   return (true);
 }

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -331,4 +331,9 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
                         void *data); /*!<in: additional argument for
                                      callback */
 
+/** update the checkpoint and recalculate the checksum of log header
+@param[in,out]	buf		log header buffer
+@param[in]	lsn		lsn to update */
+void update_log_temp_checkpoint(byte *buf, lsn_t lsn);
+
 #endif /* XB_XTRABACKUP_H */

--- a/storage/innobase/xtrabackup/test/t/stop_before_copy_log_hdr.sh
+++ b/storage/innobase/xtrabackup/test/t/stop_before_copy_log_hdr.sh
@@ -1,0 +1,41 @@
+########################################################################
+# check if PXB can set the start LSN
+# ########################################################################
+. inc/common.sh
+
+require_debug_pxb_version
+
+start_server
+
+function run_inserts()
+{
+  for i in $(seq 100);
+  do
+    $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t1 VALUES (NULL, REPEAT('a', 63 * 1024))";
+  done
+}
+
+mysql -e "CREATE TABLE t1 (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  str BLOB
+);" test
+
+xtrabackup --backup --target-dir=$topdir/backup --debug=d,simulate_backup_lower_version \
+  --debug-sync="stop_before_copy_log_hdr" \
+  2> >( tee $topdir/backup_before_redo_register.log)&
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+echo "backup pid is $job_pid"
+
+run_inserts
+innodb_wait_for_flush_all
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup


### PR DESCRIPTION
 PXB-2925 Redo start_lsn doesn't match with redo file start LSN
    https://jira.percona.com/browse/PXB-2925

    Problem:
    During the prepare phase start_lsn of redo file does not match with first lsn in redo
    file

    Analysis:
    During backup phase, PXB first reads the checkpoint LSN(say LSN A) from redo
    files and then copies the checkpoint header having checkpoint LSN (LSN B)
    from redo file.
    If server does a checkpoint after PXB read the checkpoint LSN and before
    PXB copies the checkpoint header, then LSN A would be differnt from LSN B

    During backup phase, PXB copies redo logs starting from LSN A.
    But during prepare phase, PXB was setting redo file start LSN using checkpoint
    header (LSN B).

    Fix:

    For the backup phase, PXB now update the in memory checkpoint HEADER to store
    the checkpoint LSN(LSN A).

    For the older backup(Backup taken with PXB 8.0.30), We fixed the prepare code.
    PXB now calculates the redo file first LSN and then sets the start LSN
    with the first LSN.

    changed temporary variable mysql_server_version to xb_server_version as
    there is global variable mysql_server_version
    Added new variable xb_backup_version to know the version of xtrabackup
    used during the backup