### PR TITLE
Fixed PXB-3033 - Execute STOP SLAVE conditionally depending on --lock…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1386,6 +1386,13 @@ static bool backup_rocksdb_checkpoint(Backup_context &context, bool final) {
 @return true if success. */
 bool backup_start(Backup_context &context) {
   if (!opt_no_lock) {
+    /* STOP SLAVE if lock-ddl=OFF */
+    if (!opt_lock_ddl && opt_safe_slave_backup) {
+      if (!wait_for_safe_slave(mysql_connection)) {
+        return (false);
+      }
+    }
+
     if (!backup_files(MySQL_datadir_path.path().c_str(), true, context)) {
       return (false);
     }

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -1094,9 +1094,10 @@ struct my_option xb_client_options[] = {
      100, 0, 1, 0},
 
     {"safe-slave-backup", OPT_SAFE_SLAVE_BACKUP,
-     "This option stops slave SQL thread at the start of the backup and waits "
-     "to start backup until Slave_open_temp_tables in "
-     "\"SHOW STATUS\" is zero. If there are no open temporary tables, "
+     "This option stops slave SQL thread at the start of the backup if "
+     "lock-ddl=ON or before copying non-InnoDB tables if lock-ddl=OFF and "
+     "waits until Slave_open_temp_tables in \"SHOW STATUS\" is zero. If there "
+     "are no open temporary tables, "
      "the backup will take place, otherwise the SQL thread will be "
      "started and stopped until there are no open temporary tables. "
      "The backup will fail if Slave_open_temp_tables does not become "
@@ -7535,8 +7536,8 @@ bool xb_init() {
 
     history_start_time = time(NULL);
 
-    /* stop slave before taking backup up locks */
-    if (!opt_no_lock && opt_safe_slave_backup) {
+    /* stop slave before taking backup up locks if lock-ddl=ON*/
+    if (!opt_no_lock && opt_lock_ddl && opt_safe_slave_backup) {
       if (!wait_for_safe_slave(mysql_connection)) {
         return (false);
       }

--- a/storage/innobase/xtrabackup/test/suites/binlog/ib_slave_info.sh
+++ b/storage/innobase/xtrabackup/test/suites/binlog/ib_slave_info.sh
@@ -104,6 +104,9 @@ run_cmd egrep "MySQL binlog position: $pxb_log_binlog_info_pattern" $topdir/pxb.
 
 run_cmd egrep "MySQL slave binlog position: $pxb_log_slave_info_pattern" $topdir/pxb.log
 
+# PXB-3033 - Execute STOP SLAVE before copying non-InnoDB tables
+grep -A 5 'Slave is safe to backup.' $topdir/pxb.log | grep -q 'Starting to backup non-InnoDB tables and files' || die 'STOP SLAVE in wrong place'
+
 run_cmd egrep -q "$binlog_slave_info_pattern" \
     $topdir/backup/xtrabackup_slave_info
 


### PR DESCRIPTION
…-ddl

https://jira.percona.com/browse/PXB-3033

Problem:
After PS-4758 STOP SLAVE is not allowed if the same session has acquired LIFB/LTFB. As part of enabling lock-ddl by default we moved the place where we execute STOP SLAVE to the start of the backup. In some cases, users can ensure DDL do not happen and executing STOP SLAVE later in the backup process can help with minimizing replication lag.

Fix:
Execute STOP SLAVE conditionally depending on --lock-ddl: ON - We execute STOP SLAVE at the start of backup, before LIFB/LTFB. OFF - We execute STOP SLAVE after copying InnoDB tables.