### PR TITLE
Fixed PXB-3014 - redo log consumer test fails on centos7

### DIFF
--- a/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
+++ b/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
@@ -61,7 +61,7 @@ echo "backup pid is $job_pid"
 run_inserts &
 
 # ER_IB_MSG_LOG_WRITER_WAIT_ON_CONSUMER
-while !grep -q "Redo log writer is waiting for" ${MYSQLD_ERRFILE} ; do
+while ! grep -q "Redo log writer is waiting for" ${MYSQLD_ERRFILE} ; do
 	sleep 1
 	vlog "waiting for redo log writer message in mysql error file"
 done


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3014

Problem:
centos7 identifies `!grep` as a command, rather than analyzing the exit status of grep.

Fix:
Add space between `!` and `grep` to make it a command.