### PR TITLE
Implemented PXB-2980 (Add a parameter to disable memory estimation du…

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -87,7 +87,10 @@ extern size_t real_redo_memory;
 extern ulint real_redo_frames;
 
 /** This variables holds the result of all conditions that must be set in order
-to enable estimate memory functionality */
+to enable estimate memory functionality. Used at --prepare */
 extern bool estimate_memory;
+
+/** Parameter to enable estimate memory. Used at --backup */
+extern bool xtrabackup_estimate_memory;
 #define SQUOTE(str) "'" << str << "'"
 #endif

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3453,7 +3453,7 @@ static bool recv_single_rec(byte *ptr, byte *end_ptr) {
           recv_sys->missing_ids.insert(space_id);
         }
 #endif /* !UNIV_HOTBACKUP */
-      } else {
+      } else if (xtrabackup_estimate_memory) {
         xtrabackup::recv_calculate_hash_heap(type, space_id, page_no, body,
                                              ptr + len, old_lsn);
       }
@@ -3639,7 +3639,7 @@ static bool recv_multi_rec(byte *ptr, byte *end_ptr) {
             recv_sys->missing_ids.insert(space_id);
           }
 #endif /* !UNIV_HOTBACKUP */
-        } else {
+        } else if (xtrabackup_estimate_memory) {
           xtrabackup::recv_calculate_hash_heap(type, space_id, page_no, body,
                                                ptr + len, old_lsn);
         }


### PR DESCRIPTION
…ring backup)

https://jira.percona.com/browse/PXB-2980

Description:
Memory estimation works in two phases
 1. during backup.
 2. during prepare.

We added a tech preview feature but only gave the ability to disable during phase 2.

Fix:
Added a new flag --calculate-memory to enable/disable this functionality during --backup phase. Since the feature is tech preview, it is OFF by default.
Renamed pxb-2710-predict_memory.sh test to reflect new naming.