### PR TITLE
PXB-2972 : InnoDB: Assertion failure: log0log.cc:1627:srv_is_being_st…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2434,6 +2434,8 @@ dberr_t dict_load_tables_from_space_id(space_id_t space_id, THD *thd,
 
   fil_space_t *space = fil_space_get(space_id);
 
+  DBUG_EXECUTE_IF("force_sdi_error", return (DB_ERROR););
+
   if (fsp_has_sdi(space_id) != DB_SUCCESS) {
     xb::warn() << "Failed to read SDI from " << space->name;
     return (DB_SUCCESS);
@@ -6320,7 +6322,8 @@ static bool xtrabackup_close_temp_log(bool clear_flag) {
   }
 
   if (xb_generated_redo && !clear_flag) {
-    xb::info() << "prepare generated new redo log files. Skipping rename. ";
+    xb::info() << "xtrabackup --prepare generated new redo log files. Skipping "
+               << "rename from ib_redo0 to " << XB_LOG_FILENAME;
     return (false);
   }
 

--- a/storage/innobase/xtrabackup/test/t/handle_errors.sh
+++ b/storage/innobase/xtrabackup/test/t/handle_errors.sh
@@ -1,0 +1,33 @@
+. inc/common.sh
+
+require_debug_pxb_version
+
+start_server
+
+load_dbase_schema sakila
+load_dbase_data sakila
+
+# Take backup
+mkdir -p $topdir/backup
+
+xtrabackup --backup --target-dir=${topdir}/backup 2>&1 |tee $topdir/pxb.log
+
+record_db_state test
+vlog "Run prepare with simualted error. The error is simulated after redo is applied but before rollback is finished"
+
+run_cmd_expect_failure $XB_BIN --prepare --target-dir=$topdir/backup --debug=d,force_sdi_error 2>&1 |tee $topdir/pxb_prepare_error.log
+
+
+vlog "Error message InnoDB: Assertion failure shouldn't be present in error log"
+! grep -q "InnoDB: Assertion failure: log0log.cc:.*:srv_is_being_started || srv_shutdown_state.load() == SRV_SHUTDOWN_EXIT_THREADS" $topdir/pxb_prepare_error.log || die "Unexpected crash during prepare"
+
+vlog "Resume prepare on the failed directory"
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir/*
+
+xtrabackup --move-back --target-dir=${topdir}/backup
+start_server
+
+verify_db_state test


### PR DESCRIPTION
…arted || srv_shutdown_state.load() == SRV_SHUTDOWN_EXIT_THREADS

Problem:
--------
When PXB errors out after applying redo, i.e. when we are booting InnoDB to load tables to do rollback, an error at this stage causes PXB to crash instead of a graceful exit.

PXB renames the xtrabackup_logfile to 'ib_redo0' file to apply redo and later on errors (or on success too).
On success (and if PXB hasn't generated any new redo files) and on errors, we rename back the ib_redo0 to xtrabackup_logfile

To check if any new redo files are created, PXB checks the state of redo files.

At this stage, InnoDB is de-initialized and the InnoDB APIs accessing the redo files do not expect the state to be in SRV_SHUTDOWN_NONE.

Fix:
----
Relax the assertion to make PXB exit gracefully