### PR TITLE
PXB-2959 - OpenSSL 3.0 deprecation warnings

### DIFF
--- a/components/keyrings/keyring_kms/backend/kms.cc
+++ b/components/keyrings/keyring_kms/backend/kms.cc
@@ -30,6 +30,9 @@
 #include <sstream>
 #include <string>
 
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
 #ifdef RAPIDJSON_NO_SIZETYPEDEFINE
 // if we build within the server, it will set RAPIDJSON_NO_SIZETYPEDEFINE
 // globally and require to include my_rapidjson_size_t.h
@@ -59,6 +62,15 @@ const constexpr auto AWS_SIGNATURE_ALGORITHM = "AWS4-HMAC-SHA256";
 const constexpr auto AWS_STORAGE_CLASS_HEADER = "X-Amz-Storage-Class";
 
 namespace aws {
+
+std::vector<unsigned char> sha256_ex(const unsigned char *ptr,
+                                     std::size_t len) {
+  std::vector<unsigned char> md(SHA256_DIGEST_LENGTH);
+
+  SHA256(ptr, len, md.data());
+
+  return md;
+}
 
 std::string hmac_sha256(std::string const &decodedKey, std::string const &msg) {
   std::array<unsigned char, EVP_MAX_MD_SIZE> hash;

--- a/components/keyrings/keyring_kms/backend/kms.h
+++ b/components/keyrings/keyring_kms/backend/kms.h
@@ -35,9 +35,6 @@
 #include <string>
 #include <vector>
 
-#include <openssl/hmac.h>
-#include <openssl/sha.h>
-
 namespace aws {
 
 std::string uri_escape_string(const std::string &s);
@@ -51,16 +48,11 @@ inline curl_easy_unique_ptr make_curl_easy() {
   return curl_easy_unique_ptr(curl_easy_init(), curl_easy_cleanup);
 }
 
+std::vector<unsigned char> sha256_ex(const unsigned char *ptr, std::size_t len);
+
 template <typename T>
 std::vector<unsigned char> sha256(const T &s) {
-  std::vector<unsigned char> md(SHA256_DIGEST_LENGTH);
-
-  SHA256_CTX sha256;
-  SHA256_Init(&sha256);
-  SHA256_Update(&sha256, &s[0], s.size());
-  SHA256_Final(md.data(), &sha256);
-
-  return md;
+  return sha256_ex(reinterpret_cast<const unsigned char *>(&s[0]), s.size());
 }
 
 class Http_buffer {


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2959
https://jira.percona.com/browse/PS-8330

Suppressed fixed OpenSSL 3.0.x "using deprecated function" warnings.

(cherry picked from commit bd1b6e51aab3aa85af88c0b930c270af516d6516)