### PR TITLE
Set CRC as static explicitly

### DIFF
--- a/storage/innobase/xtrabackup/src/crc/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/crc/CMakeLists.txt
@@ -31,4 +31,4 @@ ENDIF()
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake
                ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
-ADD_LIBRARY(crc crc_glue.cc crc-intel-pclmul.cc)
+ADD_LIBRARY(crc STATIC crc_glue.cc crc-intel-pclmul.cc)


### PR DESCRIPTION
CRC is acturally a STATIC library, which is used to merge into other executables. Seting it as STATIC makes it more friendly with cmake options.