### PR TITLE
PXB-2955 : Implement dictionary cache

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -1191,6 +1191,10 @@ void dict_table_add_to_cache(dict_table_t *table, bool can_be_evicted) {
   ut_ad(dict_lru_validate());
   ut_ad(dict_sys_mutex_own());
 
+  // In PXB, we always load tables as evictable. We do not have create table
+  // and upgrade from 5.7 scenarios. These paths can load table as non-evictable
+  IF_XB(ut_ad(can_be_evicted);)
+
   table->cached = true;
 
   const auto name_hash_value = ut::hash_string(table->name.m_name);

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -251,6 +251,12 @@ void dict_table_add_system_columns(dict_table_t *table, mem_heap_t *heap);
 void dict_table_set_big_rows(dict_table_t *table) MY_ATTRIBUTE((nonnull));
 
 /** Adds a table object to the dictionary cache.
+Second parameter of dict_table_add_to_cache() is to make
+a table evictable or not. NEVER use "false". It is meant for "DD" tables.
+In PXB, we handle DD tables (mysql.* tables) to be non-evictable by using
+table->n_ref_count. It is incremented to 1 on load and hence not evictable.
+The DD tables are closed at end of prepare operation. Check
+'mysql_ibd_tables' in xtrabackup.cc
 @param[in,out]  table           table
 @param[in]      can_be_evicted  true if can be evicted */
 void dict_table_add_to_cache(dict_table_t *table, bool can_be_evicted);

--- a/storage/innobase/xtrabackup/src/xb_dict.cc
+++ b/storage/innobase/xtrabackup/src/xb_dict.cc
@@ -18,13 +18,35 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 *******************************************************/
 #include "xb_dict.h"
+#include <dd/properties.h>
+#include <sql_class.h>
 #include <memory>
+#include <unordered_map>
 #include "backup_mysql.h"
+#include "include/api0api.h"
+#include "include/api0misc.h"
+#include "include/dict0sdi-decompress.h"
+#include "sql/current_thd.h"
+#include "sql/dd/dd.h"
+#include "sql/dd/impl/sdi.h"
+#include "sql/dd/impl/types/column_impl.h"
+#include "sql/dd/impl/types/table_impl.h"
+#include "sql/dd/types/column_type_element.h"
+#include "storage/innobase/include/btr0pcur.h"
+#include "storage/innobase/include/dict0dd.h"
+//#include "sql/dd/dd_table.h"
+
 namespace xb {
-std::shared_ptr<dd_tablespaces> build_space_id_set(MYSQL *connection) {
+// Dictionary used by backup phase. Currently we query running server to know
+// the list of tablespaces. PXB currently uses *.ibd scan to find the
+// tablespaces We use the dictionary during backup phase to detect the "orphan"
+// IBDs. i.e. the IBDs found in data directory but doesn't have any entry in
+// server dictionary.
+namespace backup {
+std::shared_ptr<dd_space_ids> build_space_id_set(MYSQL *connection) {
   ut_ad(srv_backup_mode);
 
-  std::shared_ptr<dd_tablespaces> dd_tab = std::make_shared<dd_tablespaces>();
+  std::shared_ptr<dd_space_ids> dd_tab = std::make_shared<dd_space_ids>();
   std::string sql = "SELECT SPACE FROM INFORMATION_SCHEMA.INNODB_TABLESPACES ";
 
   MYSQL_RES *result = xb_mysql_query(connection, sql.c_str(), true, true);
@@ -48,4 +70,777 @@ std::shared_ptr<dd_tablespaces> build_space_id_set(MYSQL *connection) {
 
   return dd_tab;
 }
+}  // namespace backup
+
+namespace prepare {
+/** map of <table_id, space_id> */
+static std::unordered_map<table_id_t, space_id_t> table_id_space_map;
+
+/** map of <space_id, partition_index_id>
+Used for answering: Given a space_id, which partition table does it belong
+If space_id doesn't exist in this map, it means the table is not partitioned */
+static std::unordered_map<space_id_t, uint64_t> space_part_map;
+
+/** multimap (duplicates allowed) of partition_index_id and space_id.
+A partition table can contain many space_ids */
+static std::multimap<uint64_t, space_id_t> part_id_spaces_map;
+
+/* map of <schema id, name> and SDI id
+This map is used to handle duplicate SDI */
+static std::map<std::pair<int, std::string>, uint64> sdi_id_map;
+
+/* map of schema name and schema id
+This map is used to handle duplicate SDI */
+static std::map<std::string, uint64> dd_schema_map;
+
+using dd_Table_Ptr = std::unique_ptr<dd::Table>;
+
+/** @return true if table_id is found in dd map. This map
+is created by scanning mysql.indexes and mysql.index_partitions
+@param[in]  table_id InnoDB table id */
+bool table_exists_in_dd(table_id_t table_id) {
+  return (table_id_space_map.find(table_id) != table_id_space_map.end());
+}
+
+/** @return true if tablespace belongs to a partition
+@param[in] space_id InnoDB tablespace id */
+static bool is_space_partitioned(space_id_t space_id) {
+  return (space_part_map.find(space_id) != space_part_map.end());
+}
+
+/** @return get partition id for a tablespace. If space is not partitioned,
+return 0. All tablespace partitions of a single table have same partition id
+@param[in] space_id InnoDB tablespace id */
+static uint64_t get_part_id_for_space(space_id_t space_id) {
+  ut_ad(is_space_partitioned(space_id));
+  auto it = space_part_map.find(space_id);
+  return (it != space_part_map.end() ? it->second : 0);
+}
+
+/** Scan the SDI id from DD table "mysql.tables"
+@param[in]  name       tablespace name database/name
+@param[out] sdi_id     id of table
+@param[out] table_name name of the table
+@param[in]  thd        THD
+@return DB_SUCCESS on success, other DB_* on error */
+static dberr_t get_sdi_id_from_dd(const std::string &name, uint64 *sdi_id,
+                                  std::string &table_name, THD *thd) {
+  ut_ad(!dict_sys_mutex_own());
+
+  std::string db_name;
+  uint64 schema_id = 0;
+
+  /* get the database and table_name from space name */
+  dict_name::get_table(name, db_name, table_name);
+
+  ut_ad(db_name.compare("mysql") != 0);
+
+  /* map of schema name and id built from scanning mysql/schemata and map of
+  <schema id, name> and SDI id built from scanning mysql/tables */
+  if (dd_schema_map.size() == 0 && sdi_id_map.size() == 0) {
+    dict_table_t *sys_tables = nullptr;
+    btr_pcur_t pcur;
+    const rec_t *rec = nullptr;
+    mtr_t mtr;
+    MDL_ticket *mdl = nullptr;
+    mem_heap_t *heap = mem_heap_create(1000, UT_LOCATION_HERE);
+
+    dict_sys_mutex_enter();
+    mtr_start(&mtr);
+    rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, "mysql/schemata",
+                              &sys_tables);
+    while (rec) {
+      uint64 rec_schema_id;
+      std::string rec_name;
+
+      dd_process_schema_rec(heap, rec, sys_tables, &mtr, &rec_name,
+                            &rec_schema_id);
+      dd_schema_map.insert(std::make_pair(rec_name, rec_schema_id));
+      mem_heap_empty(heap);
+
+      mtr_start(&mtr);
+      rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
+    }
+
+    mtr_commit(&mtr);
+    dd_table_close(sys_tables, thd, &mdl, true);
+    mem_heap_empty(heap);
+
+    mtr_start(&mtr);
+
+    rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, "mysql/tables",
+                              &sys_tables);
+
+    while (rec) {
+      uint64 rec_schema_id;
+      std::string rec_name;
+      uint64 rec_id;
+
+      dd_process_dd_tables_rec(heap, rec, sys_tables, &mtr, &rec_schema_id,
+                               &rec_name, &rec_id);
+      mem_heap_empty(heap);
+
+      auto rec_table_id = std::make_pair(rec_schema_id, rec_name);
+
+      sdi_id_map.insert(
+          std::make_pair(std::make_pair(rec_schema_id, rec_name), rec_id));
+
+      mtr_start(&mtr);
+      rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
+    }
+
+    mtr_commit(&mtr);
+    dd_table_close(sys_tables, thd, &mdl, true);
+    mem_heap_free(heap);
+
+    dict_sys_mutex_exit();
+  }
+
+  auto it = dd_schema_map.find(db_name);
+
+  if (it == dd_schema_map.end()) {
+    xb::error() << "can't find " << db_name.c_str()
+                << " entry in mysql/schemata for tablespace " << name.c_str();
+    return (DB_NOT_FOUND);
+  } else {
+    schema_id = it->second;
+    ut_ad(schema_id != 0);
+  }
+
+  auto it2 = sdi_id_map.find(std::make_pair(schema_id, table_name));
+  if (it2 == sdi_id_map.end()) {
+    xb::error() << "can't find " << table_name.c_str()
+                << " entry in mysql/tables for tablespace " << name.c_str();
+    return (DB_NOT_FOUND);
+  } else {
+    *sdi_id = it2->second;
+    ut_ad(*sdi_id != 0);
+  }
+  return (DB_SUCCESS);
+}
+
+/** Load a specific table from space_id
+@param[in] space_id InnoDB tablespace_id
+@param[in] table_id InnoDB table id
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+static xb_dict_tuple dict_load_tables_from_space_id_wrapper(
+    space_id_t space_id, table_id_t table_id) {
+  fil_space_t *space = fil_space_get(space_id);
+  if (space == nullptr) {
+    return {DB_TABLESPACE_NOT_FOUND, {}};
+  }
+
+  THD *thd = current_thd;
+  ut_a(thd != nullptr);
+  ib_trx_t trx = ib_trx_begin(IB_TRX_READ_COMMITTED, false, false, thd);
+
+  auto result = dict_load_tables_from_space_id(space_id, table_id, thd, trx);
+
+  ib_trx_commit(trx);
+  ib_trx_release(trx);
+
+  return result;
+}
+
+/** Load a specific table from space_id. This is used by InnoDB table opening
+function dd_table_open_on_id()
+@param[in] table_id InnoDB table id
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+xb_dict_tuple dict_load_tables_using_table_id(table_id_t table_id) {
+  auto it = table_id_space_map.find(table_id);
+  if (it == table_id_space_map.end()) {
+    // Table_id not present in any space_id. A dropped table
+    return {DB_TABLESPACE_NOT_FOUND, {}};
+  }
+
+  space_id_t space_id = it->second;
+  DBUG_LOG("xb_dd",
+           "space_id is " << space_id << " for table_id: " << table_id);
+
+  if (!is_space_partitioned(space_id)) {
+    return (dict_load_tables_from_space_id_wrapper(space_id, table_id));
+  }
+
+  // For partition tables, SDI exists in only one partition IBD, loop
+  // through such IBDs to find the required table_id
+  uint64_t part_id = get_part_id_for_space(space_id);
+  if (part_id == 0) return {DB_TABLESPACE_NOT_FOUND, {}};
+
+  auto low = part_id_spaces_map.lower_bound(part_id);
+  auto high = part_id_spaces_map.upper_bound(part_id);
+  while (low != high) {
+    space_id_t space_id = low->second;
+    auto result = dict_load_tables_from_space_id_wrapper(space_id, table_id);
+    // Look for the desired table_id in the result tables
+    dberr_t err = std::get<0>(result);
+    auto tables_vec = std::get<1>(result);
+    if (err != DB_SUCCESS) {
+      // Possibly we are in partition IBD that doesn't have SDI, keep
+      // looking other partition space_ids
+      ++low;
+      continue;
+    }
+    auto end = tables_vec.end();
+
+    auto i = std::search_n(tables_vec.begin(), end, 1, table_id,
+                           [](const dict_table_t *table, table_id_t id) {
+                             return (table->id == id);
+                           });
+    if (i == end) {
+      // Possibly we are in partition IBD that doesn't have SDI, keep
+      // looking other partition space_ids
+      ++low;
+      continue;
+
+    } else {
+      // Found desired table
+      return (result);
+    }
+    ++low;
+  }
+  return {DB_ERROR, {}};
+}
+
+/** Load all InnoDB tables from space_id. There could be multiple tables
+in a tablespace (general tablespace like mysql.ibd or a partition IBD (p0
+contains all tables SDI). This function uses SDI to deserialize to dd::Table and
+then convert to InnoDB table object dict_table_t*.
+Whether to convert dd::Table object to dict_table_t or not is decided by
+callback (load_table_cb)
+
+@param[in] space_id      InnoDB tablespace_id
+@param[in] table_id      InnoDB table id. If this is zero, we load *all* tables
+                         found in space_id
+@param[in] thd           Server thread context (used for DD APIs)
+@param[in] trx           InnoDB trx object (for using SDI APIs)
+@param[in] load_table_cb The callback function that processes dd::Table. A
+                         callback can convert dd::Table to dict_table_t or
+                         send the dd::Table to caller without conversion
+@return DB_SUCCESS on success, other DB_* codes on errors */
+static dberr_t dict_load_tables_from_space_id_low(
+    space_id_t space_id, table_id_t table_id, THD *thd, trx_t *trx,
+    std::function<dberr_t(dd_Table_Ptr dd_table, dd::String_type &schema_name)>
+        load_table_cb) {
+  sdi_vector_t sdi_vector;
+  ib_sdi_vector_t ib_vector;
+  ib_vector.sdi_vector = &sdi_vector;
+  uint64 sdi_id = 0;
+
+  if (!fsp_has_sdi(space_id)) {
+    return DB_SUCCESS;
+  }
+
+  fil_space_t *space = fil_space_get(space_id);
+  ut_ad(space != nullptr);
+  if (space == nullptr) {
+    return DB_TABLESPACE_NOT_FOUND;
+  }
+
+  uint32_t compressed_buf_len = 8 * 1024 * 1024;
+  uint32_t uncompressed_buf_len = 16 * 1024 * 1024;
+  auto compressed_sdi = ut_make_unique_ptr_zalloc_nokey(compressed_buf_len);
+  auto sdi = ut_make_unique_ptr_zalloc_nokey(uncompressed_buf_len);
+
+  ib_err_t err = ib_sdi_get_keys(space_id, &ib_vector, trx);
+
+  if (err != DB_SUCCESS) {
+    return err;
+  }
+
+  /* Before 8.0.24 if the table is used in EXCHANGE PARTITION or IMPORT. Even
+  after upgrade to the latest version 8.0.25 (which fixed the duplicate SDI
+  issue), such tables continue to contain duplicate SDI. PXB will scan the DD
+  table "mysql.tables" to determine the correct SDI */
+  if (ib_vector.sdi_vector->m_vec.size() > 2 &&
+      strcmp(space->name, "mysql") != 0 &&
+      fsp_is_file_per_table(space_id, space->flags)) {
+    std::string table_name;
+    err = get_sdi_id_from_dd(space->name, &sdi_id, table_name, thd);
+    xb::info() << "duplicate SDI found for tablespace " << space->name
+               << ". To remove duplicate SDI, "
+                  "please execute OPTIMIZE TABLE on "
+               << table_name.c_str();
+    if (err != DB_SUCCESS) {
+      return err;
+    }
+  }
+
+  for (sdi_container::iterator it = ib_vector.sdi_vector->m_vec.begin();
+       it != ib_vector.sdi_vector->m_vec.end(); it++) {
+    ib_sdi_key_t ib_key;
+    ib_key.sdi_key = &(*it);
+
+    uint32_t compressed_sdi_len = compressed_buf_len;
+    uint32_t uncompressed_sdi_len = uncompressed_buf_len;
+
+    if (ib_key.sdi_key->type != 1 /* dd::Sdi_type::TABLE */) {
+      continue;
+    }
+
+    /* In case of duplicate SDIs, sdi_id is the latest id according to DD, so we
+    skip other dd::Table SDIs in the IBD file */
+    if (sdi_id != 0 && ib_key.sdi_key->id != sdi_id) {
+      continue;
+    }
+
+    while (true) {
+      err = ib_sdi_get(space_id, &ib_key, compressed_sdi.get(),
+                       &compressed_sdi_len, &uncompressed_sdi_len, trx);
+      if (err == DB_OUT_OF_MEMORY) {
+        compressed_buf_len = compressed_sdi_len;
+        compressed_sdi = ut_make_unique_ptr_zalloc_nokey(compressed_buf_len);
+        continue;
+      }
+      break;
+    }
+
+    if (err != DB_SUCCESS) {
+      return err;
+    }
+
+    if (uncompressed_buf_len < uncompressed_sdi_len) {
+      uncompressed_buf_len = uncompressed_sdi_len;
+
+      sdi = ut_make_unique_ptr_zalloc_nokey(uncompressed_buf_len);
+    }
+
+    Sdi_Decompressor decompressor(sdi.get(), uncompressed_sdi_len,
+                                  compressed_sdi.get(), compressed_sdi_len);
+    decompressor.decompress();
+
+    dd_Table_Ptr dd_table{dd::create_object<dd::Table>()};
+    dd::String_type schema_name;
+
+    bool res = dd::deserialize(
+        thd, dd::Sdi_type((const char *)sdi.get(), uncompressed_sdi_len),
+        dd_table.get(), &schema_name);
+
+    if (res) {
+      return DB_ERROR;
+    }
+
+    bool is_part = dd_table_is_partitioned(*dd_table.get());
+
+    if (is_part) {
+      auto end = dd_table->leaf_partitions()->end();
+
+      if (table_id != 0) {
+        auto i =
+            std::search_n(dd_table->leaf_partitions()->begin(), end, 1,
+                          table_id, [](const dd::Partition *p, table_id_t id) {
+                            return (p->se_private_id() == id);
+                          });
+        if (i == end) {
+          continue;
+        }
+      }
+    } else {
+      uint64 se_private_id = dd_table.get()->se_private_id();
+      if (table_id != 0 && table_id != se_private_id) continue;
+    }
+
+    // Callback.
+    err = load_table_cb(std::move(dd_table), schema_name);
+    // Do not use dd_table from here. The ownership has been transferred to
+    // callback
+    ut_ad(dd_table == nullptr);
+
+    if (err != DB_SUCCESS) {
+      return err;
+    }
+  }
+
+  return (DB_SUCCESS);
+}
+
+/** This function uses dict_load_tables_from_space_id_low() with a callback
+that loads all tables from dd::table into a vector
+@param[in] space_id      InnoDB tablespace_id
+@param[in] table_id      InnoDB table id. If this is zero, we load *all* tables
+                         found in space_id
+@param[in] thd           Server thread context (used for DD APIs)
+@param[in] trx           InnoDB trx object (for using SDI APIs)
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+xb_dict_tuple dict_load_tables_from_space_id(space_id_t space_id,
+                                             table_id_t table_id, THD *thd,
+                                             trx_t *trx) {
+  std::vector<dict_table_t *> tables_vec;
+
+  auto load_table_func = [&](dd_Table_Ptr dd_table,
+                             dd::String_type &schema_name) -> dberr_t {
+    fil_space_t *space = fil_space_get(space_id);
+
+    using Client = dd::cache::Dictionary_client;
+    using Releaser = dd::cache::Dictionary_client::Auto_releaser;
+
+    Client *dc = dd::get_dd_client(thd);
+    Releaser releaser{dc};
+
+    ut_a(space != nullptr);
+
+    bool implicit = fsp_is_file_per_table(space_id, space->flags);
+    if (space_id == dict_sys_t::s_dict_space_id &&
+        schema_name != MYSQL_SCHEMA_NAME.str) {
+      schema_name = MYSQL_SCHEMA_NAME.str;
+    }
+
+    /* All tables in mysql.ibd should belong to 'mysql' schema. But
+    during upgrade, server leaves the DD tables in a temporary schema
+    'dd_upgrade_80XX". PXB reads DD tables using 'mysql' schema name.
+    For example, 'mysql/tables'. Fix the schema name to 'mysql' */
+    if (space_id == dict_sys_t::s_dict_space_id &&
+        schema_name != MYSQL_SCHEMA_NAME.str) {
+      schema_name = MYSQL_SCHEMA_NAME.str;
+    }
+
+    int ret;
+    std::vector<dict_table_t *> tables;
+    std::tie(ret, tables) = dd_table_load_on_dd_obj(
+        dc, space_id, *dd_table.get(), table_id, thd, &schema_name, implicit);
+    if (ret != 0) {
+      return (DB_ERROR);
+    } else {
+      tables_vec.insert(std::end(tables_vec), std::begin(tables),
+                        std::end(tables));
+      return (DB_SUCCESS);
+    }
+  };
+
+  dberr_t err = dict_load_tables_from_space_id_low(space_id, table_id, thd, trx,
+                                                   load_table_func);
+
+  return {err, tables_vec};
+}
+
+/** This function uses dict_load_tables_from_space_id_low() with a callback
+that returns the dd::Table object to caller. We DONT convert dd::Table to
+dict_table_t here
+@param[in] space_id      InnoDB tablespace_id
+@param[in] table_id      InnoDB table id. If this is zero, we load *all* tables
+                         found in space_id
+@return dd::Table object on success, else nullptr */
+dd_Table_Ptr get_dd_Table(space_id_t space_id, table_id_t table_id) {
+  dd_Table_Ptr tbl = dd_Table_Ptr{nullptr};
+
+  // This callback doesn't convert the dd::Table object to InnoDB table
+  // dict_table_t. This function returns dd::Table object to caller.
+  auto load_table_func_cb = [&](dd_Table_Ptr dd_table,
+                                dd::String_type &schema_name) -> dberr_t {
+    tbl = std::move(dd_table);
+    return (DB_SUCCESS);
+  };
+
+  THD *thd = current_thd;
+  ut_a(thd != nullptr);
+
+  ib_trx_t trx = ib_trx_begin(IB_TRX_READ_COMMITTED, false, false, thd);
+#ifdef UNIV_DEBUG
+  dberr_t err =
+#endif
+      dict_load_tables_from_space_id_low(space_id, table_id, thd, trx,
+                                         load_table_func_cb);
+  ib_trx_commit(trx);
+  ib_trx_release(trx);
+
+#ifdef UNIV_DEBUG
+  if (err == DB_SUCCESS) {
+    ut_ad(tbl != nullptr);
+  } else {
+    ut_ad(tbl == nullptr);
+  }
+#endif
+
+  return (tbl);
+}
+
+/** @return all tables (dict_table_t*) from a tablespace
+@param[in] space_id InnoDB tablespace id */
+xb_dict_tuple dict_load_from_spaces_sdi(space_id_t space_id) {
+  THD *thd = current_thd;
+  ut_a(thd != nullptr);
+
+  ib_trx_t trx = ib_trx_begin(IB_TRX_READ_COMMITTED, false, false, thd);
+
+  /* Load mysql tablespace to open mysql/tables and mysql/schemata which is
+  need to find the right key for tablespace in case of duplicate sdi */
+  auto ret = dict_load_tables_from_space_id(space_id, 0, thd, trx);
+
+  ib_trx_commit(trx);
+  ib_trx_release(trx);
+
+  return (ret);
+}
+
+/** Process one mysql.index_partitions record and load entries into the
+following maps table_id_space_map, space_part_map, part_id_spaces_map
+These maps are later used by PXB to load a specific table_id
+@param[in]      heap            Temp memory heap
+@param[in,out]  rec             mysql.index_partitions record
+@param[in]      dd_indexes      dict_table_t obj of mysql.index_partitions
+@retval true if index record is processed */
+static bool process_dd_index_partitions_rec(mem_heap_t *heap, const rec_t *rec,
+                                            dict_table_t *dd_indexes) {
+  ulint len;
+  const byte *field;
+  uint32_t space_id;
+  uint64_t table_id;
+
+  ut_ad(!rec_get_deleted_flag(rec, dict_table_is_comp(dd_indexes)));
+
+  ulint *offsets = rec_get_offsets(rec, dd_indexes->first_index(), nullptr,
+                                   ULINT_UNDEFINED, UT_LOCATION_HERE, &heap);
+
+  field = (const byte *)rec_get_nth_field(
+      nullptr, rec, offsets, dd_indexes->field_number("index_id"), &len);
+
+  uint64_t part_index_id = mach_read_from_8(field);
+  ut_ad(len == 8);
+
+  /* Get the se_private_data field. */
+  field = (const byte *)rec_get_nth_field(
+      nullptr, rec, offsets,
+      dd_indexes->field_number("se_private_data") + DD_FIELD_OFFSET, &len);
+
+  if (len == 0 || len == UNIV_SQL_NULL) {
+    return false;
+  }
+
+  /* Get index id. */
+  dd::String_type prop((char *)field);
+  dd::Properties *p = dd::Properties::parse_properties(prop);
+
+  if (!p || !p->exists(dd_index_key_strings[DD_TABLE_ID]) ||
+      !p->exists(dd_index_key_strings[DD_INDEX_SPACE_ID])) {
+    if (p) {
+      delete p;
+    }
+    return false;
+  }
+
+  if (p->get(dd_index_key_strings[DD_TABLE_ID], &table_id)) {
+    delete p;
+    return false;
+  }
+
+  /* Get the tablespace id. */
+  if (p->get(dd_index_key_strings[DD_INDEX_SPACE_ID], &space_id)) {
+    delete p;
+    return false;
+  }
+
+  if (table_id_space_map.find(table_id) == table_id_space_map.end()) {
+    DBUG_LOG("xb_dd", "From mysql.index_partitions: Inserting into "
+                          << "table_id_space_map: <" << table_id << ","
+                          << space_id << ">");
+    table_id_space_map.insert(std::make_pair(table_id, space_id));
+
+    if (space_part_map.find(space_id) == space_part_map.end()) {
+      DBUG_LOG("xb_dd", "From mysql.index_partitions: Inserting into "
+                            << "space_part_map: <" << space_id << ","
+                            << part_index_id << ">");
+      space_part_map.insert(std::make_pair(space_id, part_index_id));
+    }
+
+    DBUG_LOG("xb_dd", "From mysql.index_partitions: Inserting into "
+                          << "part_id_spaces_map: <" << part_index_id << ","
+                          << space_id << ">");
+    DBUG_LOG("xb_dd", "-----------------------------------------");
+
+    part_id_spaces_map.insert(std::make_pair(part_index_id, space_id));
+  }
+  delete p;
+  return true;
+}
+
+/** Process one mysql.indexes record and load entries into the
+following maps table_id_space_map
+These maps are later used by PXB to load a specific table_id
+@param[in]      heap            Temp memory heap
+@param[in,out]  rec             mysql.indexes record
+@param[in]      dd_indexes      dict_table_t obj of mysql.indexes
+@retval true if index record is processed */
+static bool process_dd_indexes_rec(mem_heap_t *heap, const rec_t *rec,
+                                   dict_table_t *dd_indexes) {
+  ulint len;
+  const byte *field;
+  uint32_t space_id;
+  uint64_t table_id;
+
+  ut_ad(!rec_get_deleted_flag(rec, dict_table_is_comp(dd_indexes)));
+
+  ulint *offsets = rec_get_offsets(rec, dd_indexes->first_index(), nullptr,
+                                   ULINT_UNDEFINED, UT_LOCATION_HERE, &heap);
+  field = rec_get_nth_field(
+      nullptr, rec, offsets,
+      dd_indexes->field_number("engine") + DD_FIELD_OFFSET, &len);
+
+  /* If "engine" field is not "innodb", return. */
+  if (strncmp((const char *)field, "InnoDB", 6) != 0) {
+    return false;
+  }
+
+  /* Get the se_private_data field. */
+  field = (const byte *)rec_get_nth_field(
+      nullptr, rec, offsets,
+      dd_indexes->field_number("se_private_data") + DD_FIELD_OFFSET, &len);
+
+  if (len == 0 || len == UNIV_SQL_NULL) {
+    return false;
+  }
+
+  /* Get index id. */
+  dd::String_type prop((char *)field);
+  dd::Properties *p = dd::Properties::parse_properties(prop);
+
+  if (!p || !p->exists(dd_index_key_strings[DD_TABLE_ID]) ||
+      !p->exists(dd_index_key_strings[DD_INDEX_SPACE_ID])) {
+    if (p) {
+      delete p;
+    }
+    return false;
+  }
+
+  if (p->get(dd_index_key_strings[DD_TABLE_ID], &table_id)) {
+    delete p;
+    return false;
+  }
+
+  /* Get the tablespace id. */
+  if (p->get(dd_index_key_strings[DD_INDEX_SPACE_ID], &space_id)) {
+    delete p;
+    return false;
+  }
+
+  if (table_id_space_map.find(table_id) == table_id_space_map.end()) {
+    DBUG_LOG("xb_dd", "From mysql.indexes: Inserting into table_id_space_map: <"
+                          << table_id << "," << space_id << ">";);
+    table_id_space_map.insert(std::make_pair(table_id, space_id));
+  }
+
+  delete p;
+  return true;
+}
+
+/** Scan mysql.indexes and build a <table_id,space_id> map
+@param[in] thd Server thread context
+@return DB_SUCCESS on success, other DB_* on errors */
+static dberr_t scan_mysql_indexes(THD *thd) {
+  dict_table_t *dd_indexes = nullptr;
+  btr_pcur_t pcur;
+  const rec_t *rec = nullptr;
+  mtr_t mtr;
+  MDL_ticket *mdl = nullptr;
+  mem_heap_t *heap = mem_heap_create(1000, UT_LOCATION_HERE);
+
+  mtr_start(&mtr);
+
+  rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, dd_indexes_name.c_str(),
+                            &dd_indexes);
+
+  while (rec != nullptr) {
+    process_dd_indexes_rec(heap, rec, dd_indexes);
+
+    mtr_commit(&mtr);
+
+    mem_heap_empty(heap);
+
+    mtr_start(&mtr);
+    rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
+  }
+
+  mtr_commit(&mtr);
+  dd_table_close(dd_indexes, thd, &mdl, true);
+  mem_heap_free(heap);
+
+  return (DB_SUCCESS);
+}
+
+/** Scan mysql.index_partitions and build following maps table_id_space_map,
+space_part_map, part_id_spaces_map
+@param[in] thd Server thread context
+@return DB_SUCCESS on success, other DB_* on errors */
+static dberr_t scan_mysql_index_partitions(THD *thd) {
+  dict_table_t *dd_indexes = nullptr;
+  btr_pcur_t pcur;
+  const rec_t *rec = nullptr;
+  mtr_t mtr;
+  MDL_ticket *mdl = nullptr;
+  mem_heap_t *heap = mem_heap_create(1000, UT_LOCATION_HERE);
+
+  mtr_start(&mtr);
+
+  rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, dd_index_partitions.c_str(),
+                            &dd_indexes);
+
+  while (rec != nullptr) {
+    process_dd_index_partitions_rec(heap, rec, dd_indexes);
+
+    mtr_commit(&mtr);
+
+    mem_heap_empty(heap);
+
+    mtr_start(&mtr);
+    rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
+  }
+
+  mtr_commit(&mtr);
+  dd_table_close(dd_indexes, thd, &mdl, true);
+  mem_heap_free(heap);
+
+  return (DB_SUCCESS);
+}
+
+/** Build dictionary required for prepare phase. Currently used
+for rollback of transactions, export of tables (.cfg file creation)
+and --stats features
+@param[in] thd Server thread context
+@return DB_SUCCESS on success or other DB_* codes on errors */
+static dberr_t build_dictionary(THD *thd) {
+  mutex_enter(&dict_sys->mutex);
+  scan_mysql_indexes(thd);
+  scan_mysql_index_partitions(thd);
+  mutex_exit(&dict_sys->mutex);
+  return (DB_SUCCESS);
+}
+
+/** Load all tables from mysql.ibd. This includes dictionary tables, system
+tables
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+xb_dict_tuple dict_load_from_mysql_ibd() {
+  auto begin = std::chrono::high_resolution_clock::now();
+  THD *thd = current_thd;
+  ut_ad(thd != nullptr);
+  auto result = dict_load_from_spaces_sdi(dict_sys_t::s_dict_space_id);
+  dberr_t err = std::get<0>(result);
+  if (err == DB_SUCCESS) {
+    err = build_dictionary(thd);
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - begin);
+  xb::info() << "Time taken to build dictionary: " << elapsed.count() * 1e-9
+             << " seconds";
+
+  return result;
+}
+
+/** Clear all the maps created to handle dictionary during prepare */
+void clear_dd_cache_maps() {
+  table_id_space_map.clear();
+  space_part_map.clear();
+  part_id_spaces_map.clear();
+  sdi_id_map.clear();
+  dd_schema_map.clear();
+}
+
+}  // namespace prepare
+
 }  // namespace xb

