### PR TITLE
PXB-2964 : PXB needs too many open files to take backups

### DIFF
--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -116,7 +116,6 @@ xb_fil_cur_result_t xb_fil_cur_open(
 {
   page_size_t page_size(0, 0, false);
   ulint page_size_shift;
-  bool success;
 
   /* Initialize these first so xb_fil_cur_close() handles them correctly
   in case of error */
@@ -143,10 +142,7 @@ xb_fil_cur_result_t xb_fil_cur_open(
   srv_close_files has an effect only on IBD tablespaces. */
   if (cursor->is_system || !srv_backup_mode ||
       (srv_close_files && cursor->is_ibd)) {
-    node->handle = os_file_create_simple_no_error_handling(
-        0, node->name, OS_FILE_OPEN, OS_FILE_READ_ONLY, srv_read_only_mode,
-        &success);
-    if (!success) {
+    if (!fil_node_open_file(node)) {
       /* The following call prints an error message */
       os_file_get_last_error(true);
 
@@ -154,8 +150,6 @@ xb_fil_cur_result_t xb_fil_cur_open(
 
       return (XB_FIL_CUR_ERROR);
     }
-
-    fil_node_open_file(node);
   }
 
   ut_ad(node->is_open);

--- a/storage/innobase/xtrabackup/test/t/pxb-1870.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1870.sh
@@ -23,5 +23,5 @@ PARTITION BY HASH (uid)
 PARTITIONS 3000;
 EOF
 
-xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup


### PR DESCRIPTION
Problem:
-------
PXB 8.0 requires very high open files limit (Operating system configuration ulimit -n).

Since, --lock-ddl is ON by default, the parameter --close-files is also ON implicitly. This means files are safe to be closed during backup. Even after closing fies, PXB asks for very high open files operating configuration.

This is because of a bug in PXB. It opens an extra handle to each IBD file which is never closed. Hence, the total number of open handles required in OS is equal to total number of IBD files.

Fix
---
Remove the duplicate open file handle which is never closed (only closed by exit of process)