### PR TITLE
Fixed PXB-2969 (migration from keyring plugin to component is breakin…

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/keyring_file.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_file.sh
@@ -16,7 +16,8 @@ then
 else
   plugin_dir=$PWD/../../lib/plugin/
 fi
-keyring_file=${TEST_VAR_ROOT}/keyring_file
+keyring_file_plugin=${TEST_VAR_ROOT}/keyring_file_plugin
+keyring_file_component=${TEST_VAR_ROOT}/keyring_file_component
 XB_EXTRA_MY_CNF_OPTS="${XB_EXTRA_MY_CNF_OPTS:-""}
 xtrabackup-plugin-dir=${plugin_dir}
 "
@@ -25,7 +26,7 @@ if [[ "${KEYRING_TYPE}" = "plugin" ]] || [[ "${KEYRING_TYPE}" = "both" ]]; then
   plugin_load=keyring_file.so
   MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS:-""}
 early-plugin-load=${plugin_load}
-keyring-file-data=${keyring_file}
+keyring-file-data=${keyring_file_plugin}
 "
 fi
 
@@ -33,7 +34,7 @@ instance_local_manifest=""
 keyring_component_cnf=${TEST_VAR_ROOT}/component_keyring_file.cnf
 
 if [[ "${KEYRING_TYPE}" = "plugin" ]]; then
-  keyring_args="--keyring-file-data=${keyring_file}"
+  keyring_args="--keyring-file-data=${keyring_file_plugin}"
 else
   keyring_args="--component-keyring-config=${keyring_component_cnf}"
 fi
@@ -53,7 +54,7 @@ function configure_keyring_file_component()
 EOF
   cat <<EOF > "${MYSQLD_DATADIR}/component_keyring_file.cnf"
 {
-  "path": "${keyring_file}",
+  "path": "${keyring_file_component}",
   "read_only": false
 }
 EOF
@@ -62,5 +63,6 @@ cp "${MYSQLD_DATADIR}/component_keyring_file.cnf" ${keyring_component_cnf}
 }
 
 function cleanup_keyring() {
-	rm -rf $keyring_file
+  rm -rf $keyring_file_plugin
+  rm -rf $keyring_file_component
 }