--- a/storage/innobase/xtrabackup/src/xb_dict.h
+++ b/storage/innobase/xtrabackup/src/xb_dict.h
@@ -1,4 +1,3 @@
-
 /******************************************************
 Copyright (c) 2023 Percona LLC and/or its affiliates.
 
@@ -23,14 +22,232 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql.h>
 #include <memory>
 #include <unordered_set>
-namespace xb {
-/** Tablespace identifier */
-typedef uint32_t space_id_t;
-using dd_tablespaces = std::unordered_set<space_id_t>;
+#include "include/db0err.h"
+#include "include/dict0types.h"
+// Forward declaration
+namespace dd {
+class Table;
+}
 
-/* build space_id set using INFORMATION_SCHEMA.INNODB_TABLESPACES
+namespace xb {
+/* Tablespace identifier */
+typedef uint32_t space_id_t;
+
+/* We have different ways to deal with dictionary during backup and prepare.
+Hence we separate namespaces. If there is common function between these two
+they can be put in some common namespace */
+namespace backup {
+/* List of tablespace ids  from server dictionary. This is used
+during backup to verify the IBDs we copy are valid. ie they have
+an entry in dictionary. With this map, it is possible to detect
+orphan IBDs in server data directory */
+using dd_space_ids = std::unordered_set<space_id_t>;
+
+/** Build space_id set using INFORMATION_SCHEMA.INNODB_TABLESPACES
 @param[in] connection  MySQL connection handler
 @param[out] dd_tabpespaces set containing all space_id present in DD */
-std::shared_ptr<dd_tablespaces> build_space_id_set(MYSQL *connection);
+std::shared_ptr<dd_space_ids> build_space_id_set(MYSQL *connection);
+}  // namespace backup
+
+namespace prepare {
+/**
+Dictionary design during prepare
+--------------------------------
+
+Dictionary is required for these purposes in PXB:
+1. Prepare phase, to do rollback of transactions. Transactions use undo log
+   and open tables based on "table_id" recorded in undo log
+2. Export of tables (--export). For every file_per_table tablespace, a table
+   object (dict_table_t) and a server table object (dd::Table) if table has
+   instant columns.
+3. --stats. For every table in tablespace, we iterate over all indexes and print
+   free page ratio, cardinality etc. This also requies InnoDB table object
+   (dict_table_t)
+
+4. dynamic metadata apply etc require InnoDB dictionary table
+mysql.dynamic_metadata to be be available
+
+5. Duplicate SDI (opens mysql.tables and mysql.schemata)
+
+Rollback Flow:
+-------------
+1. Load all tables(dict_table_t*) from mysql.ibd using SDI. These tables are not
+closed because we dont want them to be evictable. Dictionary tables reside in
+mysql.ibd
+
+2. After dictionary tables are loaded, we scan mysql.indexes,
+mysql.index_partitions to create a relation "table_id->space_id".
+
+3. By default, we don't load any tables upfront (the old design). A table is
+opened only on transaction rollback using table_id (dd_table_open_on_id()).
+Since we know the corresponding space_id, we will use
+SDI->dd::Table->dict_table_t conversion. Note that these tables are now
+evictable and treated like the normal way. Normal as in the table->n_ref_count
+is incremented on open, table can be used and close the table. Close operation
+will decrement table->n_ref_count. Such tables are now evictable by background
+threads. The only tables that are loaded "non-evictable" are tables from
+mysql.ibd. These are special tables and are evicted only on shutdown/exit
+
+Export flow:
+------------
+
+1. For every space_id, we load all tables in tablespace
+(SDI->dd::Table->dict_table_t)
+
+2. Since export works on file_per_table tablespaces, ideally there should be
+only one dict_table_t from a single space_id
+
+3. Exception is "partition tablespaces". The partition tablespaces, only of the
+partition has all the SDI and the other partitions are 'empty'. Hence, from a
+partition IBD, multiple dict_table_t objects are loaded.
+
+4. For each dict_table_t object, we create a .cfg, .cfp file
+
+Stats flow
+----------
+1. The flow is similar to steps mentioned in export
+2. After a dict_table_t is available, iterate over dict_table_t->indexes to
+calculate and print stats
+
+Dynamic metadata flow
+---------------------
+1. All tables loaded as part of mysql.ibd contains the dictionary table
+"mysql/innodb_dynamic_metadata"
+2. dd_table_open_on_name() will always find the above table in cache because we
+didn't close the tables in mysql.
+3. srv_dict_recover_on_restart()
+
+Duplicate SDI flow:
+-------------------
+1. Some of the IBDs from older server version have duplicate dd::Table objects
+in IBD. This creates confusion to PXB as PXB doesn't know which 'dd::Table' to
+use
+
+2. To solve this problem, we scan mysql.schemata and mysql.tables dictionary
+tables and figure out the right "sdi_id" for a given schema/tablename.
+
+3. After tables from mysql.ibd are loaded, we look into the cache for
+mysql.schemata and mysql.tables. Then scan every record from these tables to
+create "sdi_id_map"
+
+The tricky part (Partitions):
+-----------------------------
+
+Until now, we assumed for every table_id, we can find a space_id and just load
+SDI from the space_id to get the table (SDI->dd::Table->dict_table_t).
+
+Not always. We have a special case with partition IBDs. The SDI for all the
+partition tables is not in each partition IBD. Instead, it is "one" of the
+partition IBD So given a partition table_id, we cannot use it corresponding
+"space_id" (This we got from dictionary mysql.index_partitions)
+
+The problem with partitioned tablespaces is that, SDI exists in any ONE of the
+partition IBDs. Not all. Lets say t1#p#p0.ibd, t1#p#p1.ibd, t1#p#p2.ibd.
+All the information about p1 and p2 exists only in p0.ibd
+
+From dictionary (mysql.index_partitions), for a given table_id, we know the
+space_id (See table_id_space_map). So Lets say if table_id belongs to p2.ibd, we
+cannot simply load the table from p2.ibd. We have to "somehow" find a way to
+look into other partition IBDs.
+
+Lets get into details. How do we find "all partitions" of table?
+
+Answer: Scan mysql.index_partitions, we can get index_partition id and the
+InnoDB space_id and also the table_id->space_id relation
+
+table_id_space_map:
+{table_id -> space_id}
+{1075 -> 13} p0.ibd
+{1076 -> 14} p1.ibd
+{1077 -> 15} p2.ibd
+
+part_id_spaces_map:
+{partition_id -> space_id}
+
+{296 -> 13
+ 296 -> 14
+ 296 -> 15
+}
+
+space_part_map
+{space_id ->  partition_id }
+{
+13 : 296
+14 : 296
+15 : 296
+}
+
+Lets say, we are asked to load table for table_id 1077.
+We look into table_id_space_map and figure out that the space_id
+for 1077 is 15 (p2.ibd)
+
+Next, check if this space belongs to a "partitioned table"
+For this, we look into space_part_map. If an entry exists, it means
+the space_id belongs to partitioned table.
+
+We get the partition id. For space_id 15, the partition id is 296.
+
+Given a partition_id 296, we can easily know all the partition IBs by using
+part_id_spaces_map
+
+For 296, we now know that the IBDs are 13, 14, 15.
+
+We will start from lower bound(13) and start looking into all space_ids in this
+group. (14, 15)
+*/
+
+/** This function uses dict_load_tables_from_space_id_low() with a callback
+that loads all tables from dd::table into a vector
+@param[in] space_id      InnoDB tablespace_id
+@param[in] table_id      InnoDB table id. If this is zero, we load *all* tables
+                         found in space_id
+@param[in] thd           Server thread context (used for DD APIs)
+@param[in] trx           InnoDB trx object (for using SDI APIs)
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+using xb_dict_tuple = std::tuple<dberr_t, std::vector<dict_table_t *>>;
+xb_dict_tuple dict_load_tables_from_space_id(space_id_t space_id,
+                                             table_id_t table_id, THD *thd,
+                                             trx_t *trx);
+
+/** @return all tables (dict_table_t*) from a tablespace
+@param[in] space_id InnoDB tablespace id */
+xb_dict_tuple dict_load_from_spaces_sdi(space_id_t space_id);
+
+/** @return true if table_id is found in dd map. This map
+is created by scanning mysql.indexes and mysql.index_partitions
+@param[in]  table_id InnoDB table id */
+bool table_exists_in_dd(table_id_t table_id);
+
+/** Load a specific table from space_id. This is used by InnoDB table opening
+function dd_table_open_on_id()
+@param[in] table_id InnoDB table id
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+xb_dict_tuple dict_load_tables_using_table_id(table_id_t table_id);
+
+/** Load all tables from mysql.ibd. This includes dictionary tables, system
+tables
+@return tuple <a,b>
+a - DB_SUCCESS on success, other DB_ on errors
+b - std::vector<dict_table_t*>, empty on errors */
+xb_dict_tuple dict_load_from_mysql_ibd();
+
+/** This function uses dict_load_tables_from_space_id_low() with a callback
+that returns the dd::Table object to caller. We DONT convert dd::Table to
+dict_table_t here
+@param[in] space_id      InnoDB tablespace_id
+@param[in] table_id      InnoDB table id. If this is zero, we load *all* tables
+                         found in space_id
+@return dd::Table object on success, else nullptr */
+std::unique_ptr<dd::Table> get_dd_Table(space_id_t space_id,
+                                        table_id_t table_id);
+
+/** Clear all the maps created to handle dictionary during prepare */
+void clear_dd_cache_maps();
+}  // namespace prepare
+
 }  // namespace xb
 #endif

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -89,9 +89,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <api0api.h>
 #include <api0misc.h>
