### PR TITLE
PXB-2865 Failed to copy dymainc metadata

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7104,6 +7104,14 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
   IORequest write_request(IORequest::WRITE);
 
   read_metadata();
+  if (strcmp(metadata_type_str, "log-applied") == 0 &&
+      !xtrabackup_incremental) {
+    xb::error() << "Backup is already prepared. The final incremental should "
+                   "be prepared without --apply-log-only. or if you restoring "
+                   "full backup, It should be only prepare without option "
+                   "--apply-log-only";
+    exit(EXIT_FAILURE);
+  }
 
   if (!strcmp(metadata_type_str, "full-backuped")) {
     xb::info() << "This target seems to be not prepared yet.";

--- a/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
@@ -90,16 +90,10 @@ vlog "##############"
 xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 vlog "##############"
-vlog "# PREPARE #2 #"
+vlog "# PREPARE #2 FINAL PREPARE #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
-vlog "Delta applied to full backup"
-vlog "##############"
-vlog "# PREPARE #3 #"
-vlog "##############"
-xtrabackup --prepare --target-dir=$full_backup_dir
-vlog "Data prepared for restore"
 
 # Destroying mysql data
 stop_server

--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -99,7 +99,7 @@ EOF
   xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
        --target-dir=$topdir/backup $prepare_options
 
-  xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+  xtrabackup --prepare --incremental-dir=$topdir/inc2 \
        --target-dir=$topdir/backup $prepare_options
 
   xtrabackup --prepare --export --target-dir=$topdir/backup \

--- a/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
+++ b/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
@@ -16,10 +16,8 @@ xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full \
+xtrabackup --prepare --target-dir=$topdir/full \
 				      --incremental-dir=$topdir/inc
-
-xtrabackup --prepare --target-dir=$topdir/full
 
 # verify that following files overwritten in full backup directory with the
 # corresponding files from incremental directory

--- a/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
@@ -25,5 +25,4 @@ xtrabackup --decompress --target-dir=$topdir/backup
 xtrabackup --decompress --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup --incremental-dir=$topdir/inc
-xtrabackup --prepare --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
@@ -66,7 +66,7 @@ ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
 	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}