--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -512,7 +512,7 @@ function get_version_info()
 function copy_worker_var_dir()
 {
   local keep_worker_number=$1
-  [ -d $TEST_BASEDIR/results/debug/ ] || mkdir $TEST_BASEDIR/results/debug/
+  [ -d $PWD/results/debug/ ] || mkdir $PWD/results/debug/
   for worker_dir in $TEST_BASEDIR/var/w+([0-9])
   do
       [ -d $worker_dir ] || continue
@@ -523,7 +523,7 @@ function copy_worker_var_dir()
       if [ "$worker" = "$keep_worker_number" ]
       then
           local tname=`basename $tpath .sh`
-          local debug_dir=$(mktemp -d  $TEST_BASEDIR/results/debug/${tname}.XXXXXX)
+          local debug_dir=$(mktemp -d  $PWD/results/debug/${tname}.XXXXXX)
           cp -R ${worker_outfiles[$worker]} ${debug_dir}
           cp -R $TEST_BASEDIR/var/w${worker} ${debug_dir}
       fi

--- a/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
@@ -114,7 +114,7 @@ xtrabackup --datadir=$mysql_datadir --prepare \
 vlog "Copying files to their original locations"
 xtrabackup --copy-back \
     --target-dir=$full_backup_dir \
-    --keyring-file-data=$keyring_file
+    --keyring-file-data=$keyring_file_plugin
 vlog "Data restored"
 
 start_server

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
@@ -7,9 +7,7 @@ require_server_version_higher_than 5.7.10
 
 . inc/keyring_file.sh
 
-keyring_file=${TEST_VAR_ROOT}/keyring_file
-
-start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file --server-id=10
+start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file_plugin --server-id=10
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 
@@ -33,7 +31,7 @@ EOF
 innodb_wait_for_flush_all
 
 xtrabackup --backup --target-dir=$topdir/backup \
-	   --keyring-file-data=$keyring_file --server-id=10
+	   --keyring-file-data=$keyring_file_plugin --server-id=10
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 
@@ -45,7 +43,7 @@ EOF
 
 xtrabackup --backup --incremental-basedir=$topdir/backup \
 	   --target-dir=$topdir/inc1 \
-	   --keyring-file-data=$keyring_file --server-id=10
+	   --keyring-file-data=$keyring_file_plugin --server-id=10
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 
@@ -57,24 +55,24 @@ EOF
 
 xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
-	   --keyring-file-data=$keyring_file --server-id=10
+	   --keyring-file-data=$keyring_file_plugin --server-id=10
 
 ${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --export --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
@@ -85,7 +83,7 @@ EOF
 
 stop_server
 
-start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file --server-id=20
+start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file_plugin --server-id=20
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
@@ -33,9 +33,8 @@ prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${top
 xtrabackup --prepare --target-dir=$topdir/backup ${prepare_options}
 rm -rf ${mysql_datadir}
 xtrabackup --copy-back --target-dir=$topdir/backup
-mv $topdir/keyring_file ${TEST_VAR_ROOT}
+mv $topdir/keyring_file ${keyring_file_plugin}
 start_server
-
 run_insert &
 job_id=$!
 sleep 2
@@ -46,7 +45,7 @@ xtrabackup --backup --incremental-basedir=$topdir/full \
 record_db_state test
 stop_server
 
-prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${TEST_VAR_ROOT}/keyring_file"
+prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full ${prepare_options}
 xtrabackup --prepare --incremental-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
@@ -72,20 +71,18 @@ xtrabackup --backup --incremental-basedir=$topdir/full \
 kill -USR1 $job_id
 wait $job_id
 stop_server
-cp ${TEST_VAR_ROOT}/keyring_file ${TEST_VAR_ROOT}/keyring_file_plugin
-rm ${TEST_VAR_ROOT}/keyring_file
 configure_keyring_file_component
-# backup global and component config files
-#cp ${MYSQL_BASEDIR}/bin/mysqld.my ${MYSQL_BASEDIR}/bin/mysqld.my.backup
-#cp ${MYSQLD_DATADIR}/mysqld.my ${MYSQL_BASEDIR}/bin/mysqld.my
-cp ${MYSQL_BASEDIR}/lib/plugin/component_keyring_file.cnf ${MYSQL_BASEDIR}/lib/plugin/component_keyring_file.cnf.backup
-cp ${MYSQLD_DATADIR}/component_keyring_file.cnf ${MYSQL_BASEDIR}/lib/plugin/component_keyring_file.cnf
+# Copy required plugin file and components
+mkdir $topdir/plugin
+cp $MYSQL_BASEDIR/lib/plugin/keyring_file.so $MYSQL_BASEDIR/lib/plugin/component_keyring_file.so ${MYSQLD_DATADIR}/component_keyring_file.cnf $topdir/plugin
+
 run_cmd ${MYSQLD} --basedir=${MYSQL_BASEDIR} --keyring-migration-to-component \
 --keyring-migration-source=keyring_file.so \
 --keyring-migration-destination=component_keyring_file.so \
---keyring-file-data=${TEST_VAR_ROOT}/keyring_file_plugin
-mv ${MYSQL_BASEDIR}/lib/plugin/component_keyring_file.cnf.backup ${MYSQL_BASEDIR}/lib/plugin/component_keyring_file.cnf
-#mv ${MYSQL_BASEDIR}/bin/mysqld.my.backup ${MYSQL_BASEDIR}/bin/mysqld.my
+--keyring-file-data=${TEST_VAR_ROOT}/keyring_file_plugin \
+--plugin-dir=$topdir/plugin
+
+
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_redo_log_encrypt
 innodb_undo_log_encrypt
@@ -107,12 +104,12 @@ record_db_state test
 stop_server
 
 
-prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${TEST_VAR_ROOT}/keyring_file_plugin"
+prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full ${prepare_options}
 xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
 
-prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --component-keyring-config=${keyring_component_cnf} --keyring-file-data=${TEST_VAR_ROOT}/keyring_file"
+prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --component-keyring-config=${keyring_component_cnf} --keyring-file-data=${keyring_file_component}"
 xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
     --target-dir=$topdir/full ${prepare_options}
 xtrabackup --prepare --incremental-dir=$topdir/inc3 \
@@ -125,5 +122,5 @@ run_cmd verify_db_state test
 stop_server
 rm -rf $mysql_datadir
 rm -rf $topdir/{full,inc1,inc2,inc3}
-rm -f ${TEST_VAR_ROOT}/keyring_file_plugin ${TEST_VAR_ROOT}/keyring_file
+rm -rf ${keyring_file_component} ${keyring_file_plugin} $topdir/plugin
 vlog "-- DONE testing keyring upgrade from plugin to component --"

--- a/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
@@ -6,7 +6,7 @@ require_server_version_higher_than 5.7.10
 
 . inc/keyring_file.sh
 
-start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file --server_id=10
+start_server --early-plugin-load=keyring_file.so --keyring-file-data=$keyring_file_plugin --server_id=10
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 
@@ -35,7 +35,7 @@ innodb_wait_for_flush_all
 cat $mysql_datadir/auto.cnf
 
 xtrabackup --backup --target-dir=$topdir/backup \
-	   --keyring-file-data=$keyring_file --server_id=10
+	   --keyring-file-data=$keyring_file_plugin --server_id=10
 
 cat $topdir/backup/backup-my.cnf
 
@@ -49,7 +49,7 @@ EOF
 
 xtrabackup --backup --incremental-basedir=$topdir/backup \
            --target-dir=$topdir/inc1 \
-           --keyring-file-data=$keyring_file --server_id=10
+           --keyring-file-data=$keyring_file_plugin --server_id=10
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 
@@ -61,24 +61,24 @@ EOF
 
 xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
-	   --keyring-file-data=$keyring_file --server_id=10
+	   --keyring-file-data=$keyring_file_plugin --server_id=10
 
 ${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file \
+	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 stop_server
@@ -92,7 +92,7 @@ cat > $mysql_datadir/auto.cnf <<EOF
 server_uuid=8a94f357-aab4-11df-86ab-c80aa9429562
 EOF
 
-start_server --early-plugin-load=keyring_file.so --keyring_file_data=$keyring_file --server_id=200
+start_server --early-plugin-load=keyring_file.so --keyring_file_data=$keyring_file_plugin --server_id=200
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 SELECT @@server_id;


### PR DESCRIPTION
…g global keyring configuration)

https://jira.percona.com/browse/PXB-2969

Problem:
mysqld --keyring-migration-to-component functionality does not accept local plugin configuration file. innodb_keyring_plugin_to_component test was momentaneally replacing its local config file to instance global file, which was causing random issue on other keyring tests that were running at the same time.

Fix:
Make a temporary folder isolated to this test. Copying keyring_file.so, component_keyring_file.so and local component_keyring_file.cnf to this new folder and using it as --plugin-dir to mysqld offline migration tool.

Also adjusted an issue with run.sh -k that was unable to copy result folder if test were running in RAM via -r /dev/shm