-#include <dict0sdi-decompress.h>
 
-#include "sql/dd/impl/sdi.h"
 #include "sql_thd_internal_api.h"
 
 #define G_PTR uchar *
@@ -210,17 +208,7 @@ static regex_list_t regex_exclude_list;
 static hash_table_t *tables_include_hash = NULL;
 static hash_table_t *tables_exclude_hash = NULL;
 
-/* map of schema name and schema id */
-static std::map<std::string, uint64> dd_schema_map;
-
 static uint32_t cfg_version = IB_EXPORT_CFG_VERSION_V7;
-
-/* map of <schema id, name> and SDI id*/
-static std::map<std::pair<int, std::string>, uint64> dd_table_map;
-
-/* map of <space_id, dd:table> used at --export */
-static std::map<space_id_t, std::shared_ptr<dd::Table>> g_dd_tables;
-
 char *xtrabackup_databases = NULL;
 char *xtrabackup_databases_file = NULL;
 char *xtrabackup_databases_exclude = NULL;
@@ -518,6 +506,10 @@ bool xb_generated_redo = false;
 
 static void check_all_privileges();
 static bool validate_options(const char *file, int argc, char **argv);
+/** all tables in mysql databases. These should be closed at the end.
+We have to keep them open (table->n_ref_count >0) because we don't want
+them to be evicted */
+static std::vector<dict_table_t *> mysql_ibd_tables;
 
 #define CLIENT_WARN_DEPRECATED(opt, new_opt)                              \
   xb::warn() << opt                                                       \
