### PR TITLE
Add RISC-V support

### DIFF
--- a/configure.cmake
+++ b/configure.cmake
@@ -496,6 +496,17 @@ IF(NOT CMAKE_CROSSCOMPILING AND NOT MSVC)
     }
     " HAVE_HMT_PRIORITY_INSTRUCTION)
   ENDIF()
+
+  # Check for RISC-V Zihintpause
+  IF (processor MATCHES "riscv")
+    CHECK_C_SOURCE_COMPILES("
+    int main()
+    {
+      __asm__ __volatile__ (\"pause\");
+      return 0;
+    }
+    " HAVE_PAUSE_INSTRUCTION)
+  ENDIF()
 ENDIF()
   
 INCLUDE (CheckIncludeFileCXX)


### PR DESCRIPTION
Adds various memory barrier methods:

- mb(), rmb(), wmb() according to [RISC-V unpriviledged specs](https://riscv.org/wp-content/uploads/2019/12/riscv-spec-20191213.pdf) section A.5
- xcng() from [Linux kernel source code](https://github.com/torvalds/linux/blob/master/arch/riscv/include/asm/cmpxchg.h#L124)
- cpu_pause() using Zihintpause's pause, with checks included.

See also https://github.com/percona/percona-server/pull/5030.