### PR TITLE
Fixed PXB-2979 (Xtrabackup with 8.0.30 processes redo log files too s…

### DIFF
--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -81,7 +81,7 @@ struct recv_sys_t {
   struct space_page_t {
     /** Default constructor */
     space_page_t() : m_pages(), m_blocks() {}
-    std::vector<page_no_t> m_pages;
+    std::unordered_set<page_no_t> m_pages;
     std::vector<mem_block_t *> m_blocks;
   };
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2758,14 +2758,13 @@ static void recv_calculate_hash_heap(mlog_id_t type, space_id_t space_id,
   }
   last_block->free = last_block->free + MEM_SPACE_NEEDED(sizeof(recv_t));
 
-  if (std::find(space->m_pages.begin(), space->m_pages.end(), page_no) ==
-      space->m_pages.end()) {
+  if (space->m_pages.find(page_no) == space->m_pages.end()) {
     if (last_block->len <
         (last_block->free + MEM_SPACE_NEEDED(sizeof(recv_addr_t)))) {
       last_block = xtrabackup::add_new_block(space, sizeof(recv_addr_t));
     }
     last_block->free = last_block->free + MEM_SPACE_NEEDED(sizeof(recv_addr_t));
-    space->m_pages.push_back(page_no);
+    space->m_pages.insert(page_no);
   }
 
   while (rec_end > body) {


### PR DESCRIPTION
…lowly)

https://jira.percona.com/browse/PXB-2979

Problem:
Smart memory estimation, parses metadata from redo records in order to correctly estimate the required memory. As part of the parsing, an inefficient data structure were been used which could cause slowness on heavy write workloads.

Fix:
Adjust structure that holds pages to use unordered_set.