@@ -537,7 +529,7 @@ static inline void xtrabackup_add_datasink(ds_ctxt_t *ds) {
 
 /* ======== Datafiles iterator ======== */
 datafiles_iter_t *datafiles_iter_new(
-    const std::shared_ptr<const xb::dd_tablespaces> dd) {
+    const std::shared_ptr<const xb::backup::dd_space_ids> dd_spaces) {
   datafiles_iter_t *it = new datafiles_iter_t();
 
   mutex_create(LATCH_ID_XTRA_DATAFILES_ITER_MUTEX, &it->mutex);
@@ -545,11 +537,12 @@ datafiles_iter_t *datafiles_iter_new(
   Fil_iterator::for_each_file([&](fil_node_t *file) {
     auto space_id = file->space->id;
 
-    ut_ad(dd == nullptr || (dd != nullptr && srv_backup_mode && opt_lock_ddl));
+    ut_ad(dd_spaces == nullptr ||
+          (dd_spaces != nullptr && srv_backup_mode && opt_lock_ddl));
 
-    if (dd != nullptr && fsp_is_ibd_tablespace(space_id) &&
+    if (dd_spaces != nullptr && fsp_is_ibd_tablespace(space_id) &&
         !fsp_is_system_or_temp_tablespace(space_id) &&
-        !fsp_is_undo_tablespace(space_id) && dd->count(space_id) == 0) {
+        !fsp_is_undo_tablespace(space_id) && dd_spaces->count(space_id) == 0) {
       xb::warn() << "Skipping, Tablespace " << file->name
                  << " space_id: " << space_id << " does not exists"
                  << " in INFORMATION_SCHEMA.INNODB_TABLESPACES";
@@ -2320,246 +2313,6 @@ error:
   return (true);
 }
 
-/** Scan the SDI id from DD table "mysql.tables"
-@param[in]  name       tablespace name database/name
-@param[out] sdi_id     id of table
-@param[out] table_name name of the table
-@param[in]  thd        THD */
-static dberr_t get_id_from_dd_scan(const std::string &name, uint64 *id,
-                                   std::string &table_name, THD *thd) {
-  std::string db_name;
-  uint64 schema_id = 0;
-
-  /* get the database and table_name from space name */
-  dict_name::get_table(name, db_name, table_name);
-
-  ut_ad(db_name.compare("mysql") != 0);
-
-  /* map of schema name and id built from scanning mysql/schemata and map of
-  <schema id, name> and SDI id built from scanning mysql/tables */
-  if (dd_schema_map.size() == 0 && dd_table_map.size() == 0) {
-    dict_table_t *sys_tables = nullptr;
-    btr_pcur_t pcur;
-    const rec_t *rec = nullptr;
-    mtr_t mtr;
-    MDL_ticket *mdl = nullptr;
-    mem_heap_t *heap = mem_heap_create(1000, UT_LOCATION_HERE);
-    mutex_enter(&(dict_sys->mutex));
-
-    mtr_start(&mtr);
-    rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, "mysql/schemata",
-                              &sys_tables);
-    while (rec) {
-      uint64 rec_schema_id;
-      std::string rec_name;
-
-      dd_process_schema_rec(heap, rec, sys_tables, &mtr, &rec_name,
-                            &rec_schema_id);
-      dd_schema_map.insert(std::make_pair(rec_name, rec_schema_id));
-      mem_heap_empty(heap);
-
-      mtr_start(&mtr);
-      rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
-    }
-
-    mtr_commit(&mtr);
-    dd_table_close(sys_tables, thd, &mdl, true);
-    mem_heap_empty(heap);
-
-    mtr_start(&mtr);
-
-    rec = dd_startscan_system(thd, &mdl, &pcur, &mtr, "mysql/tables",
-                              &sys_tables);
-
-    while (rec) {
-      uint64 rec_schema_id;
-      std::string rec_name;
-      uint64 rec_id;
-
-      dd_process_dd_tables_rec(heap, rec, sys_tables, &mtr, &rec_schema_id,
-                               &rec_name, &rec_id);
-      mem_heap_empty(heap);
-
-      auto rec_table_id = std::make_pair(rec_schema_id, rec_name);
-
-      dd_table_map.insert(
-          std::make_pair(std::make_pair(rec_schema_id, rec_name), rec_id));
-
-      mtr_start(&mtr);
-      rec = (rec_t *)dd_getnext_system_rec(&pcur, &mtr);
-    }
-
-    mtr_commit(&mtr);
-    dd_table_close(sys_tables, thd, &mdl, true);
-    mem_heap_free(heap);
-
-    mutex_exit(&(dict_sys->mutex));
-  }
-
-  schema_id = dd_schema_map[db_name];
-
-  ut_ad(schema_id != 0);
-  if (schema_id == 0) {
-    xb::error() << "can't find " << db_name.c_str()
-                << " entry in mysql/schemata for tablespace " << name.c_str();
-    return (DB_NOT_FOUND);
-  }
-
-  *id = dd_table_map[std::make_pair(schema_id, table_name)];
-
-  ut_ad(*id != 0);
-  if (id == 0) {
-    xb::error() << "can't find " << table_name.c_str()
-                << " entry in mysql/tables for tablespace " << name.c_str();
-    return (DB_NOT_FOUND);
-  }
-  return (DB_SUCCESS);
-}
-
-dberr_t dict_load_tables_from_space_id(space_id_t space_id, THD *thd,
-                                       ib_trx_t trx) {
-  sdi_vector_t sdi_vector;
-  ib_sdi_vector_t ib_vector;
-  ib_vector.sdi_vector = &sdi_vector;
-  uint64 sdi_id = 0;
-
-  fil_space_t *space = fil_space_get(space_id);
-
-  DBUG_EXECUTE_IF("force_sdi_error", return (DB_ERROR););
-
-  if (fsp_has_sdi(space_id) != DB_SUCCESS) {
-    xb::warn() << "Failed to read SDI from " << space->name;
-    return (DB_SUCCESS);
-  }
-
-  uint32_t compressed_buf_len = 1024 * 1024;
-  uint32_t uncompressed_buf_len = 1024 * 1024;
-  byte *compressed_sdi = static_cast<byte *>(
-      ut::malloc_withkey(UT_NEW_THIS_FILE_PSI_KEY, compressed_buf_len));
-  byte *sdi = static_cast<byte *>(
-      ut::malloc_withkey(UT_NEW_THIS_FILE_PSI_KEY, uncompressed_buf_len));
-
-  ib_err_t err = ib_sdi_get_keys(space_id, &ib_vector, trx);
-
-  if (err != DB_SUCCESS) {
-    goto error;
-  }
-
-  /* Before 8.0.24 if the table is used in EXCHANGE PARTITION or IMPORT. Even
-  after upgrade to the latest version 8.0.25 (which fixed the duplicate SDI
-  issue), such tables continue to contain duplicate SDI. PXB will scan the DD
-  table "mysql.tables" to determine the correct SDI */
-  if (ib_vector.sdi_vector->m_vec.size() > 2 &&
-      strcmp(space->name, "mysql") != 0 &&
-      fsp_is_file_per_table(space_id, space->flags)) {
-    std::string table_name;
-    err = get_id_from_dd_scan(space->name, &sdi_id, table_name, thd);
-    xb::warn() << "duplicate SDI found for tablespace " << space->name
-               << ". To remove duplicate SDI, "
-                  "please execute OPTIMIZE TABLE on "
-               << table_name.c_str();
-    if (err != DB_SUCCESS) {
-      goto error;
-    }
-  }
-
-  for (sdi_container::iterator it = ib_vector.sdi_vector->m_vec.begin();
-       it != ib_vector.sdi_vector->m_vec.end(); it++) {
-    ib_sdi_key_t ib_key;
-    ib_key.sdi_key = &(*it);
-
-    uint32_t compressed_sdi_len = compressed_buf_len;
-    uint32_t uncompressed_sdi_len = uncompressed_buf_len;
-
-    if (ib_key.sdi_key->type != 1 /* dd::Sdi_type::TABLE */) {
-      continue;
-    }
-
-    /* In case of duplicate SDIs, sdi_id is the latest id according to DD, so we
-    skip other dd::Table SDIs in the IBD file */
-    if (sdi_id != 0 && ib_key.sdi_key->id != sdi_id) {
-      continue;
-    }
-
-    while (true) {
-      err = ib_sdi_get(space_id, &ib_key, compressed_sdi, &compressed_sdi_len,
-                       &uncompressed_sdi_len, trx);
-      if (err == DB_OUT_OF_MEMORY) {
-        compressed_buf_len = compressed_sdi_len;
-        compressed_sdi = static_cast<byte *>(
-            ut::realloc(compressed_sdi, compressed_buf_len));
-        continue;
-      }
-      break;
-    }
-
-    if (err != DB_SUCCESS) {
-      goto error;
-    }
-
-    if (uncompressed_buf_len < uncompressed_sdi_len) {
-      uncompressed_buf_len = uncompressed_sdi_len;
-      sdi = static_cast<byte *>(ut::realloc(sdi, uncompressed_buf_len));
-    }
-
-    Sdi_Decompressor decompressor(static_cast<byte *>(sdi),
-                                  uncompressed_sdi_len, compressed_sdi,
-                                  compressed_sdi_len);
-    decompressor.decompress();
-
-    using Table_Ptr = std::shared_ptr<dd::Table>;
-
-    Table_Ptr dd_table{dd::create_object<dd::Table>()};
-    dd::String_type schema_name;
-
-    bool res = dd::deserialize(
-        thd, dd::Sdi_type((const char *)sdi, uncompressed_sdi_len),
-        dd_table.get(), &schema_name);
-
-    if (res) {
-      err = DB_ERROR;
-      goto error;
-    }
-
-    Table_Ptr g_dd_table = dd_table;
-    if (xtrabackup_export) {
-      g_dd_tables.insert(std::make_pair(space_id, g_dd_table));
-    }
-
-    using Client = dd::cache::Dictionary_client;
-    using Releaser = dd::cache::Dictionary_client::Auto_releaser;
-
-    Client *dc = dd::get_dd_client(thd);
-    Releaser releaser{dc};
-
-    dict_table_t *ib_table = nullptr;
-
-    ut_a(space != nullptr);
-
-    /* All tables in mysql.ibd should belong to 'mysql' schema. But
-    during upgrade, server leaves the DD tables in a temporary schema
-    'dd_upgrade_80XX". PXB reads DD tables using 'mysql' schema name.
-    For example, 'mysql/tables'. Fix the schema name to 'mysql' */
-    if (space_id == dict_sys_t::s_dict_space_id &&
-        schema_name != MYSQL_SCHEMA_NAME.str) {
-      schema_name = MYSQL_SCHEMA_NAME.str;
-    }
-
-    bool implicit = fsp_is_file_per_table(space_id, space->flags);
-    if (dd_table_load_on_dd_obj(dc, space_id, *dd_table.get(), ib_table, thd,
-                                &schema_name, implicit) != 0) {
-      err = DB_ERROR;
-      goto error;
-    }
-  }
-
-error:
-  ut::free(compressed_sdi);
-  ut::free(sdi);
-
-  return (err);
-}
-
 static void xb_scan_for_tablespaces() {
   /* This is the default directory for IBD and IBU files. Put it first
   in the list of known directories. */
@@ -2582,60 +2335,6 @@ static void xb_scan_for_tablespaces() {
   if (fil_scan_for_tablespaces(true) != DB_SUCCESS) {
     exit(EXIT_FAILURE);
   }
-}
-
-static dberr_t dict_load_from_spaces_sdi() {
-  fil_open_ibds();
-
-  my_thread_init();
-
-  THD *thd = create_internal_thd();
-
-  ib_trx_t trx = ib_trx_begin(IB_TRX_READ_COMMITTED, false, false, thd);
-
-  std::vector<space_id_t> space_ids;
-
-  Fil_space_iterator::for_each_space([&](fil_space_t *space) {
-    space_ids.push_back(space->id);
-    return (DB_SUCCESS);
-  });
-
-  /* Load mysql tablespace to open mysql/tables and mysql/schemata which is
-  need to find the right key for tablespace in case of duplicate sdi */
-  dberr_t err =
-      dict_load_tables_from_space_id(dict_sys_t::s_dict_space_id, thd, trx);
-
-  if (err != DB_SUCCESS) {
-    xb::error() << "Failed to load tables from mysql.ibd";
-    goto error;
-  }
-
-  for (auto space_id : space_ids) {
-    if (!fsp_is_ibd_tablespace(space_id) ||
-        space_id == dict_sys_t::s_dict_space_id) {
-      continue;
-    }
-    err = dict_load_tables_from_space_id(space_id, thd, trx);
-    if (err != DB_SUCCESS) {
-      xb::error() << "Failed to load table from tablespace "
-                  << fil_space_get(space_id)->name;
-      err = DB_ERROR;
-      break;
-    }
-  }
-
-error:
-
-  dd_schema_map.clear();
-  dd_table_map.clear();
-
-  ib_trx_commit(trx);
-  ib_trx_release(trx);
-
-  destroy_internal_thd(thd);
-
-  my_thread_end();
-  return err;
 }
 
 static bool innodb_init(bool init_dd, bool for_apply_log) {
@@ -2680,7 +2379,10 @@ static bool innodb_init(bool init_dd, bool for_apply_log) {
   }
 
   if (init_dd) {
-    err = dict_load_from_spaces_sdi();
+    fil_open_ibds();
+
+    dberr_t err;
+    std::tie(err, mysql_ibd_tables) = xb::prepare::dict_load_from_mysql_ibd();
     if (err != DB_SUCCESS) {
       xb::error() << "Failed to load table using tablespace SDI ";
       goto error;
@@ -2721,8 +2423,12 @@ static bool innodb_end(void) {
 
   mutex_free(&master_key_id_mutex);
 
+  for (auto table : mysql_ibd_tables) {
+    dict_table_close(table, false, false);
+  }
   srv_shutdown();
 
+  xb::prepare::clear_dd_cache_maps();
   os_event_global_destroy();
 
   free(internal_innobase_data_file_path);
@@ -4232,7 +3938,7 @@ void xtrabackup_backup_func(void) {
 
   recv_is_making_a_backup = true;
   bool data_copying_error = false;
-  std::shared_ptr<xb::dd_tablespaces> xb_dd_space;
+  std::shared_ptr<xb::backup::dd_space_ids> xb_dd_spaces;
   init_mysql_environment();
 
   if (print_instant_versioned_tables(mysql_connection)) exit(EXIT_FAILURE);
@@ -4265,8 +3971,8 @@ void xtrabackup_backup_func(void) {
   srv_backup_mode = true;
 
   if (opt_lock_ddl) {
-    xb_dd_space = xb::build_space_id_set(mysql_connection);
-    ut_ad(xb_dd_space->size());
+    xb_dd_spaces = xb::backup::build_space_id_set(mysql_connection);
+    ut_ad(xb_dd_spaces->size());
   }
 
   /* We can safely close files if we don't allow DDL during the
@@ -4453,7 +4159,7 @@ void xtrabackup_backup_func(void) {
                << " threads for parallel data files transfer";
   }
 
-  auto it = datafiles_iter_new(xb_dd_space);
+  auto it = datafiles_iter_new(xb_dd_spaces);
   if (it == NULL) {
     xb::error() << "datafiles_iter_new() failed.";
     exit(EXIT_FAILURE);
@@ -4910,6 +4616,8 @@ static void xtrabackup_stats_func(int argc, char **argv) {
   srv_read_only_mode = true;
 
   init_mysql_environment();
+  my_thread_init();
+  THD *thd = create_internal_thd();
   if (!xtrabackup::components::keyring_init_offline()) {
     xb::error() << "failed to init keyring component";
     exit(EXIT_FAILURE);
@@ -4970,9 +4678,6 @@ static void xtrabackup_stats_func(int argc, char **argv) {
   /* gather stats */
 
   {
-    my_thread_init();
-    THD *thd = create_internal_thd();
-
     dict_table_t *sys_tables = nullptr;
     dict_table_t *table = nullptr;
     btr_pcur_t pcur;
@@ -5031,8 +4736,6 @@ static void xtrabackup_stats_func(int argc, char **argv) {
 
     mutex_exit(&(dict_sys->mutex));
 
-    destroy_internal_thd(thd);
-    my_thread_end();
   }
 
   putc('\n', stdout);
@@ -5046,6 +4749,8 @@ static void xtrabackup_stats_func(int argc, char **argv) {
 
   xb_keyring_shutdown();
 
+  destroy_internal_thd(thd);
+  my_thread_end();
   cleanup_mysql_environment();
 }
 
@@ -6554,8 +6259,12 @@ static bool xb_export_cfg_write_index_fields(
       }
       /* Write DD::Column specific info for dropped columns */
       if (col->is_instant_dropped()) {
-        auto dd_search = g_dd_tables.find(table->space);
-        if (dd_search != g_dd_tables.end()) {
+        mutex_exit(&dict_sys->mutex);
+        std::unique_ptr<dd::Table> dd_table =
+            xb::prepare::get_dd_Table(table->space, table->id);
+        mutex_enter(&dict_sys->mutex);
+
+        if (dd_table != nullptr) {
           /* Total metadata to be written
           1 byte for is NULLABLE
           1 byte for is_unsigned
@@ -6568,8 +6277,7 @@ static bool xb_export_cfg_write_index_fields(
           byte _row[METADATA_SIZE];
 
           ut_ad(col->is_instant_dropped());
-          const dd::Table *dd_table = dd_search->second.get();
-          const dd::Column *column = dd_find_column(dd_table, col_name);
+          const dd::Column *column = dd_find_column(dd_table.get(), col_name);
           ut_ad(column != nullptr);
 
           byte *_ptr = _row;
@@ -7068,6 +6776,8 @@ skip_check:
   }
 
   init_mysql_environment();
+  my_thread_init();
+  THD *thd = create_internal_thd();
 
   /* Create logfiles for recovery from 'xtrabackup_logfile', before start InnoDB
    */
@@ -7250,13 +6960,7 @@ skip_check:
       exit(EXIT_FAILURE);
     }
 
-    my_thread_init();
-
-    THD *thd = create_internal_thd();
-
     while ((node = datafiles_iter_next(it)) != NULL) {
-      dict_table_t *table;
-
       space = node->space;
 
       /* treat file_per_table only */
@@ -7264,35 +6968,38 @@ skip_check:
         continue;
       }
 
-      table = dd_table_open_on_name(thd, NULL, space->name, false, true);
-
-      mutex_enter(&(dict_sys->mutex));
-      if (!table) {
+      auto result = xb::prepare::dict_load_from_spaces_sdi(space->id);
+      dberr_t err = std::get<0>(result);
+      auto table_vec = std::get<1>(result);
+      if (err != DB_SUCCESS) {
         xb::error() << "cannot find dictionary record of table " << space->name;
-        goto next_node;
+        ut_ad(table_vec.empty());
+        continue;
       }
 
-      /* Write transfer key for tablespace file */
-      if (!xb_export_cfp_write(table)) {
-        goto next_node;
-      }
+      // It is possible that partition IBD has multiple tables
+      for (auto table : table_vec) {
+        mutex_enter(&(dict_sys->mutex));
+        /* Write transfer key for tablespace file */
+        fil_space_t *sp = fil_space_get(table->space);
+        if (!xb_export_cfp_write(table)) {
+          goto next_node;
+        }
 
-      /* Write MySQL 8.0 .cfg file */
-      if (!xb_export_cfg_write(node, table)) {
-        goto next_node;
-      }
+        /* Write MySQL 8.0 .cfg file */
+        if (!xb_export_cfg_write(&sp->files[0], table)) {
+          goto next_node;
+        }
 
-    next_node:
-      if (table != nullptr) {
-        dd_table_close(table, thd, nullptr, true);
+      next_node:
+        if (table != nullptr) {
+          dd_table_close(table, thd, nullptr, true);
+        }
+        mutex_exit(&(dict_sys->mutex));
       }
-      mutex_exit(&(dict_sys->mutex));
     }
 
     datafiles_iter_free(it);
-
-    destroy_internal_thd(thd);
-    my_thread_end();
   }
 
   /* Check whether the log is applied enough or not. */
@@ -7372,6 +7079,8 @@ skip_check:
 
   xb_keyring_shutdown();
 
+  destroy_internal_thd(thd);
+  my_thread_end();
   Tablespace_map::instance().serialize();
 
   cleanup_mysql_environment();
@@ -7383,6 +7092,8 @@ skip_check:
 error_cleanup:
 
   xb_keyring_shutdown();
+  destroy_internal_thd(thd);
+  my_thread_end();
 
   xtrabackup_close_temp_log(false);
 
@@ -8029,6 +7740,10 @@ int main(int argc, char **argv) {
 
   /* Logs xtrabackup generated timestamps in local timezone instead of UTC */
   opt_log_timestamps = 1;
+  /* This variable determines the size of dict_table_t* cache in InnoDB. This is
+  default and it is sufficient because rollback is single threaded and we only
+  open tables one by one */
+  table_def_size = 4000;
 
   setup_signals();
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -238,7 +238,7 @@ void xtrabackup_io_throttling(void);
 bool xb_write_delta_metadata(const char *filename, const xb_delta_info_t *info);
 
 datafiles_iter_t *datafiles_iter_new(
-    const std::shared_ptr<const xb::dd_tablespaces>);
+    const std::shared_ptr<const xb::backup::dd_space_ids>);
 fil_node_t *datafiles_iter_next(datafiles_iter_t *it);
 void datafiles_iter_free(datafiles_iter_t *it);
 

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -376,6 +376,7 @@ pid-file=${MYSQLD_PIDFILE}
 replicate-ignore-db=mysql
 replicate-ignore-db=performance_schema
 replicate-ignore-db=sys
+secure-file-priv=""
 innodb_log_file_size=48M
 ${MYSQLD_EXTRA_MY_CNF_OPTS:-}
 #core-file
@@ -1438,11 +1439,12 @@ function grep_general_log()
 function kill_query_pattern()
 {
   local condition=$1
-  run_cmd $MYSQL $MYSQL_ARGS --force --batch  test <<EOF
+  $MYSQL $MYSQL_ARGS --force --batch <<EOF
   select concat('KILL ',id,';') from information_schema.processlist
   where $condition into outfile '$MYSQLD_TMPDIR/killcondition.sql';
   source $MYSQLD_TMPDIR/killcondition.sql;
 EOF
+
   rm -f $MYSQLD_TMPDIR/killcondition.sql
 }
 

--- a/storage/innobase/xtrabackup/test/inc/dictionary_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/dictionary_common.sh
@@ -1,0 +1,262 @@
+. inc/common.sh
+
+vlog "#"
+vlog "# PXB-2955 : Implement dictionary cache"
+vlog "#"
+
+function wait_for_bg_trx() {
+# we should NOT exit if grep fails or mysql client fails. We have to retry
+# hence exit on err should be avoided.
+set +e
+ while true; do
+   $MYSQL $MYSQL_ARGS -e "SHOW PROCESSLIST" |  grep -i 'SELECT SLEEP'
+   if [ $? -eq 0 ]; then
+	   break;
+   fi
+   vlog "waiting for background trx to finish inserting data and reach to sleep"
+   sleep 1
+ done
+
+set -e
+
+ vlog "Wait for trx data to be flushed. This guarantees rollback during prepare"
+ innodb_wait_for_flush_all
+}
+
+function kill_bg_trx() {
+ # Following commands in function can fail. Either success or failure is OK
+ # Also used by 'trap'. Hence we unset the 'e' flag which Exit immediately if a
+ # command exits with a non-zero status.
+ set +e
+ TRX_PID=$1
+ vlog "Kill the Long running uncommited transaction after the backup"
+ kill_query_pattern "INFO like '%SLEEP%'"
+
+ kill -SIGKILL $TRX_PID
+
+ vlog "Wait for killed process to exit"
+ wait $TRX_PID
+ set -e
+}
+
+function check_rollback_msg() {
+FILE=$1
+egrep -q "Rolling back trx with id [0-9]+, [0-9]+ rows to undo" $FILE || die "Expected rollback didn't happen during prepare"
+}
+
+function create_tablespace() {
+ mysql test << EOF
+ CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd';
+ CREATE TABLE t11(a INT) TABLESPACE=ts1;
+ CREATE TABLE t12(a INT, b INT) TABLESPACE=ts1;
+EOF
+}
+
+function create_tables() {
+  TABLE=$1
+  # optional parameter 2 for TABLESPACE
+  TABLESPACE=${2:-}
+  if [ ! -z ${TABLESPACE} ];
+  then
+    TABLESPACE="TABLESPACE=$TABLESPACE"
+  fi
+  mysql test << EOF
+    CREATE TABLE $TABLE (
+    id INT PRIMARY KEY,
+    val INT NOT NULL DEFAULT 0
+    ) $TABLESPACE ENGINE=InnoDB
+EOF
+
+  mysql -e "INSERT INTO $TABLE (id) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)" test
+  vlog "Long running transaction that modifies table data but is not committed at the time of backup"
+  $MYSQL $MYSQL_ARGS -e "\
+   BEGIN;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   INSERT INTO $TABLE (id) SELECT id + (SELECT MAX(id) FROM $TABLE) FROM $TABLE;\
+   SELECT SLEEP (10000);
+ " test &
+ uncommitted_trx=$!
+
+ trap "kill_bg_trx $uncommitted_trx" EXIT
+
+ wait_for_bg_trx
+
+ vlog "Backup"
+ rm -rf $topdir/backup
+ xtrabackup --backup --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb.log
+
+ kill_bg_trx $uncommitted_trx
+
+ vlog "Record db state"
+ record_db_state test
+
+ vlog "Prepare the backup"
+ xtrabackup --prepare --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb_prepare.log
+ check_rollback_msg $topdir/pxb_prepare.log
+
+ vlog "Restore"
+ stop_server
+ rm -rf $MYSQLD_DATADIR/*
+ xtrabackup --move-back --target-dir=${topdir}/backup
+ start_server
+ verify_db_state test
+}
+
+function create_part_table() {
+  vlog "Create partition table"
+  mysql  test << EOF
+  DROP TABLE IF EXISTS t1;
+  CREATE TABLE t1 (
+  a INT,
+  pad1 CHAR(250) NOT NULL DEFAULT "a",
+  pad2 CHAR(250) NOT NULL DEFAULT "a",
+  pad3 CHAR(250) NOT NULL DEFAULT "a",
+  pad4 CHAR(250) NOT NULL DEFAULT "a"
+  ) ENGINE=InnoDB DEFAULT CHARSET=latin1
+  PARTITION BY RANGE (a)
+  (PARTITION p0 VALUES LESS THAN (2000) ENGINE = InnoDB,
+   PARTITION P1 VALUES LESS THAN (4000) ENGINE = InnoDB,
+   PARTITION p2 VALUES LESS THAN (6000) ENGINE = InnoDB,
+   PARTITION p3 VALUES LESS THAN (8000) ENGINE = InnoDB,
+   PARTITION p4 VALUES LESS THAN MAXVALUE ENGINE = InnoDB);
+EOF
+}
+
+function load_data_part_table() {
+  vlog "Load data"
+  mysql test << EOF
+  SET cte_max_recursion_depth=10000;
+  INSERT INTO t1 WITH RECURSIVE cte (n) AS (   SELECT 1   UNION ALL   SELECT n + 1 FROM cte WHERE n < 10000 ) SELECT  *, REPEAT('a', 250) , REPEAT('b',250) , REPEAT('c', 250), REPEAT('d',250) FROM cte;
+EOF
+}
+
+function create_part_sub_table() {
+  vlog "Create partition table with sub partitions"
+  mysql  test << EOF
+  DROP TABLE IF EXISTS t1;
+  CREATE TABLE t1 (
+   a INT,
+   pad1 CHAR(250) NOT NULL DEFAULT "a",
+   pad2 CHAR(250) NOT NULL DEFAULT "a",
+   pad3 CHAR(250) NOT NULL DEFAULT "a",
+   pad4 CHAR(250) NOT NULL DEFAULT "a"
+   ) ENGINE=InnoDB DEFAULT CHARSET=latin1
+   PARTITION BY RANGE (a)
+   SUBPARTITION BY HASH(a) SUBPARTITIONS 5
+   (PARTITION p0 VALUES LESS THAN (2000),
+    PARTITION P1 VALUES LESS THAN (4000),
+    PARTITION p2 VALUES LESS THAN (6000),
+    PARTITION p3 VALUES LESS THAN (8000),
+    PARTITION p4 VALUES LESS THAN MAXVALUE);
+EOF
+}
+
+function test_partition() {
+  START=$1
+  END=$2
+
+  vlog "Long running transaction that modifies table data but is not committed at the time of backup"
+ $MYSQL $MYSQL_ARGS -e "\
+   BEGIN;\
+   DELETE FROM t1 WHERE a>$START AND a < $END; \
+   SELECT SLEEP (10000);
+ " test &
+ uncommitted_trx=$!
+
+ trap "kill_bg_trx $uncommitted_trx" EXIT
+
+ wait_for_bg_trx
+
+ vlog "Backup"
+ rm -rf $topdir/backup
+ xtrabackup --backup --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb.log
+
+ kill_bg_trx $uncommitted_trx
+
+ vlog "Record db state"
+ record_db_state test
+
+ vlog "Prepare the backup"
+ xtrabackup --prepare --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb_prepare.log
+ check_rollback_msg $topdir/pxb_prepare.log
+
+ vlog "Restore"
+ stop_server
+ rm -rf $MYSQLD_DATADIR/*
+ xtrabackup --move-back --target-dir=${topdir}/backup
+ start_server
+ verify_db_state test
+}
+# This function uses a datadir that contains table with duplicate SDI
+# Such tables are possible with an older version of server. Duplicate SDI
+# can continue to remain even after an upgrade.
+# Test rollback on such tables
+
+function duplicate_sdi() {
+
+  stop_server
+  rm -rf $topdir/backup && mkdir -p $topdir/backup
+  run_cmd tar -xf inc/duplicate_sdi_backup.tar.gz -C $topdir/backup
+  vlog "prepare the backup dir with dup SDI"
+  xtrabackup --prepare --target-dir=$topdir/backup
+  #restore
+  [[ -d $mysql_datadir ]] && rm -rf $mysql_datadir && mkdir -p $mysql_datadir
+  vlog "Restoring the dup SDI prepared backup"
+  xtrabackup --copy-back --target-dir=$topdir/backup
+
+  MYSQLD_START_TIMEOUT=1200
+  MYSQLD_EXTRA_MY_CNF_OPTS="
+  lower_case_table_names
+  "
+  start_server
+
+  vlog "Load more data to tables with duplicate SDI"
+  mysql test <<EOF
+  SET cte_max_recursion_depth=5000;
+  INSERT INTO t1 WITH RECURSIVE cte (n) AS (   SELECT 105   UNION ALL   SELECT n + 1 FROM cte WHERE n < 4999 ) SELECT * FROM cte;
+  INSERT INTO pt1 WITH RECURSIVE cte (n) AS (   SELECT 5   UNION ALL   SELECT n + 1 FROM cte WHERE n < 2999 ) SELECT * FROM cte;
+EOF
+
+  vlog "Long running transaction that modifies table data but is not committed at the time of backup"
+
+$MYSQL $MYSQL_ARGS -e "\
+   BEGIN;\
+   DELETE FROM t1 WHERE a < 4000;
+   DELETE FROM pt1 WHERE a < 2500;
+   SELECT SLEEP (10000);
+ " test &
+ uncommitted_trx=$!
+
+ trap "kill_bg_trx $uncommitted_trx" EXIT
+
+ wait_for_bg_trx
+
+ vlog "Backup"
+ rm -rf $topdir/backup
+ xtrabackup --backup --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb.log
+
+ kill_bg_trx $uncommitted_trx
+
+ vlog "Record db state"
+ record_db_state test
+
+ vlog "Prepare the backup"
+ xtrabackup --prepare --target-dir=$topdir/backup 2>&1 | tee $topdir/pxb_prepare.log
+ check_rollback_msg $topdir/pxb_prepare.log
+
+ vlog "Restore"
+ stop_server
+ rm -rf $MYSQLD_DATADIR/*
+ xtrabackup --move-back --target-dir=${topdir}/backup
+ start_server
+ verify_db_state test
+}

--- a/storage/innobase/xtrabackup/test/t/dictionary.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary.sh
@@ -1,0 +1,13 @@
+. inc/dictionary_common.sh
+
+start_server
+
+vlog "test rollback on a table (fil_per_table_tablespace)"
+create_tables t1
+
+vlog "test rollback on a table in general tablespaces"
+create_tablespace
+create_tables t2 ts1
+
+vlog "test rollback on a table in system tablespaces"
+create_tables t3 innodb_system

--- a/storage/innobase/xtrabackup/test/t/dictionary_part1.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary_part1.sh
@@ -1,0 +1,30 @@
+. inc/dictionary_common.sh
+
+start_server
+
+#   PARTITION p0 VALUES LESS THAN (2000) ENGINE = InnoDB,
+#   PARTITION P1 VALUES LESS THAN (4000) ENGINE = InnoDB,
+#   PARTITION p2 VALUES LESS THAN (6000) ENGINE = InnoDB,
+#   PARTITION p3 VALUES LESS THAN (8000) ENGINE = InnoDB,
+#   PARTITION p4 VALUES LESS THAN MAXVALUE ENGINE = InnoDB
+
+vlog "Creating partition table and loading data"
+create_part_table
+
+vlog "Load data into partition table"
+load_data_part_table
+
+vlog "Testing rollback on partition p0"
+test_partition 0 1999
+
+vlog "Testing rollback on partition p1"
+test_partition 2000 3999
+
+vlog "Testing rollback on partition p2"
+test_partition 4000 5999
+
+vlog "Testing rollback on partition p3"
+test_partition 6000 7999
+
+vlog "Testing rollback on partition p4"
+test_partition 8000 10000

--- a/storage/innobase/xtrabackup/test/t/dictionary_part2.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary_part2.sh
@@ -1,0 +1,24 @@
+. inc/dictionary_common.sh
+
+start_server
+
+#   PARTITION p0 VALUES LESS THAN (2000) ENGINE = InnoDB,
+#   PARTITION P1 VALUES LESS THAN (4000) ENGINE = InnoDB,
+#   PARTITION p2 VALUES LESS THAN (6000) ENGINE = InnoDB,
+#   PARTITION p3 VALUES LESS THAN (8000) ENGINE = InnoDB,
+#   PARTITION p4 VALUES LESS THAN MAXVALUE ENGINE = InnoDB
+
+vlog "Truncate Parition p0 and rollback on p1"
+create_part_table
+load_data_part_table
+
+mysql test <<EOF
+ALTER TABLE t1 TRUNCATE PARTITION p0;
+EOF
+test_partition 2000 3999
+
+vlog "Drop partition p0 and rollback on p3"
+mysql test <<EOF
+ALTER TABLE t1 DROP PARTITION p0;
+EOF
+test_partition 6000 7999

--- a/storage/innobase/xtrabackup/test/t/dictionary_sdi.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary_sdi.sh
@@ -1,0 +1,6 @@
+. inc/dictionary_common.sh
+
+start_server
+
+vlog "Test rollback on tables with duplicate SDI"
+duplicate_sdi

--- a/storage/innobase/xtrabackup/test/t/dictionary_sub_part1.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary_sub_part1.sh
@@ -1,0 +1,24 @@
+. inc/dictionary_common.sh
+
+start_server
+
+vlog "Creating partition table with SUBPARTITIONS"
+create_part_sub_table
+
+vlog "Load data into partition table with sub partitions"
+load_data_part_table
+
+vlog "Testing rollback on partition p0sp0"
+test_partition 0 199
+
+vlog "Testing rollback on partition p1sp1"
+test_partition 2400 2799
+
+vlog "Testing rollback on partition p2*"
+test_partition 4000 5999
+
+vlog "Testing rollback on partition p3*"
+test_partition 6000 7999
+
+vlog "Testing rollback on partition p4"
+test_partition 8000 10000

--- a/storage/innobase/xtrabackup/test/t/dictionary_sub_part2.sh
+++ b/storage/innobase/xtrabackup/test/t/dictionary_sub_part2.sh
@@ -1,0 +1,16 @@
+. inc/dictionary_common.sh
+
+start_server
+
+create_part_sub_table
+load_data_part_table
+mysql test <<EOF
+ALTER TABLE t1 TRUNCATE PARTITION p0;
+EOF
+test_partition 2000 3999
+
+vlog "Drop partition p0 and rollback on p3"
+mysql test <<EOF
+ALTER TABLE t1 DROP PARTITION p0;
+EOF
+test_partition 6000 7999


### PR DESCRIPTION
Problem(s)
----------
1. xtrabackup --prepare requires very high ram (--use-memory doesn't help)
2. xtrabackup --prepare crashes or doesn't finish if backup dir has more than 300K tablespaces
3. xtrabackup --prepare takes long time to complete if backup dir has huge number of tablespaces (redo to be applied is small)

Before this PR(the old design)
------------------------------
xtrabackup --prepare, after applying redo logs, starts InnoDB engine to do "rollback" of uncompleted
transactions at the time of backup.

For this purpose, it has to prepare a dictionary. Rollback works by loading a table object. This is based
on "table_id" recorded in undo log record.

PXB doesn't use the same server APIs to boot DD engine. It is complicated and requires significant efforts
to load server component and initialize DD cache. PXB uses SDI (Serialized Dictionary Info) found on IBD tablespaces.

SDI is a JSON representation of the "table structure". Index information, index fields, columns, column types etc
are part of SDI.

it is possible for an user to see SDI using the below command

ibd2sdi t1.ibd > t1.sdi

PXB uses the same SDI present inside the tablespace. To build a dictionary cache (that is required for rollback). PXB
goes through all tablespaces (*.ibd files) in backup dir. For each IBD:

1. open IBD file
2. Parse SDI using SDI APIs
3. Uncompress the SDI (it is stored as zlib compressed stream)
4. Deserialize the SDI to Server table object (dd::Table)
5. Convert dd::Table to InnoDB table object (dict_table_t)

Note that we load every table in the above steps as "non-evictable". This is because InnoDB has master thread enforces
the table (dict_table_t) cache limit.

The reason for storing them as "non-evictable" is that if a table is evicted, and rollback asks to load a table using
"table_id", we don't know the "tablespace" that contains the table_id. The relation ship "table_id" to "space_id" doesnt
exist. Hence, we load the tables as "non-evictable"

This design (to not being able to evict tables) has a huge penalty. Since we have to load all tables from all IBDs,
the number of tables loaded into cache is huge. We load a table that is NOT required for rollback.

Fix (New Design):
-----------------

If we could somehow maintain the relation "table_id (key) -> space_id (value)", we can do "on-demand" loading of table

The "somehow" part:
-------------------
1. We scan mysql.indexes table to parse a DD table directly using InnoDB APIs
2. We parse the InnoDB record and extract "se_private_data"
3. A sample "se_private_data" looks like this: "id=158;root=4;space_id=6;table_id=1067;trx_id=1548;"
4. From se_private_data, extract "space_id" and "table_id". From this we know for table_id 1067, the space_id
   to look for SDi is 6.
8. For partitions we take a similar approach. we scan mysql.index_partitions and the build "table_id -> space_id" map

New Flow:
---------
1. Load all tables mysql.ibd, we need them to be able to do B-Tree scan of mysql.indexes, mysql.index_partitions, mysql.tables tables.
2. Read from mysql.indexes/index_partitions to build dictionary map (std::unordered_map) of  "table_id -> space_id"
3. On rollback, if server looks for a table_id, we first look into cache. If it doesn't exists, we load the table using the following steps.
   a. find the space_id for the given table_id
   b. Load a table_id from the above space_id (step a result)
   c. Load the table into cache
   d. Table is opened (table->n_ref_count is 1)

4. After the table object is used and undo apply is over, we close the table (table->n_ref_count is 0). Hence evictable

We save memory by
1. By not loading all tables from all tablespaces (using SDI) upfront
2. We load a table on-demand. i.e. "only" if there is rollback on the table (or on --export)

The partition conundrum:
------------------------
The above solution to use "table_id -> space_id" doesn't work with partitions. This is because Server stores SDI only in the first IBD.

Lets say, we create a partition table with 3 partitions. t1#p#p0.ibd, t1#p#p1.ibd and t1#p#p2.ibd. Server stores SDI only in t1#p#p0.ibd.
Other partitions t1#p#p1.ibd and t1#p#p2.ibd do not have the dd::Table SDI. Only dd::Tablespace SDI is present in p1 and p2.

This means, if ever there is rollback on p1 and p2, we cannot use the p1.ibd or p2.ibd. We have to look always into p0.ibd (or the first partition)

To solve this problem, we first have to identify all partition of a table. In the above example, we have to find the group is

t1#p#p0.ibd, t1#p#p1.ibd and t1#p#p2.ibd all three form one table with paritions. We could do a name scan but we chose a different way to figure out
the partitions. Again, that is by relying "partition index id"

Lets get into details. How do we find "all partitions" of table?
Answer: Scan mysql.index_partitions, we can get index_partition id and the
InnoDB space_id and also the table_id->space_id relation

table_id_space_map:
{table_id -> space_id}
1075 -> 13 (p0.ibd)
1076 -> 14 (p1.ibd)
1077 -> 15 (p2.ibd)}

part_id_spaces_map:
{partition_id -> space_id}
{296 -> 13
296 -> 14
296 -> 15 }

space_part_map
{space_id -> partition_id } {
13 : 296
14 : 296
15 : 296 }

Lets say, we are asked to load table for table_id 1077.
We look into table_id_space_map and figure out that the space_id
for 1077 is 15 (p2.ibd)

Next, check if this space belongs to a "partitioned table"
For this, we look into space_part_map. If an entry exists, it means
the space_id belongs to partitioned table.

We get the partition id. For space_id 15, the partition id is 296.

Given a partition_id 296, we can easily know all the partition IBs by using
part_id_spaces_map

For 296, we now know that the IBDs are 13, 14, 15.

We will start from lower bound(13) and start looking into all space_ids in this
group. (14, 15)

We will load SDI from space_id 13 (p0.ibd)

Other improvements:
-------------------
We now use multiple threads to load IBDs into cache. Previously, only the scan is parallel.
See Tablespace_files::open_ibds()