### PR TITLE
Fixed PXB-3032 - BiDiScan not running anymore

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: BiDiScan
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-latest'
 
   steps:
   - checkout: self


### PR DESCRIPTION
BiDiScan not running anymore

Problem:
BiDiScan is running on outdated vmImage not supported by azure.

Fix:
Adjusted the vmImage to the latest supported by azure.