### PR TITLE
PXB-3022 : From PXB 8.0.30 version, prepare requires more memory than previous versions

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2531,7 +2531,10 @@ dberr_t dict_load_tables_from_space_id(space_id_t space_id, THD *thd,
     }
 
     Table_Ptr g_dd_table = dd_table;
-    g_dd_tables.insert(std::make_pair(space_id, g_dd_table));
+    if (xtrabackup_export) {
+      g_dd_tables.insert(std::make_pair(space_id, g_dd_table));
+    }
+
     using Client = dd::cache::Dictionary_client;
     using Releaser = dd::cache::Dictionary_client::Auto_releaser;
 


### PR DESCRIPTION
Problem:
--------
This is because we now store "dd::Tables" in the global map for the purpose of extracting the "instant column" info required for creating a ".cfg" file for --export. We store these dd::Tables in the global map by default, even if --export is not used. The memory occupied by dd::Table is not freed until end of prepare

Fix:
----
Store these dd::Tables in global map only if --export is specified during prepare