### PR TITLE
Fixed PXB-2978 (skip storage class test with running against Minio)

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
@@ -41,6 +41,17 @@ function write_credentials() {
   echo ${XBCLOUD_CREDENTIALS} | sed 's/ *--/\'$'\n/g' >> $topdir/xbcloud.cnf
 }
 
+function is_minio_server() {
+  if [[ "$XBCLOUD_CREDENTIALS" =~ .*"s3-endpoint".* ]]; then
+    ENDPOINT=$(echo ${XBCLOUD_CREDENTIALS} | awk -F's3-endpoint=' '{print $2}' | awk '{print $1}' | tr -d "'" | tr -d '\\')
+    SERVER=$(curl -sI ${ENDPOINT} | grep Server)
+    if [[ "$SERVER" =~ .*"MinIO".* ]]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
 function is_ec2_with_profile() {
   TOKEN=`curl -sS --connect-timeout 3 -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` || \
   return 1

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/storage_class.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/storage_class.sh
@@ -1,6 +1,6 @@
 . inc/xbcloud_common.sh
 is_xbcloud_credentials_set
-
+is_minio_server && skip_test "Storage Class is not supported on MinIO servers"
 write_credentials
 
 storage_class_folder=${now}-${uuid}-storage_class


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2978

Problem:
MinIO servers do not support storage class:

```
230206 19:07:37 xbcloud: Successfully connected.
230206 19:07:37 xbcloud: S3 error message: Invalid storage class.
230206 19:07:37 xbcloud: error: failed to upload chunk: 1675690626-08592cf97f1205a4b3feddf26d477f72-storage_class/xtrabackup_tablespaces.00000000000000000000, size: 36
230206 19:07:37 xbcloud: Upload failed.
```

Fix:
Add a check to skip the test if we are running against MinIO server.