--- a/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
@@ -72,12 +72,8 @@ ${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
 	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
-	  --keyring-file-data=$keyring_file_plugin \
-	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
-
-${XB_BIN} --prepare --target-dir=$topdir/backup \
 	  --keyring-file-data=$keyring_file_plugin \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
@@ -90,12 +90,10 @@ vlog "Preparing backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --apply-log-only --target-dir=$topdir/full
 vlog "Log applied to backup"
+
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full \
+--target-dir=$topdir/full \
 --incremental-dir=$topdir/delta
-vlog "Delta applied to backup"
-xtrabackup --datadir=$mysql_datadir --prepare \
---target-dir=$topdir/full
 vlog "Data prepared for restore"
 
 # removing rows

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
@@ -88,12 +88,10 @@ vlog "Preparing backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --apply-log-only --target-dir=$topdir/full
 vlog "Log applied to backup"
+
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full \
+--target-dir=$topdir/full \
 --incremental-dir=$topdir/delta
-vlog "Delta applied to backup"
-xtrabackup --datadir=$mysql_datadir --prepare \
---target-dir=$topdir/full
 vlog "Data prepared for restore"
 
 # removing rows

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
@@ -47,11 +47,9 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
         ${inc_backup_name} | \
     xbstream -xv -C $topdir/downloaded_inc
 
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare \
 	   --target-dir=$topdir/downloaded_full \
 	   --incremental-dir=$topdir/downloaded_inc
-
-xtrabackup --prepare --target-dir=$topdir/downloaded_full
 
 # test partial download
 

--- a/storage/innobase/xtrabackup/test/t/bug1002688.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1002688.sh
@@ -35,12 +35,9 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir/ \
+xtrabackup --prepare --incremental-dir=$inc_backup_dir/ \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
-
-xtrabackup --prepare --target-dir=$full_backup_dir
-vlog "Data prepared for restore"
 
 # Destroying mysql data
 stop_server

--- a/storage/innobase/xtrabackup/test/t/bug1022562.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1022562.sh
@@ -55,14 +55,10 @@ xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
     --target-dir=$FULL_DIR $mysqld_additional_args
 vlog "Log applied to backup"
 
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --datadir=$mysql_datadir --prepare \
     --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR \
     $mysqld_additional_args
-vlog "Delta applied to backup"
-
-xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$FULL_DIR \
-    $mysqld_additional_args
-vlog "Data prepared for restore"
+vlog "Full Applied Delta applied to backup"
 
 # removing rows
 ${MYSQL} ${MYSQL_ARGS} -e "delete from t2;" incremental_sample

--- a/storage/innobase/xtrabackup/test/t/bug1028949.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1028949.sh
@@ -64,12 +64,9 @@ function test_bug_1028949()
       --target-dir=$FULL_DIR
   vlog "Log applied to backup"
 
-  xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+  xtrabackup --datadir=$mysql_datadir --prepare  \
       --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR
-  vlog "Delta applied to backup"
-
-  xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$FULL_DIR
-  vlog "Data prepared for restore"
+  vlog "Prepared with Delta applied to backup"
 
   # removing rows
   for i in $PAGE_SIZES;

--- a/storage/innobase/xtrabackup/test/t/bug1038127.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1038127.sh
@@ -30,11 +30,8 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --incremental-dir=$topdir/inc \
     --target-dir=$topdir/full
-vlog "Delta applied to full backup"
-
-xtrabackup --prepare --target-dir=$topdir/full
 vlog "Data prepared for restore"
 
 grep -q "This backup was taken with XtraBackup 2.0.1" $OUTFILE

--- a/storage/innobase/xtrabackup/test/t/bug1062684.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1062684.sh
@@ -62,13 +62,8 @@ vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
-vlog "Delta applied to full backup"
-vlog "##############"
-vlog "# PREPARE #3 #"
-vlog "##############"
-xtrabackup --prepare --target-dir=$full_backup_dir
 vlog "Data prepared for restore"
 
 # Destroying mysql data

--- a/storage/innobase/xtrabackup/test/t/bug759701.sh
+++ b/storage/innobase/xtrabackup/test/t/bug759701.sh
@@ -36,12 +36,9 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
-vlog "Delta applied to full backup"
-
-xtrabackup --prepare --target-dir=$full_backup_dir
-vlog "Data prepared for restore"
+vlog "Last Delta applied to full backup"
 
 # Destroying mysql data
 stop_server

--- a/storage/innobase/xtrabackup/test/t/bug766607.sh
+++ b/storage/innobase/xtrabackup/test/t/bug766607.sh
@@ -26,12 +26,8 @@ vlog "Preparing full backup"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup/full
 
 # The following would fail before the bugfix
-vlog "Applying incremental delta"
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
-
-vlog "Preparing full backup"
-xtrabackup --prepare --target-dir=$topdir/backup/full
-vlog "Data prepared for restore"
+vlog "apply final incremental"
+xtrabackup --prepare --incremental-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
 
 stop_server
 rm -r $mysql_datadir/*

--- a/storage/innobase/xtrabackup/test/t/bug856400.sh
+++ b/storage/innobase/xtrabackup/test/t/bug856400.sh
@@ -61,12 +61,9 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --incremental-dir=$topdir/inc \
     --target-dir=$topdir/full
 vlog "Delta applied to full backup"
-
-xtrabackup --prepare --target-dir=$topdir/full
-vlog "Data prepared for restore"
 
 ls -al $topdir/full/test/*
 

--- a/storage/innobase/xtrabackup/test/t/bug932623.sh
+++ b/storage/innobase/xtrabackup/test/t/bug932623.sh
@@ -45,12 +45,9 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare  \
     --incremental-dir=$topdir/inc --target-dir=$topdir/full
-vlog "Delta applied to full backup"
-
-xtrabackup --prepare --target-dir=$topdir/full
-vlog "Data prepared for restore"
+vlog "Prepared with Delta applied to full backup"
 
 checksum_t1_a=`checksum_table test t1`
 checksum_t1_old_a=`checksum_table test t1_old`

--- a/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
@@ -38,10 +38,8 @@ fi
 # prepare
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/incremental \
+xtrabackup --prepare --incremental-dir=$topdir/incremental \
     --target-dir=$topdir/backup
-
-xtrabackup --prepare --target-dir=$topdir/backup
 
 # restore from backup
 rm -rf $mysql_datadir/*

--- a/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
@@ -80,13 +80,8 @@ vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup_no_defaults_file --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup_no_defaults_file --prepare --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
-vlog "Delta applied to full backup"
-vlog "##############"
-vlog "# PREPARE #3 #"
-vlog "##############"
-xtrabackup_no_defaults_file --prepare --target-dir=$full_backup_dir
 vlog "Data prepared for restore"
 
 # Destroying mysql data

--- a/storage/innobase/xtrabackup/test/t/pxb-1824.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1824.sh
@@ -62,9 +62,8 @@ stop_server
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
 xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
 	   --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --incremental-dir=$topdir/inc1 \
 	   --target-dir=$topdir/backup
-xtrabackup --prepare --target-dir=$topdir/backup
 
 lsn1=$(grep -q flushed_lsn $topdir/backup/xtrabackup_checkpoints)
 lsn2=$(grep -q flushed_lsn $topdir/inc1/xtrabackup_checkpoints)

--- a/storage/innobase/xtrabackup/test/t/xb_export.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_export.sh
@@ -213,9 +213,6 @@ mkdir -p $topdir/backup/full
 
 xtrabackup --datadir=$mysql_datadir --backup --target-dir=$topdir/backup/full
 
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
-    --target-dir=$topdir/backup/full
-
 xtrabackup --datadir=$mysql_datadir --prepare \
     --target-dir=$topdir/backup/full
 

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
@@ -143,12 +143,9 @@ incremental_sample`
       --apply-log-only --target-dir=$topdir/full
   vlog "Log applied to backup"
   xtrabackup --datadir=$mysql_datadir --prepare \
-      --apply-log-only --target-dir=$topdir/full \
+      --target-dir=$topdir/full \
       --incremental-dir=$topdir/delta
-  vlog "Delta applied to backup"
-  xtrabackup --datadir=$mysql_datadir --prepare \
-      --target-dir=$topdir/full
-  vlog "Data prepared for restore"
+  vlog "Prepared and Delta applied to backup"
 
   # removing rows
   ${MYSQL} ${MYSQL_ARGS} -e "delete from test;" incremental_sample

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
@@ -50,9 +50,8 @@ rm -r $mysql_datadir
 
 vlog "Applying log"
 xtrabackup --prepare --apply-log-only --target-dir=$topdir/full_backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc_backup \
+xtrabackup --prepare --incremental-dir=$topdir/inc_backup \
     --target-dir=$topdir/full_backup
-xtrabackup --prepare --target-dir=$topdir/full_backup
 
 vlog "Restoring MySQL datadir"
 mkdir -p $mysql_datadir

--- a/storage/innobase/xtrabackup/test/t/xb_part_range.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_part_range.sh
@@ -78,12 +78,8 @@ vlog "Preparing backup"
 xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-log-only \
     --target-dir=$topdir/backup/full
 vlog "Log applied to backup"
-xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-log-only \
-    --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta
-vlog "Delta applied to backup"
 xtrabackup --no-defaults --datadir=$mysql_datadir --prepare \
-    --target-dir=$topdir/backup/full
-vlog "Data prepared for restore"
+    --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta
 
 # removing rows
 vlog "Table cleared"

--- a/storage/innobase/xtrabackup/test/t/xb_stats.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_stats.sh
@@ -10,7 +10,7 @@ load_dbase_data sakila
 mkdir -p $topdir/backup
 xtrabackup --datadir=$mysql_datadir --backup --target-dir=$topdir/backup
 vlog "Backup taken, trying stats"
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$topdir/backup
 
 # First check that xtrabackup fails with the correct error message
 # when trying to get stats before creating the log files
@@ -22,8 +22,6 @@ if ! grep -q "Cannot find correct redo log files" $OUTFILE
 then
     die "Cannot find the expected error message from xtrabackup --stats"
 fi
-
-xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$topdir/backup
 
 vlog "Now start the server so it creates redo log files"
 stop_server


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2865

We have the logic of skipping dynamic metadata on the apply-log phase and relying on MySQL.ibd to copy those changes. see PXB-2180 The issue comes if there are change that are not flushed to mysql.ibd before the Final incremental backup.
Final Incremental prepare will skip applying of DYNAMIC_METADATA redo and mysql.ibd will not have those changes.

PXB does not allow final prepare on backup prepared already with apply-log-only. Last incremental backup should be prepared without apply-log-only.