### PR TITLE
Fixed PXB-2971-8.0 (Xtrabackup is unnecessarily copying local manifes…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -298,20 +298,8 @@ comparing its name to the list of known data file types and checking
 if passes the rules for partial backup.
 @return true if file backed up or skipped successfully. */
 static bool datafile_copy_backup(const char *filepath, uint thread_n) {
-  const char *ext_list[] = {"MYD",
-                            "MYI",
-                            "MAD",
-                            "MAI",
-                            "MRG",
-                            "ARM",
-                            "ARZ",
-                            "CSM",
-                            "CSV",
-                            "opt",
-                            "sdi",
-                            "mysqld.my",
-                            "mysqld-debug.my",
-                            NULL};
+  const char *ext_list[] = {"MYD", "MYI", "MAD", "MAI", "MRG", "ARM",
+                            "ARZ", "CSM", "CSV", "opt", "sdi", NULL};
 
   /* Get the name and the path for the tablespace. node->name always
   contains the path (which may be absolute for remote tablespaces in

--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -127,6 +127,7 @@ EOF
   xtrabackup --copy-back --target-dir=$topdir/backup
 
 if [[ "${KEYRING_TYPE}" = "component" ]] || [[ "${KEYRING_TYPE}" = "both" ]]; then
+  cp ${instance_local_manifest}  $mysql_datadir
   cp ${keyring_component_cnf} $mysql_datadir
 fi
 
@@ -172,6 +173,7 @@ fi
     if [[ "${KEYRING_TYPE}" = "component" ]] || [[ "${KEYRING_TYPE}" = "both" ]];
     then
       vlog "copying component config back to datadir"
+      cp ${instance_local_manifest}  $mysql_datadir
       cp ${keyring_component_cnf} $mysql_datadir
     fi
     start_server
@@ -260,6 +262,7 @@ function keyring_extra_tests()
   xtrabackup --copy-back --target-dir=$topdir/backup1
   if [[ "${KEYRING_TYPE}" = "component" ]] || [[ "${KEYRING_TYPE}" = "both" ]];
   then
+    cp ${instance_local_manifest}  $mysql_datadir
     cp ${keyring_component_cnf} $mysql_datadir
   fi
   start_server

--- a/storage/innobase/xtrabackup/test/inc/keyring_file.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_file.sh
@@ -29,6 +29,7 @@ keyring-file-data=${keyring_file}
 "
 fi
 
+instance_local_manifest=""
 keyring_component_cnf=${TEST_VAR_ROOT}/component_keyring_file.cnf
 
 if [[ "${KEYRING_TYPE}" = "plugin" ]]; then
@@ -44,6 +45,7 @@ function configure_keyring_file_component()
   else
     binary="mysqld"
   fi
+  instance_local_manifest="${TEST_VAR_ROOT}/${binary}.my"
   cat <<EOF > "${MYSQLD_DATADIR}/${binary}.my"
 {
     "components": "file://component_keyring_file"
@@ -55,6 +57,7 @@ EOF
   "read_only": false
 }
 EOF
+cp "${MYSQLD_DATADIR}/${binary}.my" ${instance_local_manifest}
 cp "${MYSQLD_DATADIR}/component_keyring_file.cnf" ${keyring_component_cnf}
 }
 

--- a/storage/innobase/xtrabackup/test/inc/keyring_kmip.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_kmip.sh
@@ -9,6 +9,7 @@ if [ -z ${KEYRING_TYPE+x} ]; then
   KEYRING_TYPE="component"
 fi
 
+instance_local_manifest=""
 keyring_component_cnf=${TEST_VAR_ROOT}/component_keyring_kmip.cnf
 keyring_args="--component-keyring-config=${keyring_component_cnf}"
 
@@ -30,6 +31,7 @@ function configure_keyring_file_component()
   else
     binary="mysqld"
   fi
+  instance_local_manifest="${TEST_VAR_ROOT}/${binary}.my"
   cat <<EOF > "${MYSQLD_DATADIR}/${binary}.my"
 {
     "components": "file://component_keyring_kmip"
@@ -45,6 +47,7 @@ EOF
   "object_group": "${KMIP_OBJECT_GROUP}"
 }
 EOF
+cp "${MYSQLD_DATADIR}/${binary}.my" ${instance_local_manifest}
 cp "${MYSQLD_DATADIR}/component_keyring_kmip.cnf" ${keyring_component_cnf}
 }
 

--- a/storage/innobase/xtrabackup/test/inc/keyring_kms.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_kms.sh
@@ -9,6 +9,7 @@ if [ -z ${KEYRING_TYPE+x} ]; then
   KEYRING_TYPE="component"
 fi
 
+instance_local_manifest=""
 keyring_component_cnf=${TEST_VAR_ROOT}/component_keyring_kms.cnf
 keyring_args="--component-keyring-config=${keyring_component_cnf}"
 
@@ -27,6 +28,7 @@ function configure_keyring_file_component()
   else
     binary="mysqld"
   fi
+  instance_local_manifest="${TEST_VAR_ROOT}/${binary}.my"
   cat <<EOF > "${MYSQLD_DATADIR}/${binary}.my"
 {
     "components": "file://component_keyring_kms"
@@ -42,6 +44,7 @@ EOF
   "kms_key": "${KMS_KEY}"
 }
 EOF
+cp "${MYSQLD_DATADIR}/${binary}.my" ${instance_local_manifest}
 cp "${MYSQLD_DATADIR}/component_keyring_kms.cnf" ${keyring_component_cnf}
 }
 


### PR DESCRIPTION
…t file)

https://jira.percona.com/browse/PXB-2971

Problem:
Xtrabackup used to copy manifest and component configuration files. After implementation of KMS we found out that copying the component configuration file is a security risk and decided to not copy it anymore and let the used do it. As part of this rework, we also removed the need of mysqld.my manifest file as PXB only cares about config file now. However, we are still copying instance local manifest file.

Fix:
Skip copying this file and adjust test.