### PR TITLE
Fixed PXB-2963 (compression tests are failing due to missing command.)

### DIFF
--- a/storage/innobase/xtrabackup/test/suites/compression/page_compression_lz4.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/page_compression_lz4.sh
@@ -1,6 +1,5 @@
 . inc/page_compression_common.sh
 
-prepare_data
 vlog "Taking backup with LZ4 compression"
 take_backup "--compress=lz4 --read-buffer-size=1M"
 decompress "--decompress --read-buffer-size=1M"

--- a/storage/innobase/xtrabackup/test/suites/compression/page_compression_lz4_multi_thread.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/page_compression_lz4_multi_thread.sh
@@ -1,6 +1,5 @@
 . inc/page_compression_common.sh
 
-prepare_data
 vlog "Taking backup with LZ4 compression and multi thread"
 take_backup "--parallel=2  --compress=lz4 --compress-threads=2 --read-buffer-size=1M"
 decompress "--decompress --parallel=2 --read-buffer-size=1M"

--- a/storage/innobase/xtrabackup/test/suites/compression/page_compression_no_compress.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/page_compression_no_compress.sh
@@ -1,6 +1,5 @@
 . inc/page_compression_common.sh
 
-prepare_data
 vlog "Taking backup with no compression"
 take_backup ""
 restore_and_verify

--- a/storage/innobase/xtrabackup/test/suites/compression/page_compression_zstd.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/page_compression_zstd.sh
@@ -1,6 +1,5 @@
 . inc/page_compression_common.sh
 
-prepare_data
 vlog "Taking backup with ZSTD compression"
 take_backup "--compress=zstd --read-buffer-size=1M"
 decompress "--decompress --read-buffer-size=1M"

--- a/storage/innobase/xtrabackup/test/suites/compression/page_compression_zstd_multi_thread.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/page_compression_zstd_multi_thread.sh
@@ -1,6 +1,5 @@
 . inc/page_compression_common.sh
 
-prepare_data
 vlog "Taking backup with ZSTD compression and multi thread"
 take_backup "--parallel=2 --compress=zstd --compress-threads=2 --read-buffer-size=1M"
 decompress "--decompress --parallel=2 --read-buffer-size=1M"


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2963

Issue:
Compression tests are failing due to missing command: suites/compression/page_compression_no_compress.sh: line 3: prepare_data: command not found

Fix:
This call is a left over from before some refactoring done on those test. Its safe to remove.