### PR TITLE
Fixed PXB-2999 - [Xtrabackup] An optimized(without redo logging) DDL …

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1866,11 +1866,6 @@ static byte *recv_parse_or_apply_log_rec_body(
               recv_sys->recovered_lsn > incremental_start_checkpoint_lsn) {
             full_scan_tables.insert(space_id);
           }
-          /* offline backup */
-          xb::info() << "Last flushed lsn: " << backup_redo_log_flushed_lsn
-                     << " load_index lsn " << recv_sys->recovered_lsn;
-
-          xb::warn(ER_IB_MSG_717);
         }
       }
 #endif /* XTRABACKUP */


### PR DESCRIPTION
…operation has been performed.

https://jira.percona.com/browse/PXB-2999

Problem:
Xtrackup allows for MLOG_INDEX_LOAD to happen during its first scan of redo logs. If a redo log record of this type is found, we print a warning message indicating we found such a record. This warning message brings no benefit to the user and can be misleading saying the backup might not be consistent.

Fix:
Remove the warning message. We still print the message if we find a MLOG_INDEX_LOAD record after the initial catchup has been completed.