### PR TITLE
Implemented PXB-2514 - multiple FIFO streams

### DIFF
--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -86,6 +86,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   ds_compress_lz4.cc
   ds_compress_zstd.cc
   ds_encrypt.cc
+  ds_fifo.cc
   ds_local.cc
   ds_stdout.cc
   ds_tmpfile.cc

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2022 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2023 Percona LLC and/or its affiliates.
 
 Data sink interface.
 
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "ds_decompress_zstd.h"
 #include "ds_decrypt.h"
 #include "ds_encrypt.h"
+#include "ds_fifo.h"
 #include "ds_local.h"
 #include "ds_stdout.h"
 #include "ds_tmpfile.h"
@@ -45,6 +46,9 @@ ds_ctxt_t *ds_create(const char *root, ds_type_t type) {
   switch (type) {
     case DS_TYPE_STDOUT:
       ds = &datasink_stdout;
+      break;
+    case DS_TYPE_FIFO:
+      ds = &datasink_fifo;
       break;
     case DS_TYPE_LOCAL:
       ds = &datasink_local;

--- a/storage/innobase/xtrabackup/src/datasink.h
+++ b/storage/innobase/xtrabackup/src/datasink.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2022 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2023 Percona LLC and/or its affiliates.
 
 Data sink interface.
 
@@ -64,6 +64,7 @@ struct datasink_struct {
 /* Supported datasink types */
 typedef enum {
   DS_TYPE_STDOUT,
+  DS_TYPE_FIFO,
   DS_TYPE_LOCAL,
   DS_TYPE_XBSTREAM,
   DS_TYPE_COMPRESS_QUICKLZ,

--- a/storage/innobase/xtrabackup/src/ds_fifo.cc
+++ b/storage/innobase/xtrabackup/src/ds_fifo.cc
@@ -1,0 +1,199 @@
+/******************************************************
+Copyright (c) 2023 Percona LLC and/or its affiliates.
+
+FIFO datasink implementation for XtraBackup.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+#include <my_base.h>
+#include <my_io.h>
+#include <my_thread_local.h>
+#include <mysql/service_mysql_alloc.h>
+#include <mysys_err.h>
+#include <mutex>
+#include <unordered_map>
+#include "common.h"
+#include "datasink.h"
+#include "file_utils.h"
+#include "msg.h"
+
+typedef struct {
+  /* List of FIFO files to be used for stream */
+  std::unordered_map<std::string, File> FIFO_list;
+  /* Mutex protecting FIFO list */
+  std::mutex fifo_mutex;
+
+  /* Add a new pair of fullpath and fd to FIFO_list */
+  void populate_list(std::string fullpath, File fd) {
+    std::lock_guard<std::mutex> g(fifo_mutex);
+    FIFO_list.insert({fullpath, fd});
+  }
+
+  /**
+  Get the first file from FIFO_list. This call will remove the
+  file from the list.
+  @return false in case of file found from list, true in case of error */
+  bool allocate_from_list(std::string &fullpath, File &fd) {
+    std::lock_guard<std::mutex> g(fifo_mutex);
+    auto fifo_it = FIFO_list.begin();
+    if (fifo_it == FIFO_list.end()) {
+      return true;
+    }
+    fullpath = fifo_it->first;
+    fd = fifo_it->second;
+    FIFO_list.erase(fifo_it);
+    return false;
+  }
+} ds_fifo_ctxt_t;
+
+typedef struct {
+  File fd;
+  char *path;
+  ds_fifo_ctxt_t *fifo_context;
+} ds_fifo_file_t;
+
+extern uint xtrabackup_fifo_streams;
+extern uint xtrabackup_fifo_timeout;
+static ds_ctxt_t *fifo_init(const char *root);
+static ds_file_t *fifo_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *mystat);
+static int fifo_write(ds_file_t *file, const void *buf, size_t len);
+static int fifo_close(ds_file_t *file);
+static void fifo_deinit(ds_ctxt_t *ctxt);
+
+datasink_t datasink_fifo = {&fifo_init, &fifo_open,  &fifo_write,
+                            nullptr,    &fifo_close, &fifo_deinit};
+
+static void cleanup_on_error(int idx, const char *root) {
+  std::string path;
+  char fullpath[FN_REFLEN];
+  for (int i = 0; i <= idx; i++) {
+    path = "thread_" + std::to_string(i);
+    fn_format(fullpath, path.c_str(), root, "", MYF(MY_RELATIVE_PATH));
+    unlink(fullpath);
+  }
+}
+
+/**
+Initialize FIFO datasink. This function is responsible for creating stream dir,
+and the fifo files
+
+@param [in]  root  path to create FIFO files.
+
+@return ds_ctxt_t object with a ptr to ds_fifo_ctxt_t object.
+NULL in case of error. */
+static ds_ctxt_t *fifo_init(const char *root) {
+  ds_fifo_ctxt_t *fifo_context = new ds_fifo_ctxt_t;
+  File fd;
+  ds_ctxt_t *ctxt = new ds_ctxt_t;
+  char fullpath[FN_REFLEN];
+
+  if (my_mkdir(root, 0600, MYF(0)) < 0 && my_errno() != EEXIST &&
+      my_errno() != EISDIR) {
+    char errbuf[MYSYS_STRERROR_SIZE];
+    my_error(EE_CANT_MKDIR, MYF(0), root, my_errno(),
+             my_strerror(errbuf, sizeof(errbuf), my_errno()));
+    return NULL;
+  }
+
+  for (uint i = 0; i < xtrabackup_fifo_streams; i++) {
+    std::string path = "thread_" + std::to_string(i);
+    fn_format(fullpath, path.c_str(), root, "", MYF(MY_RELATIVE_PATH));
+    if (mkfifo(fullpath, 0600) < 0) {
+      msg_ts("mkfifo(%s) failed with error %d\n", fullpath, errno);
+      if (errno == EEXIST) {
+        msg_ts(
+            "FIFO file %s already exists. Please ensure you don't have other "
+            "xtrabackup instance running, remove the file(s) and try again.\n",
+            fullpath);
+      } else {
+        cleanup_on_error(i, root);
+      }
+      return NULL;
+    }
+  }
+
+  for (uint i = 0; i < xtrabackup_fifo_streams; i++) {
+    std::string path = "thread_" + std::to_string(i);
+    fn_format(fullpath, path.c_str(), root, "", MYF(MY_RELATIVE_PATH));
+    fd = open_fifo_for_write_with_timeout(fullpath, xtrabackup_fifo_timeout);
+    if (fd < 0) {
+      cleanup_on_error(i, root);
+      return NULL;
+    }
+    fifo_context->populate_list(fullpath, fd);
+  }
+
+  ctxt->ptr = fifo_context;
+  ctxt->root = my_strdup(PSI_NOT_INSTRUMENTED, root, MYF(MY_FAE));
+
+  return ctxt;
+}
+
+static ds_file_t *fifo_open(ds_ctxt_t *ctxt,
+                            const char *path __attribute__((unused)),
+                            MY_STAT *mystat __attribute__((unused))) {
+  ds_fifo_ctxt_t *fifo_context = (ds_fifo_ctxt_t *)ctxt->ptr;
+  std::string fifo_path;
+  File fd;
+  if (fifo_context->allocate_from_list(fifo_path, fd)) return NULL;
+
+  size_t path_len = fifo_path.length() + 1; /* terminating '\0' */
+
+  ds_file_t *file = (ds_file_t *)my_malloc(
+      PSI_NOT_INSTRUMENTED,
+      sizeof(ds_file_t) + sizeof(ds_fifo_file_t) + path_len, MYF(MY_FAE));
+  ds_fifo_file_t *fifo_file = (ds_fifo_file_t *)(file + 1);
+
+  fifo_file->fd = fd;
+  fifo_file->fifo_context = fifo_context;
+  fifo_file->path = (char *)fifo_path.c_str();
+  file->path = (char *)fifo_file + sizeof(ds_fifo_file_t);
+  memcpy(file->path, fifo_path.c_str(), path_len);
+
+  file->ptr = fifo_file;
+
+  return file;
+}
+
+static int fifo_write(ds_file_t *file, const void *buf, size_t len) {
+  File fd = ((ds_fifo_file_t *)file->ptr)->fd;
+
+  if (!my_write(fd, static_cast<const uchar *>(buf), len,
+                MYF(MY_WME | MY_NABP))) {
+    posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    return 0;
+  }
+
+  return 1;
+}
+
+static int fifo_close(ds_file_t *file) {
+  ds_fifo_ctxt_t *fifo_context = ((ds_fifo_file_t *)file->ptr)->fifo_context;
+  File fd = ((ds_fifo_file_t *)file->ptr)->fd;
+  my_close(fd, MYF(MY_WME));
+  fifo_context->populate_list(((ds_fifo_file_t *)file)->path, fd);
+  my_free(file);
+
+  return 0;
+}
+
+static void fifo_deinit(ds_ctxt_t *ctxt) {
+  ds_fifo_ctxt_t *fifo_context = (ds_fifo_ctxt_t *)ctxt->ptr;
+  assert(fifo_context->FIFO_list.size() == xtrabackup_fifo_streams);
+  delete fifo_context;
+  my_free(ctxt->root);
+  delete ctxt;
+}

--- a/storage/innobase/xtrabackup/src/ds_fifo.h
+++ b/storage/innobase/xtrabackup/src/ds_fifo.h
@@ -1,0 +1,70 @@
+/******************************************************
+Copyright (c) 2023 Percona LLC and/or its affiliates.
+
+FIFO datasink interface for XtraBackup.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+/* FIFO Datasink implementation
+
+at xtrabackup_init_datasinks we initialize ds_data as DS_TYPE_FIFO, and create a ds object as XB_STREAM_FMT_XBSTREAM (xbstream).
+We adjust ds saying it has to pipe its data to DS_TYPE_FIFO and we adjust ds_data to xbstream.
+From this point forward we know we need to first convert the raw data we received from copy threads to xbstream and then later pipe the transformed data (xbstream format) to FIFO (same was there before but fixed to STDOUT).
+
+(gdb) p *ds_data
+$2 = {
+ datasink = 0x55555d670dc0 <datasink_xbstream>,
+ root = 0x0,
+ ptr = 0x55555e5af190,
+ pipe_ctxt = 0x55555e1e43f0,
+ fs_support_punch_hole = 105
+}
+(gdb) p *ds_data->pipe_ctxt
+$3 = {
+ datasink = 0x55555d670cc0 <datasink_fifo>,
+ root = 0x55555e15ae10 "/tmp/stream",
+ ptr = 0x55555e15ae50,
+ pipe_ctxt = 0x666e632e706d75,
+ fs_support_punch_hole = false
+}
+
+fifo_init - responsible for creating the stream dir and all the fifo files (thread_XX).
+Once created, we open them for writing at the init function despite the fact that we have an open function, this is because with FIFO / STDOUT we do not actually close the FD when a copy thread finishes its works on a specific data file, so ds_open / ds_close operate differently, ds_open just returns a ds_fifo_file_t as file(ds_file_t)->ptr back to xbstream datasink
+xbstream_init will create a list of ds_stream_ctxt_t, those stream contexts will later receive a fifo FD assigned to it. this list is called ds_parallel_stream_ctxt_t.
+at xtrabackup_copy_datafile (aka copy threads) we call ds_open passing ds_data (xbstream) as a parameter - xbstream_open will pick the first ds_stream_ctxt_t from the ds_parallel_stream_ctxt_t list and rotate it to the end of the list, so the next copy thread gets the next item on the list. Once we have our stream context assigned, we will check if it has a destination file assigned to it, if not we will do it via ds_open this time passing out destination datasink (either FIFO or STDOUT).
+FIFO datasink has a list of FIFO files it can assign on an open operation, when xbstream::ds_open calls FIFO::ds_open we assign the first FIFO file in the list and from this point forward that xbstream ds_stream_ctxt_t will be bound to this particular FIFO file. We do not assign the fifo file back to the list of fifo files as xbstream ds_stream_ctxt_t->fifo is a 1:1 mapping
+Note: an xbstream_close operation only ensures we write any remaining buffer data to FIFO/STDOUT, we do not close the FD assigned to that stream context. We only remove the binding of stream context to FIFO file at xbstream_deinit
+next xtrabackup_copy_datafile thread, will then go again to xbstream_open and this time it will get the next stream context from the list and same workflow will happen until the first stream context is reached again. When it happens, we will get a stream context assigned that already has a stream_ctxt->dest_file assigned and this is where we will start having multiple copy threads writing in parallel to the same stream
+In summary, the relationship is:
+ * Copy threads to stream context - N:1 - Multiple copy threads are assigned to the same xbstream context (this is done by the LRU pop_from & push_back)
+ * xbstream context -> FIFO file - 1:1 - One stream context to one fifo file, once a stream context has a fifo file assigned to it, it will remain bound to this FIFO until deinit
+Workflow:
+Before:
+ * copy_thread->stream_context->stdout
+Now:
+ * copy_thread->parallel_stream_ctxt->stream_context->fifo
+
+*/
+#ifndef DS_FIFO_H
+#define DS_FIFO_H
+
+#include "datasink.h"
+
+extern uint ds_fifo_threads;
+
+extern datasink_t datasink_fifo;
+
+#endif

--- a/storage/innobase/xtrabackup/src/ds_xbstream.cc
+++ b/storage/innobase/xtrabackup/src/ds_xbstream.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2013 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2023 Percona LLC and/or its affiliates.
 
 Streaming implementation for XtraBackup.
 
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_io.h>
 #include <mysql/service_mysql_alloc.h>
 #include <mysql_version.h>
+#include <list>
+#include <mutex>
 #include "common.h"
 #include "datasink.h"
 #include "msg.h"
@@ -30,14 +32,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 typedef struct {
   xb_wstream_t *xbstream;
   ds_file_t *dest_file;
-  pthread_mutex_t mutex;
+  std::mutex mutex;
 } ds_stream_ctxt_t;
+
+typedef struct {
+  std::list<ds_stream_ctxt_t *> ctx_list;
+  std::mutex mutex;
+} ds_parallel_stream_ctxt_t;
 
 typedef struct {
   xb_wstream_file_t *xbstream_file;
   ds_stream_ctxt_t *stream_ctxt;
 } ds_stream_file_t;
 
+extern uint xtrabackup_fifo_streams;
 /***********************************************************************
 General streaming interface */
 
@@ -75,28 +83,29 @@ static ssize_t my_xbstream_write_callback(xb_wstream_file_t *f
 
 static ds_ctxt_t *xbstream_init(const char *root __attribute__((unused))) {
   ds_ctxt_t *ctxt;
-  ds_stream_ctxt_t *stream_ctxt;
-  xb_wstream_t *xbstream;
+  ds_parallel_stream_ctxt_t *parallel_stream_ctxt =
+      new ds_parallel_stream_ctxt_t;
 
   ctxt = static_cast<ds_ctxt_t *>(
       my_malloc(PSI_NOT_INSTRUMENTED,
-                sizeof(ds_ctxt_t) + sizeof(ds_stream_ctxt_t), MYF(MY_FAE)));
-  stream_ctxt = (ds_stream_ctxt_t *)(ctxt + 1);
+                sizeof(ds_ctxt_t) + sizeof(ds_parallel_stream_ctxt_t) +
+                    (sizeof(ds_stream_ctxt_t) * (xtrabackup_fifo_streams + 1)),
+                MYF(MY_FAE)));
 
-  if (pthread_mutex_init(&stream_ctxt->mutex, NULL)) {
-    msg("xbstream_init: pthread_mutex_init() failed.\n");
-    goto err;
+  for (uint i = 0; i < xtrabackup_fifo_streams; i++) {
+    ds_stream_ctxt_t *stream_ctxt = new ds_stream_ctxt_t;
+    xb_wstream_t *xbstream;
+    xbstream = xb_stream_write_new();
+    if (xbstream == NULL) {
+      msg("xb_stream_write_new() failed.\n");
+      goto err;
+    }
+    stream_ctxt->xbstream = xbstream;
+    stream_ctxt->dest_file = NULL;
+    parallel_stream_ctxt->ctx_list.push_back(stream_ctxt);
   }
 
-  xbstream = xb_stream_write_new();
-  if (xbstream == NULL) {
-    msg("xb_stream_write_new() failed.\n");
-    goto err;
-  }
-  stream_ctxt->xbstream = xbstream;
-  stream_ctxt->dest_file = NULL;
-
-  ctxt->ptr = stream_ctxt;
+  ctxt->ptr = parallel_stream_ctxt;
 
   return ctxt;
 
@@ -108,6 +117,7 @@ err:
 static ds_file_t *xbstream_open(ds_ctxt_t *ctxt, const char *path,
                                 MY_STAT *mystat) {
   ds_file_t *file;
+  ds_parallel_stream_ctxt_t *parallel_stream_ctxt;
   ds_stream_file_t *stream_file;
   ds_stream_ctxt_t *stream_ctxt;
   ds_ctxt_t *dest_ctxt;
@@ -117,16 +127,21 @@ static ds_file_t *xbstream_open(ds_ctxt_t *ctxt, const char *path,
   xb_ad(ctxt->pipe_ctxt != NULL);
   dest_ctxt = ctxt->pipe_ctxt;
 
-  stream_ctxt = (ds_stream_ctxt_t *)ctxt->ptr;
+  parallel_stream_ctxt = (ds_parallel_stream_ctxt_t *)ctxt->ptr;
+  parallel_stream_ctxt->mutex.lock();
+  stream_ctxt = parallel_stream_ctxt->ctx_list.front();
+  parallel_stream_ctxt->ctx_list.pop_front();
+  parallel_stream_ctxt->ctx_list.push_back(stream_ctxt);
+  parallel_stream_ctxt->mutex.unlock();
 
-  pthread_mutex_lock(&stream_ctxt->mutex);
+  stream_ctxt->mutex.lock();
   if (stream_ctxt->dest_file == NULL) {
     stream_ctxt->dest_file = ds_open(dest_ctxt, path, mystat);
     if (stream_ctxt->dest_file == NULL) {
       return NULL;
     }
   }
-  pthread_mutex_unlock(&stream_ctxt->mutex);
+  stream_ctxt->mutex.unlock();
 
   file = (ds_file_t *)my_malloc(PSI_NOT_INSTRUMENTED,
                                 sizeof(ds_file_t) + sizeof(ds_stream_file_t),
@@ -210,20 +225,23 @@ static int xbstream_close(ds_file_t *file) {
 }
 
 static void xbstream_deinit(ds_ctxt_t *ctxt) {
+  ds_parallel_stream_ctxt_t *parallel_stream_ctxt =
+      (ds_parallel_stream_ctxt_t *)ctxt->ptr;
   ds_stream_ctxt_t *stream_ctxt;
 
-  stream_ctxt = (ds_stream_ctxt_t *)ctxt->ptr;
+  for (uint i = 0; i < xtrabackup_fifo_streams; i++) {
+    stream_ctxt = parallel_stream_ctxt->ctx_list.front();
+    parallel_stream_ctxt->ctx_list.pop_front();
+    if (xb_stream_write_done(stream_ctxt->xbstream)) {
+      msg("xb_stream_done() failed.\n");
+    }
 
-  if (xb_stream_write_done(stream_ctxt->xbstream)) {
-    msg("xb_stream_done() failed.\n");
+    if (stream_ctxt->dest_file) {
+      ds_close(stream_ctxt->dest_file);
+      stream_ctxt->dest_file = NULL;
+    }
+    delete stream_ctxt;
   }
-
-  if (stream_ctxt->dest_file) {
-    ds_close(stream_ctxt->dest_file);
-    stream_ctxt->dest_file = NULL;
-  }
-
-  pthread_mutex_destroy(&stream_ctxt->mutex);
-
+  delete parallel_stream_ctxt;
   my_free(ctxt);
 }

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2021 Percona LLC and/or its affiliates.
+Copyright (c) 2021-2023 Percona LLC and/or its affiliates.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -175,4 +175,29 @@ xb_fil_cur_result_t datafile_read(datafile_cur_t *cursor);
 */
 bool restore_sparseness(const char *src_file_path, uint buffer_size,
                         char error[512]);
+
+/**
+  Open FIFO file for writing. Wait up to timeout seconds for it to return a
+  valid file descriptor. This is done by opening it on non-blocking mode which
+  does not block if the file is not open for read. Then later changing FD mode
+  to blocking mode.
+
+  @param [in]       path      path to file
+  @param [in]       timeout   timeout in seconds.
+
+  @return file descriptor in case of success, -1 otherwise
+*/
+File open_fifo_for_write_with_timeout(const char *path, uint timeout);
+
+/**
+  Open FIFO file for reading. Wait up to timeout seconds for it to return a
+  valid file descriptor. This is done by opening it on non-blocking mode waiting
+  the FD to report EPOLLIN (FD ready for read).
+
+  @param [in]       path      path to file
+  @param [in]       timeout   timeout in seconds.
+
+  @return file descriptor in case of success, -1 otherwise
+*/
+File open_fifo_for_read_with_timeout(const char *path, uint timeout);
 #endif

--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Percona and/or its affiliates. All rights reserved.
+# Copyright (c) 2019-2023 Percona and/or its affiliates. All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,6 +51,7 @@ MYSQL_ADD_EXECUTABLE(xbcloud
   s3.cc
   s3_ec2.cc
   ../xbcrypt_common.cc
+  ../file_utils.cc
   swift.cc)
 
 SET_TARGET_PROPERTIES(xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2019, 2021 Percona LLC and/or its affiliates.
+Copyright (c) 2019, 2023 Percona LLC and/or its affiliates.
 
 HTTP client implementation using cURL.
 
@@ -639,7 +639,7 @@ void Http_client::callback(CLIENT *client, std::string container,
                   std::placeholders::_1, std::placeholders::_2, count + 1),
         true);
     return;
-  } else if (count > client->get_max_retries())
+  } else if (retry_error && count > client->get_max_retries())
     msg_ts("%s: No more retries for %s\n", my_progname, name.c_str());
 
   if (callback) {

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.h
@@ -1,0 +1,186 @@
+/******************************************************
+Copyright (c) 2014, 2023 Percona LLC and/or its affiliates.
+
+xbcloud utility. Manage backups on cloud storage services.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+
+struct file_metadata_t {
+  my_off_t last_chunk;
+  my_off_t next_chunk;
+  std::string name;
+};
+
+/** struct to hold state of current per thread in progress files. This avoids
+ * multiple chunks from the same file to be downloaded in parallel */
+struct thread_state_t {
+  std::mutex m;
+  /* files with active chunks been downloaded (waiting http client to complete
+   * the download) */
+  std::set<std::string> in_progress_files;
+
+  /* list of files allocated for this thread */
+  std::unordered_map<std::string, file_metadata_t> file_list;
+
+  /**
+  Check if there is any file been downloaded.
+
+  @return false if there are files been downloaded, true otherwise. */
+  bool in_progress_files_empty() {
+    std::lock_guard<std::mutex> g(m);
+    return in_progress_files.empty();
+  }
+
+  /**
+  Check the number of files been downloaded.
+
+  @return Number of files in in_progress_files list. */
+  my_off_t in_progress_files_size() {
+    std::lock_guard<std::mutex> g(m);
+    return in_progress_files.size();
+  }
+
+  /**
+  Check if there is any file allocated for this thread.
+
+  @return false if there are no allocated files, true otherwise. */
+  bool file_list_empty() {
+    std::lock_guard<std::mutex> g(m);
+    return file_list.empty();
+  }
+
+  /**
+  Get the next available file to be downloaded. The file is on file_list
+  (allocated to this thread) and has no in progress chunks been downloaded.
+
+  @param [in/out]  file  file available to download.
+
+  @return true if a file has been allocated, false otherwise */
+  bool next_file(file_metadata_t &file) {
+    std::lock_guard<std::mutex> g(m);
+    if (!file_list.empty()) {
+      for (auto it : file_list) {
+        if (in_progress_files.count(it.first) == 0) {
+          file = it.second;
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+  Get the next chunk for a given file.
+
+  @param [in]  file  file to get the next chunk.
+
+  @return id of next available chunk */
+  my_off_t next_chunk(file_metadata_t &file) {
+    std::lock_guard<std::mutex> g(m);
+    auto it = file_list.find(file.name);
+    assert(it != file_list.end());
+    return it->second.next_chunk;
+  }
+
+  /**
+  Attempt to reserve ownsership of a file with intend to start downloading it.
+  This will add the file into both in_progress_files list and file_list list.
+
+  @param [in]  file  file to attempt to reserve.
+
+  @return true if the file is not already in progress, false otherwise. */
+  bool start_file(const file_metadata_t &file) {
+    std::lock_guard<std::mutex> g(m);
+    if (in_progress_files.count(file.name) > 0) {
+      return false;
+    }
+    in_progress_files.insert(file.name);
+    file_list.insert({file.name, file});
+    return true;
+  }
+
+  /**
+  Indicates the current chunk of a given file has been completed.
+  This will remove the file from in_progress_files list. If this is the last
+  chunk for this file, it will remove the file from file_list otherwise advance
+  the next_chunk of the file.
+
+  @param [in]  file  filen to complete chunk.
+  @param [in]  idx   chunk index that we have completed. */
+  void complete_chunk(const file_metadata_t &file, const my_off_t &idx) {
+    std::lock_guard<std::mutex> g(m);
+    in_progress_files.erase(file.name);
+    auto it = file_list.find(file.name);
+    assert(it != file_list.end());
+    if (file.last_chunk == idx)
+      file_list.erase(it);
+    else
+      it->second.next_chunk++;
+  }
+};
+
+/* Thread safe global file list */
+struct global_list_t {
+  std::mutex m;
+  /* Global list of files to be downloaded*/
+  std::unordered_map<std::string, file_metadata_t> files;
+
+  /**
+  Check if the file list is empty.
+
+  @return false if there are files in the list, true otherwise. */
+  bool empty() {
+    std::lock_guard<std::mutex> g(m);
+    return files.empty();
+  }
+
+  /**
+  Get the next available file to be downloaded from global list. The file
+  will be removed from this list. The caller must allocate the file into
+  its own thread file list.
+
+  @param [in/out]  file  file available to download.
+
+  @return true if a file has been allocated, false otherwise */
+  bool next_file(file_metadata_t &file) {
+    std::lock_guard<std::mutex> g(m);
+    if (!files.empty()) {
+      auto it = files.begin();
+      file = it->second;
+      files.erase(it);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+  Adds a new file to global list of files or update the last_chunk if necessary.
+
+  @param [in]  filename   filename of the new file.
+  @param [in]  idx        chunk index of the file. */
+  void add(std::string filename, size_t idx) {
+    std::lock_guard<std::mutex> g(m);
+    if (files.find(filename) == files.end()) {
+      file_metadata_t file;
+      file.name = filename;
+      file.last_chunk = idx;
+      file.next_chunk = 0;
+      files.insert({filename, file});
+    } else {
+      if (files[filename].last_chunk < idx) files[filename].last_chunk = idx;
+    }
+  }
+};

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2013-2022 Percona LLC and/or its affiliates.
+Copyright (c) 2013-2023 Percona LLC and/or its affiliates.
 
 The xbcrypt utility: decrypt files in the XBCRYPT format.
 
@@ -121,6 +121,7 @@ datasink_t datasink_decompress_lz4;
 datasink_t datasink_decompress_zstd;
 datasink_t datasink_tmpfile;
 datasink_t datasink_buffer;
+datasink_t datasink_fifo;
 
 static int get_options(int *argc, char ***argv);
 

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -1,5 +1,6 @@
 /******************************************************
-Copyright (c) 2011-2022 Percona LLC and/or its affiliates.
+
+Copyright (c) 2011-2023 Percona LLC and/or its affiliates.
 
 The xbstream utility: serialize/deserialize files in the XBSTREAM format.
 
@@ -25,9 +26,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_thread.h>
 #include <mysql/service_mysql_alloc.h>
 #include <mysql_version.h>
-#include <pthread.h>
 #include <typelib.h>
+#include <mutex>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 #include "common.h"
 #include "crc_glue.h"
 #include "datasink.h"
@@ -62,11 +65,15 @@ datasink_t datasink_compress_lz4;
 datasink_t datasink_compress_zstd;
 datasink_t datasink_tmpfile;
 datasink_t datasink_encrypt;
+datasink_t datasink_fifo;
 
 static run_mode_t opt_mode;
 static char *opt_directory = NULL;
 static bool opt_verbose = 0;
 static int opt_parallel = 1;
+static int opt_fifo_streams = 1;
+static char *opt_fifo_dir = nullptr;
+static uint opt_fifo_timeout = 60;
 static ulong opt_encrypt_algo;
 static char *opt_encrypt_key_file = NULL;
 static char *opt_encrypt_key = NULL;
@@ -78,7 +85,14 @@ static bool opt_absolute_names = 0;
 static const int compression_prefix_len = 4;
 static const int compression_and_encryption_prefix_len = 12;
 
-enum { OPT_DECOMPRESS = 256, OPT_DECOMPRESS_THREADS, OPT_ENCRYPT_THREADS };
+enum {
+  OPT_DECOMPRESS = 256,
+  OPT_DECOMPRESS_THREADS,
+  OPT_ENCRYPT_THREADS,
+  OPT_PARALLEL,
+  OPT_FIFO_DIR,
+  OPT_FIFO_TIMEOUT
+};
 
 static struct my_option my_long_options[] = {
     {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG, 0,
@@ -105,9 +119,21 @@ static struct my_option my_long_options[] = {
      0, 0},
     {"verbose", 'v', "Print verbose output.", &opt_verbose, &opt_verbose, 0,
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-    {"parallel", 'p', "Number of worker threads for reading / writing.",
+    {"parallel", OPT_PARALLEL,
+     "Deprecated. Use --fifo-streams instead. Number of worker threads for "
+     "reading / writing.",
      &opt_parallel, &opt_parallel, 0, GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0,
      0, 0},
+    {"fifo-streams", 'f', "Number of worker threads for reading / writing.",
+     &opt_fifo_streams, &opt_fifo_streams, 0, GET_INT, REQUIRED_ARG, 1, 1,
+     INT_MAX, 0, 0, 0},
+    {"fifo-dir", OPT_FIFO_DIR, "Directory to read Named Pipe.", &opt_fifo_dir,
+     &opt_fifo_dir, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+    {"fifo-timeout", OPT_FIFO_TIMEOUT,
+     "How many seconds to wait for other end to open the stream. "
+     "Default 60 seconds",
+     &opt_fifo_timeout, &opt_fifo_timeout, 0, GET_INT, REQUIRED_ARG, 60, 1,
+     INT_MAX, 0, 0, 0},
     {"decrypt", 'd', "Decrypt files ending with .xbcrypt.", &opt_encrypt_algo,
      &opt_encrypt_algo, &xbstream_encrypt_algo_typelib, GET_ENUM, REQUIRED_ARG,
      0, 0, 0, 0, 0, 0},
@@ -133,12 +159,12 @@ typedef struct {
   uint pathlen;
   my_off_t offset;
   ds_file_t *file;
-  pthread_mutex_t mutex;
+  std::mutex mutex;
 } file_entry_t;
 
 typedef struct {
-  std::unordered_map<std::string, file_entry_t *> filehash;
-  xb_rstream_t *stream;
+  int thread_id;
+  std::unordered_map<std::string, file_entry_t *> *filehash;
   ds_ctxt_t *ds_ctxt;
   ds_ctxt_t *ds_decompress_quicklz_ctxt;
   ds_ctxt_t *ds_decompress_lz4_ctxt;
@@ -147,7 +173,8 @@ typedef struct {
   ds_ctxt_t *ds_decrypt_lz4_ctxt;
   ds_ctxt_t *ds_decrypt_zstd_ctxt;
   ds_ctxt_t *ds_decrypt_uncompressed_ctxt;
-  pthread_mutex_t *mutex;
+  std::mutex *mutex;
+  std::atomic<bool> *has_errors;
 } extract_ctxt_t;
 
 static int get_options(int *argc, char ***argv);
@@ -175,6 +202,18 @@ int main(int argc, char **argv) {
     goto err;
   }
 
+  if (opt_parallel > 1 && opt_fifo_streams == 1) {
+    msg("%s: option --parallel is deprecated and has no effect. Please use "
+        "--fifo-streams instead.\n",
+        my_progname);
+  }
+
+  if (opt_mode == RUN_MODE_EXTRACT && opt_fifo_streams > 1 &&
+      opt_fifo_dir == nullptr) {
+    msg("%s: --fifo-streams requires --fifo-dir parameter.\n", my_progname);
+    goto err;
+  }
+
   if (opt_encrypt_algo || opt_encrypt_key) {
     xb_libgcrypt_init();
   }
@@ -182,7 +221,7 @@ int main(int argc, char **argv) {
   if (opt_mode == RUN_MODE_CREATE && mode_create(argc, argv)) {
     goto err;
   } else if (opt_mode == RUN_MODE_EXTRACT &&
-             mode_extract(opt_parallel, argc, argv)) {
+             mode_extract(opt_fifo_streams, argc, argv)) {
     goto err;
   }
 
@@ -427,8 +466,6 @@ static file_entry_t *file_entry_new(extract_ctxt_t *ctxt, const char *path,
 
   entry->file = file;
 
-  pthread_mutex_init(&entry->mutex, NULL);
-
   return entry;
 
 err:
@@ -441,36 +478,58 @@ err:
 }
 
 static void file_entry_free(file_entry_t *entry) {
-  pthread_mutex_destroy(&entry->mutex);
   ds_close(entry->file);
   my_free(entry->path);
   my_free(entry);
 }
 
-static void *extract_worker_thread_func(void *arg) {
+static void extract_worker_thread_func(extract_ctxt_t &ctxt) {
+  xb_rstream_t *stream = NULL;
   xb_rstream_chunk_t chunk;
   file_entry_t *entry;
   xb_rstream_result_t res;
-
-  extract_ctxt_t *ctxt = (extract_ctxt_t *)arg;
+  if (opt_fifo_streams > 1) {
+    char filename[FN_REFLEN];
+    snprintf(filename, sizeof(filename), "%s%s%lu", opt_fifo_dir, "/thread_",
+             (ulong)ctxt.thread_id);
+    stream = xb_stream_read_new_fifo(filename, opt_fifo_timeout);
+    if (stream == nullptr) {
+      msg_ts(
+          "%s: xb_stream_read_new_fifo() failed for thread %d. Possibly sender "
+          "did "
+          "not start.\n",
+          my_progname, ctxt.thread_id);
+      ctxt.has_errors->store(true);
+      return;
+    }
+  } else {
+    stream = xb_stream_read_new_stdin();
+    if (stream == NULL) {
+      msg("%s: xb_stream_read_new_stdin() failed.\n", my_progname);
+      ctxt.has_errors->store(true);
+      return;
+    }
+  }
 
   my_thread_init();
 
   memset(&chunk, 0, sizeof(chunk));
 
   while (1) {
-    pthread_mutex_lock(ctxt->mutex);
-    res = xb_stream_read_chunk(ctxt->stream, &chunk);
+    /* Abort in case of error in any thread */
+    if (ctxt.has_errors->load()) {
+      break;
+    }
+
+    res = xb_stream_read_chunk(stream, &chunk);
 
     if (res != XB_STREAM_READ_CHUNK) {
-      pthread_mutex_unlock(ctxt->mutex);
       break;
     }
 
     /* If unknown type and ignorable flag is set, skip this chunk */
     if (chunk.type == XB_CHUNK_TYPE_UNKNOWN &&
         !(chunk.flags & XB_STREAM_FLAG_IGNORABLE)) {
-      pthread_mutex_unlock(ctxt->mutex);
       continue;
     }
 
@@ -481,27 +540,30 @@ static void *extract_worker_thread_func(void *arg) {
         msg("%s: absolute path not allowed: %.*s.\n", my_progname,
             chunk.pathlen, chunk.path);
         res = XB_STREAM_READ_ERROR;
-        pthread_mutex_unlock(ctxt->mutex);
         break;
       }
     }
 
+    ctxt.mutex->lock();
     /* See if we already have this file open */
-    entry = ctxt->filehash[chunk.path];
+    std::unordered_map<std::string, file_entry_t *>::const_iterator entry_it =
+        ctxt.filehash->find(chunk.path);
 
-    if (entry == NULL) {
-      entry = file_entry_new(ctxt, chunk.path, chunk.pathlen);
+    if (entry_it == ctxt.filehash->end()) {
+      entry = file_entry_new(&ctxt, chunk.path, chunk.pathlen);
       if (entry == NULL) {
         res = XB_STREAM_READ_ERROR;
-        pthread_mutex_unlock(ctxt->mutex);
+        ctxt.mutex->unlock();
         break;
       }
-      ctxt->filehash[chunk.path] = entry;
+      ctxt.filehash->insert({chunk.path, entry});
+    } else {
+      entry = entry_it->second;
     }
 
-    pthread_mutex_lock(&entry->mutex);
+    entry->mutex.lock();
 
-    pthread_mutex_unlock(ctxt->mutex);
+    ctxt.mutex->unlock();
 
     if (chunk.type == XB_CHUNK_TYPE_PAYLOAD ||
         chunk.type == XB_CHUNK_TYPE_SPARSE) {
@@ -509,21 +571,21 @@ static void *extract_worker_thread_func(void *arg) {
     }
 
     if (res != XB_STREAM_READ_CHUNK) {
-      pthread_mutex_unlock(&entry->mutex);
+      entry->mutex.unlock();
       break;
     }
 
     if (chunk.type == XB_CHUNK_TYPE_EOF) {
-      pthread_mutex_lock(ctxt->mutex);
-      pthread_mutex_unlock(&entry->mutex);
-      ctxt->filehash.erase(entry->path);
+      ctxt.mutex->lock();
+      entry->mutex.unlock();
+      ctxt.filehash->erase(entry->path);
       file_entry_free(entry);
-      pthread_mutex_unlock(ctxt->mutex);
+      ctxt.mutex->unlock();
       /*
        * no need for mutex here. At this point, we are guarantee that all other
        * threads have completed its work with this file
        */
-      if (opt_decompress && ctxt->ds_ctxt->fs_support_punch_hole &&
+      if (opt_decompress && ctxt.ds_ctxt->fs_support_punch_hole &&
           (is_compressed_suffix(chunk.path) ||
            is_encrypted_and_compressed_suffix(chunk.path))) {
         char path[FN_REFLEN] = {0};
@@ -549,7 +611,7 @@ static void *extract_worker_thread_func(void *arg) {
       msg("%s: out-of-order chunk: real offset = 0x%llx, "
           "expected offset = 0x%llx\n",
           my_progname, chunk.offset, entry->offset);
-      pthread_mutex_unlock(&entry->mutex);
+      entry->mutex.unlock();
       res = XB_STREAM_READ_ERROR;
       break;
     }
@@ -557,7 +619,7 @@ static void *extract_worker_thread_func(void *arg) {
     if (chunk.type == XB_CHUNK_TYPE_PAYLOAD) {
       if (ds_write(entry->file, chunk.data, chunk.length)) {
         msg("%s: my_write() failed.\n", my_progname);
-        pthread_mutex_unlock(&entry->mutex);
+        entry->mutex.unlock();
         res = XB_STREAM_READ_ERROR;
         break;
       }
@@ -566,9 +628,9 @@ static void *extract_worker_thread_func(void *arg) {
     } else if (chunk.type == XB_CHUNK_TYPE_SPARSE) {
       if (ds_write_sparse(entry->file, chunk.data, chunk.length,
                           chunk.sparse_map_size, chunk.sparse_map,
-                          ctxt->ds_ctxt->fs_support_punch_hole)) {
+                          ctxt.ds_ctxt->fs_support_punch_hole)) {
         msg("%s: my_write() failed.\n", my_progname);
-        pthread_mutex_unlock(&entry->mutex);
+        entry->mutex.unlock();
         res = XB_STREAM_READ_ERROR;
         break;
       }
@@ -578,20 +640,20 @@ static void *extract_worker_thread_func(void *arg) {
       entry->offset += chunk.length;
     }
 
-    pthread_mutex_unlock(&entry->mutex);
+    entry->mutex.unlock();
   }
 
+  xb_stream_read_done(stream);
   my_free(chunk.raw_data);
   my_free(chunk.sparse_map);
 
   my_thread_end();
 
-  return (void *)(res);
+  if (res == XB_STREAM_READ_ERROR) ctxt.has_errors->store(res);
 }
 
 static int mode_extract(int n_threads, int argc __attribute__((unused)),
                         char **argv __attribute__((unused))) {
-  xb_rstream_t *stream = NULL;
   ds_ctxt_t *ds_ctxt = NULL;
   ds_ctxt_t *ds_decrypt_lz4_ctxt = NULL;
   ds_ctxt_t *ds_decrypt_zstd_ctxt = NULL;
@@ -600,17 +662,14 @@ static int mode_extract(int n_threads, int argc __attribute__((unused)),
   ds_ctxt_t *ds_decompress_quicklz_ctxt = NULL;
   ds_ctxt_t *ds_decompress_lz4_ctxt = NULL;
   ds_ctxt_t *ds_decompress_zstd_ctxt = NULL;
-  extract_ctxt_t ctxt;
+  extract_ctxt_t *data_threads = NULL;
+  std::atomic<bool> has_errors{false};
+  std::vector<std::thread> threads;
+  std::unordered_map<std::string, file_entry_t *> *filehash =
+      new std::unordered_map<std::string, file_entry_t *>();
   int i;
-  pthread_t *tids = NULL;
-  void **retvals = NULL;
-  pthread_mutex_t mutex;
+  std::mutex mutex;
   int ret = 0;
-
-  if (pthread_mutex_init(&mutex, NULL)) {
-    msg("%s: failed to initialize mutex.\n", my_progname);
-    return 1;
-  }
 
   /* If --directory is specified, it is already set as CWD by now. */
   ds_ctxt = ds_create(".", DS_TYPE_LOCAL);
@@ -668,46 +727,40 @@ static int mode_extract(int n_threads, int argc __attribute__((unused)),
       ds_set_pipe(ds_decrypt_zstd_ctxt, ds_decompress_zstd_ctxt);
     }
   }
+  data_threads = (extract_ctxt_t *)my_malloc(
+      PSI_NOT_INSTRUMENTED, sizeof(extract_ctxt_t) * (n_threads + 1),
+      MYF(MY_FAE));
+  for (int i = 0; i < n_threads; i++) {
+    data_threads[i].thread_id = i;
+    data_threads[i].filehash = filehash;
+    data_threads[i].ds_ctxt = ds_ctxt;
+    data_threads[i].ds_decompress_quicklz_ctxt = ds_decompress_quicklz_ctxt;
+    data_threads[i].ds_decompress_lz4_ctxt = ds_decompress_lz4_ctxt;
+    data_threads[i].ds_decompress_zstd_ctxt = ds_decompress_zstd_ctxt;
+    data_threads[i].ds_decrypt_uncompressed_ctxt = ds_decrypt_uncompressed_ctxt;
+    data_threads[i].ds_decrypt_quicklz_ctxt = ds_decrypt_quicklz_ctxt;
+    data_threads[i].ds_decrypt_lz4_ctxt = ds_decrypt_lz4_ctxt;
+    data_threads[i].ds_decrypt_zstd_ctxt = ds_decrypt_zstd_ctxt;
+    data_threads[i].mutex = &mutex;
+    data_threads[i].has_errors = &has_errors;
 
-  stream = xb_stream_read_new();
-  if (stream == NULL) {
-    msg("%s: xb_stream_read_new() failed.\n", my_progname);
-    pthread_mutex_destroy(&mutex);
-    ret = 1;
-    goto exit;
+    threads.push_back(
+        std::thread(extract_worker_thread_func, std::ref(data_threads[i])));
   }
 
-  ctxt.stream = stream;
-  ctxt.ds_ctxt = ds_ctxt;
-  ctxt.ds_decompress_quicklz_ctxt = ds_decompress_quicklz_ctxt;
-  ctxt.ds_decompress_lz4_ctxt = ds_decompress_lz4_ctxt;
-  ctxt.ds_decompress_zstd_ctxt = ds_decompress_zstd_ctxt;
-  ctxt.ds_decrypt_uncompressed_ctxt = ds_decrypt_uncompressed_ctxt;
-  ctxt.ds_decrypt_quicklz_ctxt = ds_decrypt_quicklz_ctxt;
-  ctxt.ds_decrypt_lz4_ctxt = ds_decrypt_lz4_ctxt;
-  ctxt.ds_decrypt_zstd_ctxt = ds_decrypt_zstd_ctxt;
-  ctxt.mutex = &mutex;
+  for (i = 0; i < n_threads; i++) threads.at(i).join();
 
-  tids = new pthread_t[n_threads];
-  retvals = new void *[n_threads];
-
-  for (i = 0; i < n_threads; i++)
-    pthread_create(tids + i, NULL, extract_worker_thread_func, &ctxt);
-
-  for (i = 0; i < n_threads; i++) pthread_join(tids[i], retvals + i);
-
-  for (i = 0; i < n_threads; i++) {
-    if ((ulong)retvals[i] == XB_STREAM_READ_ERROR) {
-      ret = 1;
-      goto exit;
-    }
-  }
+  if (has_errors.load()) ret = 1;
 
 exit:
-  pthread_mutex_destroy(&mutex);
 
-  delete[] tids;
-  delete[] retvals;
+  for (uint i = 0; i < (uint)n_threads; i++) {
+    char filename[FN_REFLEN];
+    snprintf(filename, sizeof(filename), "%s%s%lu", opt_fifo_dir, "/thread_",
+             (ulong)i);
+    unlink(filename);
+  }
+  delete filehash;
 
   if (ds_ctxt != NULL) {
     ds_destroy(ds_ctxt);
@@ -733,7 +786,10 @@ exit:
   if (ds_decompress_quicklz_ctxt != NULL) {
     ds_destroy(ds_decompress_quicklz_ctxt);
   }
-  xb_stream_read_done(stream);
+
+  if (data_threads != nullptr) {
+    my_free(data_threads);
+  }
 
   if (ret) {
     msg("exit code: %d\n", ret);

--- a/storage/innobase/xtrabackup/src/xbstream.h
+++ b/storage/innobase/xtrabackup/src/xbstream.h
@@ -1,5 +1,5 @@
 /******************************************************
-Copyright (c) 2011-2017 Percona LLC and/or its affiliates.
+Copyright (c) 2011-2023 Percona LLC and/or its affiliates.
 
 The xbstream format interface.
 
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_base.h>
 #include <my_dir.h>
 #include <my_io.h>
+#include <string>
 #include "datasink.h"
 
 /* Magic value in a chunk header */
@@ -105,7 +106,22 @@ typedef struct {
   ds_sparse_chunk_t *sparse_map;
 } xb_rstream_chunk_t;
 
-xb_rstream_t *xb_stream_read_new(void);
+/**
+ * Open FIFO file for reading
+ *
+ * @param[in] path      Path of FIFO file
+ * @param[in] timeout   Timeout in seconds
+ *
+ * @return pointer to xb_rstream_t object or nullptr in case of error
+ */
+xb_rstream_t *xb_stream_read_new_fifo(const char *path, int timeout);
+
+/**
+ * Open STDIN for reading
+ *
+ * @return pointer to xb_rstream_t object
+ */
+xb_rstream_t *xb_stream_read_new_stdin(void);
 
 xb_rstream_result_t xb_stream_read_chunk(xb_rstream_t *stream,
                                          xb_rstream_chunk_t *chunk);

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -242,6 +242,10 @@ bool io_watching_thread_running = false;
 bool xtrabackup_logfile_is_renamed = false;
 
 int xtrabackup_parallel;
+int xtrabackup_fifo_streams;
+bool xtrabackup_fifo_streams_set = false;
+uint xtrabackup_fifo_timeout = 60;
+char *xtrabackup_fifo_dir = NULL;
 bool opt_strict = true;
 
 char *xtrabackup_stream_str = NULL;
@@ -623,7 +627,10 @@ enum options_xtrabackup {
   OPT_XTRA_DATABASES_FILE,
   OPT_XTRA_CREATE_IB_LOGFILE,
   OPT_XTRA_PARALLEL,
+  OPT_XTRA_FIFO_STREAMS,
   OPT_XTRA_STREAM,
+  OPT_XTRA_FIFO_DIR,
+  OPT_XTRA_FIFO_TIMEOUT,
   OPT_XTRA_STRICT,
   OPT_XTRA_COMPRESS,
   OPT_XTRA_COMPRESS_THREADS,
@@ -897,11 +904,11 @@ struct my_option xb_client_options[] = {
      0},
 
     {"stream", OPT_XTRA_STREAM,
-     "Stream all backup files to the standard output "
-     "in the specified format. Currently supported formats are 'tar' and "
-     "'xbstream'.",
+     "Stream all backup files using xbstream format. Files are streamed to "
+     "STDOUT or FIFO files depending on --fifo-streams option. The only "
+     "supported stream format is 'xbstream'.",
      (G_PTR *)&xtrabackup_stream_str, (G_PTR *)&xtrabackup_stream_str, 0,
-     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
     {"compress", OPT_XTRA_COMPRESS,
      "Compress individual backup files using the specified compression "
@@ -1367,6 +1374,23 @@ struct my_option xb_client_options[] = {
      "The default value is 1.",
      (G_PTR *)&xtrabackup_parallel, (G_PTR *)&xtrabackup_parallel, 0, GET_INT,
      REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
+
+    {"fifo-streams", OPT_XTRA_FIFO_STREAMS,
+     "Number of FIFO files to use for parallel datafiles stream. Setting this "
+     "parameter to 1 disables FIFO and stream is sent to STDOUT.",
+     (G_PTR *)&xtrabackup_fifo_streams, (G_PTR *)&xtrabackup_fifo_streams, 0,
+     GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
+
+    {"fifo-dir", OPT_XTRA_FIFO_DIR,
+     "Directory to write Named Pipe. If ommited, we use --target-dir",
+     &xtrabackup_fifo_dir, &xtrabackup_fifo_dir, 0, GET_STR_ALLOC, REQUIRED_ARG,
+     0, 0, 0, 0, 0, 0},
+
+    {"fifo-timeout", OPT_XTRA_FIFO_TIMEOUT,
+     "How many seconds to wait for other end to open the fifo stream for "
+     "reading. Default 60 seconds",
+     (G_PTR *)&xtrabackup_fifo_timeout, (G_PTR *)&xtrabackup_fifo_timeout, 0,
+     GET_INT, REQUIRED_ARG, 60, 1, INT_MAX, 0, 0, 0},
 
     {"strict", OPT_XTRA_STRICT,
      "Fail with error when invalid arguments were passed to the xtrabackup.",
@@ -1848,13 +1872,16 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
       xtrabackup_target_dir = xtrabackup_real_target_dir;
       break;
     case OPT_XTRA_STREAM:
-      if (!strcasecmp(argument, "xbstream"))
+      if (argument == NULL || !strcasecmp(argument, "xbstream"))
         xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
       else {
         xb::error() << "Invalid --stream argument: " << argument;
         return 1;
       }
       xtrabackup_stream = true;
+      break;
+    case OPT_XTRA_FIFO_STREAMS:
+      xtrabackup_fifo_streams_set = true;
       break;
     case OPT_XTRA_COMPRESS:
       if (argument == NULL) {
@@ -3517,9 +3544,20 @@ files first, and then streams them in a serialized way when closed. */
 static void xtrabackup_init_datasinks(void) {
   /* Start building out the pipelines from the terminus back */
   if (xtrabackup_stream) {
-    /* All streaming goes to stdout */
-    ds_data = ds_meta = ds_redo =
-        ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
+    if (xtrabackup_fifo_streams > 1) {
+      /* Use Named PIPEs */
+      xb::info() << "Creating " << xtrabackup_fifo_streams
+                 << " Named Pipes(FIFO) at folder " << xtrabackup_target_dir
+                 << ". Waiting up to " << xtrabackup_fifo_timeout
+                 << " second(s) for xbstream/xbcloud to open the "
+                    "files for reading.\n";
+      ds_data = ds_meta = ds_redo =
+          ds_create(xtrabackup_target_dir, DS_TYPE_FIFO);
+    } else {
+      /* All streaming goes to stdout */
+      ds_data = ds_meta = ds_redo =
+          ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
+    }
   } else {
     /* Local filesystem */
     ds_data = ds_meta = ds_redo =
@@ -4414,6 +4452,25 @@ void xtrabackup_backup_func(void) {
     xb::error() << "cannot mkdir: " << my_errno() << " "
                 << xtrabackup_extra_lsndir;
     exit(EXIT_FAILURE);
+  }
+
+  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir != NULL) {
+    xtrabackup_target_dir = xtrabackup_fifo_dir;
+  }
+
+  if (xtrabackup_fifo_streams_set && !xtrabackup_stream) {
+    xb::info() << "Option --fifo-streams require xbstream format. Setting "
+                  "--stream to xbstream.";
+    xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
+    xtrabackup_stream = true;
+  }
+
+  if (xtrabackup_fifo_streams_set &&
+      xtrabackup_fifo_streams > xtrabackup_parallel) {
+    xb::info() << "Option --fifo-streams set higer than --parallel. "
+                  "Adjusting --parallel to "
+               << xtrabackup_fifo_streams;
+    xtrabackup_parallel = xtrabackup_fifo_streams;
   }
 
   /* create target dir if not exist */
@@ -8124,6 +8181,12 @@ int main(int argc, char **argv) {
       (strcmp(mysql_data_home, "./") == 0)) {
     if (!xtrabackup_print_param) usage();
     xb::error() << "Please set parameter 'datadir'";
+    exit(EXIT_FAILURE);
+  }
+
+  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir == NULL &&
+      strcmp(xtrabackup_target_dir, "./xtrabackup_backupfiles/") == 0) {
+    xb::error() << "Option --fifo-streams requires --fifo-dir to be set.";
     exit(EXIT_FAILURE);
   }
 

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -833,7 +833,7 @@ function verify_db_state()
 {
     $MYSQLDUMP $MYSQL_ARGS $MYSQLDUMP_ARGS -t --compact --skip-extended-insert \
         $1 >"$topdir/tmp/$1_new.sql"
-    diff -u "$topdir/tmp/$1_old.sql" "$topdir/tmp/$1_new.sql"
+    run_cmd diff -u "$topdir/tmp/$1_old.sql" "$topdir/tmp/$1_new.sql"
 }
 
 ########################################################################

--- a/storage/innobase/xtrabackup/test/inc/fifo_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/fifo_common.sh
@@ -1,0 +1,50 @@
+function create_base_table() {
+  mysql -e "CREATE TABLE t (ID INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO t VALUES();" test
+}
+
+function run_insert() {
+  for i in {1..100} ; do
+      mysql -e "INSERT INTO t VALUES ()" test
+  done 1>/dev/null 2>/dev/null
+}
+
+function take_backup_fifo_xbstream()
+{
+  local stream_dir=$1
+  local xtrabackup_args=$2
+  local xbstream_args=$3
+
+  xtrabackup --backup ${xtrabackup_args} --target-dir=${stream_dir} &
+  pxb_pid=$!
+  wait_for_file_to_generated ${stream_dir}/thread_0
+  xbstream ${xbstream_args} --fifo-dir=${stream_dir}
+  wait ${pxb_pid}
+}
+
+function take_backup_fifo_xbcloud()
+{
+  local stream_dir=$1
+  local xtrabackup_args=$2
+  local xbcloud_args=$3
+
+  xtrabackup --backup ${xtrabackup_args} --target-dir=${stream_dir} &
+  pxb_pid=$!
+  wait_for_file_to_generated ${stream_dir}/thread_0
+  xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+  --fifo-dir=${stream_dir} ${xbcloud_args}
+  wait ${pxb_pid}
+}
+
+function download_fifo_xbcloud()
+{
+  local stream_dir=$1
+  local xbcloud_args=$2
+  local xbstream_args=$3
+
+  xbcloud --defaults-file=$topdir/xbcloud.cnf get \
+  --fifo-dir=${stream_dir} ${xbcloud_args} &
+  xbcloud_pid=$!
+  wait_for_file_to_generated ${stream_dir}/thread_0
+  xbstream ${xbstream_args} --fifo-dir=${stream_dir}
+  wait ${xbcloud_pid}
+}

--- a/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
@@ -31,6 +31,7 @@ now=$(date +%s)
 uuid=($(cat /proc/sys/kernel/random/uuid))
 full_backup_name=${now}-${uuid}-full_backup
 inc_backup_name=${now}-${uuid}-inc_backup
+inc2_backup_name=${now}-${uuid}-inc2_backup
 
 full_backup_dir=$topdir/${full_backup_name}
 inc_backup_dir=$topdir/${inc_backup_name}
@@ -61,4 +62,10 @@ function is_ec2_with_profile() {
 
   curl -sS --connect-timeout 3 -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/${PROFILE} || \
   return 1
+}
+
+xbcloud_cleanup() {
+     xbcloud --defaults-file=$topdir/xbcloud.cnf delete --parallel=10 ${full_backup_name}
+     xbcloud --defaults-file=$topdir/xbcloud.cnf delete --parallel=10 ${inc_backup_name}
+     xbcloud --defaults-file=$topdir/xbcloud.cnf delete --parallel=10 ${inc2_backup_name}
 }

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
@@ -1,0 +1,61 @@
+. inc/xbcloud_common.sh
+. inc/fifo_common.sh
+is_xbcloud_credentials_set
+
+# call cleanup in case of error
+trap 'xbcloud_cleanup' ERR
+
+start_server
+write_credentials
+load_dbase_schema sakila
+load_dbase_data sakila
+create_base_table
+
+mkdir ${topdir}/full ${topdir}/inc1 ${topdir}/inc2
+
+vlog "Test 1 - Taking full backup"
+run_insert &
+insert_pid=$!
+take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --extra-lsndir=${full_backup_dir}" "--parallel=10 --fifo-streams=3 ${full_backup_name}"
+wait ${insert_pid}
+run_insert &
+insert_pid=$!
+vlog "Test 1 - Taking inc1 backup"
+take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${full_backup_dir} --extra-lsndir=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc_backup_name}"
+wait ${insert_pid}
+vlog "Test 1 - Taking inc2 backup"
+take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc2_backup_name}"
+record_db_state test
+
+vlog "download & prepare"
+download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${full_backup_name}" "-x -C ${topdir}/full --fifo-streams=3"
+download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc_backup_name}" "-x -C ${topdir}/inc1 --fifo-streams=3"
+download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc2_backup_name}" "-x -C ${topdir}/inc2 --fifo-streams=3"
+stop_server
+vlog "Test 1 - Preparing full backup"
+xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full
+vlog "Test 1 - Preparing inc1 backup"
+xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+vlog "Test 1 - Preparing inc2 backup"
+xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
+rm -rf ${mysql_datadir}
+vlog "Test 1 - Running copy-back"
+xtrabackup --copy-back --target-dir=${topdir}/full
+start_server
+verify_db_state test
+rm -rf ${topdir}/full ${topdir}/inc1 ${topdir}/inc2
+vlog "Test 1 - Completed"
+vlog "Test 2 - Partial Download"
+
+mkdir $topdir/partial
+download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=2 ${full_backup_name} ibdata1 sakila/payment.ibd test/t.ibd" "-x -C ${topdir}/partial --fifo-streams=2"
+if [ ! -f "$topdir/partial/ibdata1" ] || \
+[ ! -f "$topdir/partial/sakila/payment.ibd" ] || \
+[ ! -f "$topdir/partial/test/t.ibd" ]
+then
+    vlog "Error: File was not downloaded"
+    exit 1
+fi
+vlog "Test 2 - Completed"
+
+xbcloud_cleanup

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/redact_password.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/redact_password.sh
@@ -1,6 +1,9 @@
 . inc/xbcloud_common.sh
 is_xbcloud_credentials_set
 
+# call cleanup in case of error
+trap 'xbcloud_cleanup' ERR
+
 start_server --innodb_file_per_table
 
 write_credentials
@@ -75,9 +78,9 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 for password_string in "${secret_keys[@]}"
 do
   vlog "check for $password_string in backup directory"
-  if grep -rq $password_string $topdir/downloaded_full
+  if grep -rq $password_string $topdir/downloaded_full/xtrabackup*
   then
-     grep -r $password_string $topdir/downloaded_full
+     grep -r $password_string $topdir/downloaded_full/xtrabackup*
      die "found $password_string string in $topdir/downloaded_full"
   fi
 done

--- a/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
+++ b/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
@@ -1,0 +1,63 @@
+. inc/fifo_common.sh
+
+
+start_server
+create_base_table
+
+vlog "Test 1 - Create a backup and restore"
+
+record_db_state test
+
+mkdir ${topdir}/backup
+take_backup_fifo_xbstream ${topdir}/stream '--parallel=4 --fifo-streams=3' "-x -C ${topdir}/backup --fifo-streams=3"
+
+stop_server
+xtrabackup --prepare --target-dir=${topdir}/backup
+rm -rf ${mysql_datadir}
+xtrabackup --copy-back --target-dir=${topdir}/backup
+start_server
+verify_db_state test
+rm -rf ${topdir}/backup
+vlog "Test 1 - Completed"
+
+vlog "Test 2 - Create a incremental backup and restore"
+vlog "Test 2 - Taking full backup"
+mkdir ${topdir}/full ${topdir}/inc1 ${topdir}/inc2
+run_insert &
+insert_pid=$!
+take_backup_fifo_xbstream ${topdir}/stream '--parallel=4 --fifo-streams=3' "-x -C ${topdir}/full --fifo-streams=3"
+wait ${insert_pid}
+run_insert &
+insert_pid=$!
+vlog "Test 2 - Taking inc1 backup"
+take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${topdir}/full" "-x -C ${topdir}/inc1 --fifo-streams=3"
+wait ${insert_pid}
+vlog "Test 2 - Taking inc2 backup"
+take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${topdir}/inc1" "-x -C ${topdir}/inc2 --fifo-streams=3"
+record_db_state test
+
+stop_server
+vlog "Test 2 - Preparing full backup"
+xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full
+vlog "Test 2 - Preparing inc1 backup"
+xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+vlog "Test 2 - Preparing inc2 backup"
+xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
+rm -rf ${mysql_datadir}
+vlog "Test 2 - Runninc copy-back"
+xtrabackup --copy-back --target-dir=${topdir}/full
+start_server
+verify_db_state test
+rm -rf ${topdir}/full ${topdir}/inc1 ${topdir}/inc2
+vlog "Test 2 - Completed"
+
+vlog "Test 3 - different fifo streams on xtrabackup and xbcloud"
+load_sakila
+stream_dir=${topdir}/stream
+mkdir ${topdir}/stream_backup
+xtrabackup --backup --fifo-streams=2 --target-dir=${stream_dir} --throttle=1 &
+pxb_pid=$!
+wait_for_file_to_generated ${stream_dir}/thread_0
+run_cmd_expect_failure xbstream --fifo-dir=${stream_dir} -x -C ${topdir}/stream_backup --fifo-streams=3 --fifo-timeout=5
+run_cmd_expect_failure wait ${pxb_pid}
+vlog "Test 3 - Completed"


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-2514

New FIFO datasink for xtrabackup / xbcloud / xbstream that uses true
multi-thread.

-- FIFO datasink --
FIFO/named pipes is a new data sink that transfers data
between xtrabackup and xbcloud. The main advantage of using FIFO is
that it allows multiple threads to truly write in parallel, which is
not possible with STDIN/STDOUT. FIFO works by creating a FIFO file and
opening it with read and write mode. By default, FIFO is opened in
blocking mode. This is what we want for when both sides have been open
because it will ensure that:
- Read end will block while there is no data to read.
- Write end will block if the reader is not reading fast enough.
- This avoids the threads having to use epool/select to validate if the
other end is ready.

However, opening a FIFO in blocking mode can make the process hang
forever if the other end is not opened. This is the case when xtrabackup
is writing to FIFO and xbcloud is not reading from it. To avoid this, we
open the FIFO in non-blocking mode. This way, we can set a timeout and
keep validating if the other side has been opened. If the timeout is
reached, we close the FIFO and exit. If both sides have been opened, we
set the FIFO back to blocking mode.

To support multiple parallel streams, a new struct called
ds_parallel_stream_ctxt_t has been created. This struct is used to
maintain a list of ds_stream_ctxt_t (either a single-entry list
pointing to STDOUT or multiple entries pointing to FIFO files).

When a thread calls xbstream_open we get the first entry of the
ds_parallel_stream_ctxt_t list and assign it to ds_stream_ctxt_t object
that will be used to form the return file. Once we pick the first entry
from the parallel stream list, we reenter it at the end of the list.
This way we maintain a LRU list and multiple copy threads will evenly
utilize the available FIFO ds_stream_ctxt_t.

Once we have our ds_stream_ctxt_t assigned, we will check if it has a
destination file assigned to it, if not we will do it via ds_open this
time passing out destination datasink (either FIFO or STDOUT).
FIFO datasink has a list of FIFO files it can assign on an open operation.
When xbstream::ds_open calls FIFO::fifo_open we assign the first FIFO file
in the list and from this point forward xbstream ds_stream_ctxt_t will be
bound to this particular FIFO file. We do not assign the fifo file back to
the list of fifo files as xbstream ds_stream_ctxt_t->fifo is a 1:1 mapping.

When using FIFO, ddded logic to ensure --parallel is at least equal to the
number FIFO files. Otherwise, there will be FIFO files without data been
written to it.

-- xbcloud Download --
Xbstream format has a limitation in that it requires that each chunk of
a file is downloaded/extracted in order. For example, chunk 3 of the
file X cannot arrive before chunks 0, 1 and 2.
More details at https://jira.percona.com/browse/PXB-2950

Each thread has its own download state instance. With that in mind, to
download from xbcloud we keep 3 lists of files:

* cntx->global_list->files - Global list of files. Shared among
all threads. This list is populated by the main thread by querying the
object storage bucket. Each file has a next_chunk field that indicates
the next chunk and last_chunk field that indicates the last chunk of
the file.

* thread_state->in_progress_files - List of files that are currently
being downloaded by this thread. This list is intended to synchronize the
chunks of a file. If a file has in-progress chunks, we do not start the
next chunk of this file.

* thread_state->file_list - List of files that are assigned to
current thread.

Example:

cntx->global_list->files {
["bkp/performance_schema/events_stages_su_125.sdi"] = {
last_chunk = 1,
next_chunk = 0,
name = "bkp/performance_schema/events_stages_su_125.sdi"
},
["bkp/performance_schema/events_statement_135.sdi"] = {
last_chunk = 1,
next_chunk = 0,
name = "bkp/performance_schema/events_statement_135.sdi"
}
}

thread_state->in_progress_files {
[0] = "bkp/performance_schema/accounts_154.sdi",
[1] = "bkp/performance_schema/events_stages_su_126.sdi",
[2] = "bkp/performance_schema/events_statement_136.sdi",
[3] = "bkp/sbtest/sbtest5.ibd",
[4] = "bkp/sbtest/sbtest7.ibd"
}

thread_state->file_list {
["bkp/performance_schema/events_stages_su_126.sdi"] = {
last_chunk = 1,
next_chunk = 0,
name = "bkp/performance_schema/events_stages_su_126.sdi"
},
["bkp/performance_schema/events_statement_136.sdi"] = {
last_chunk = 1,
next_chunk = 1,
name = "bkp/performance_schema/events_statement_136.sdi"
},
["bkp/performance_schema/accounts_154.sdi"] = {
last_chunk = 1,
next_chunk = 0,
name = "bkp/performance_schema/accounts_154.sdi"
},
["bkp/sbtest/sbtest7.ibd"] = {
last_chunk = 24,
next_chunk = 4,
name = "bkp/sbtest/sbtest7.ibd"
},
["bkp/sbtest/sbtest5.ibd"] = {
last_chunk = 24,
next_chunk = 8,
name = "bkp/sbtest/sbtest5.ibd"
}
}

Download flow is as follow:
* We check that we don't have more in progress file than --parallel
option.
* if the global list of files and the thread list of files we completed
the flow
* We attempt to get the next file from per thread list
(thread_state->file_list). Where we check if the file is not part
of the in progress list. If it is, we skip it.
* If there is no available files from per thread list, we pick a new
one from global list. If we get a file from this list, the file is
removed from global list.
* Once we have a file, we indicate that we are downloading it by adding
it to the in progress list and per thread list.
* We make an async request to download the current chunk of the file.
The event handler thread will handle this via a callback.
* Event handler callback, will complete the download of the chunk.
It will remove the file from in progress list and advance the next
chunk of the file. In case we just completed the last chunk of the file,
we remove the file from the per-thread list.

-- xbcloud upload --

Upload is a bit more simple. We keep reading more data on STDIN or
FIFO file. Until the other side (xtrabackup) closes the pipe.
For each chunk of data, we create one async request that will be handled
by the event handler.

-- xbstream --
xbstream changes are related to where to read the data from. Similar to
other tools, we read from STDIN in case of a single thread and from the
FIFO files in case of multiple threads.

Introduced 3 new parameters:
--fifo-streams=# Number of FIFO files to use for parallel datafiles
                stream. Setting this parameter to 1 disables FIFO and
                stream is sent to STDOUT.
--fifo-dir=name   Directory to write Named Pipe.
--fifo-timeout=#  How many seconds to wait for other end to open the
                stream for reading. Default 60 seconds

-- pthread refactor --
Moved from pthread to std::thread and from  ptread_mutex to std::mutex