### PR TITLE
add a innodb_redo_log archive option to xtrabackup

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -932,6 +932,7 @@ void Archived_Redo_Log_Monitor::thread_func() {
 
   stopped = false;
   ready = false;
+  redo_arch = false;
 
   auto mysql = xb_mysql_connect();
   if (mysql == nullptr) {
@@ -953,8 +954,21 @@ void Archived_Redo_Log_Monitor::thread_func() {
     std::string dir;
     std::string subdir;
   } archive;
-
+  std::ostringstream query;
   read_mysql_variables(mysql, "SHOW VARIABLES", vars, true);
+
+  if(!(redo_log_archive_dirs == nullptr || *redo_log_archive_dirs == 0)){                                      
+     xb::info() << "innodb_redo_log_archive_dirs is now  set .";                                               
+     redo_arch = true;                                                                                         
+  }                                                                                                            
+                                                                                                               
+  if (xtrabackup_redo_log_arch_dir) {                                                                          
+     xb::info() << "xtrabackup redo_log_arch_dir is now  set .";                                           
+     query << "SET GLOBAL innodb_redo_log_archive_dirs =" << "\"" << xtrabackup_redo_log_arch_dir << "\"" ;
+     xb_mysql_query(mysql, query.str().c_str(), false);                                                    
+  }                                                                                                            
+                                                                                                               
+  read_mysql_variables(mysql, "SHOW VARIABLES", vars, true);                                                   
 
   if (redo_log_archive_dirs == nullptr || *redo_log_archive_dirs == 0) {
     xb::info() << "Redo Log Archiving is not set up.";
@@ -1128,6 +1142,10 @@ void Archived_Redo_Log_Monitor::thread_func() {
   }
 
   xb_mysql_query(mysql, "SELECT innodb_redo_log_archive_stop()", false);
+  if(!redo_arch ){                                                                                             
+    xb::info() << "innodb_redo_log_archive_dirs is not set,set it NULL .";                                     
+    xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;", false,true);                      
+  }                                                                                                            
   unlink(archive.filename.c_str());
   rmdir(archive.dir.c_str());
   mysql_close(mysql);

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -271,6 +271,9 @@ class Archived_Redo_Log_Monitor {
   /** readiness flag. */
   std::atomic<bool> ready;
 
+  /** redo arch flag. */
+  std::atomic<bool> redo_arch;
+
   /** first log block no. */
   uint32_t first_log_block_no;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -844,11 +844,10 @@ struct my_option xb_client_options[] = {
      "careful!",
      (G_PTR *)&xtrabackup_incremental, (G_PTR *)&xtrabackup_incremental, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-
-      {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS, "destination directory",
-      (G_PTR *)&xtrabackup_redo_log_arch_dir, (G_PTR *)&xtrabackup_redo_log_arch_dir, 0,
-      GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
-
+    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+     "redo log archive directory",
+     (G_PTR *)&xtrabackup_redo_log_arch_dir, (G_PTR *)&xtrabackup_redo_log_arch_dir, 0,
+     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
     {"incremental-basedir", OPT_XTRA_INCREMENTAL_BASEDIR,
      "(for --backup): copy only .ibd pages newer than backup at specified "
      "directory.",

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -187,7 +187,7 @@ pagetracking::xb_space_map *changed_page_tracking = nullptr;
 char *xtrabackup_incremental_basedir = NULL; /* for --backup */
 char *xtrabackup_extra_lsndir = NULL;    /* for --backup with --extra-lsndir */
 char *xtrabackup_incremental_dir = NULL; /* for --prepare */
-
+char *xtrabackup_redo_log_arch_dir = NULL;
 char xtrabackup_real_incremental_basedir[FN_REFLEN];
 char xtrabackup_real_extra_lsndir[FN_REFLEN];
 char xtrabackup_real_incremental_dir[FN_REFLEN];
@@ -637,6 +637,7 @@ enum options_xtrabackup {
   OPT_LOG,
   OPT_LOG_BIN_INDEX,
   OPT_INNODB,
+  OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
   OPT_INNODB_CHECKSUMS,
   OPT_INNODB_DATA_FILE_PATH,
   OPT_INNODB_DATA_HOME_DIR,
@@ -843,6 +844,11 @@ struct my_option xb_client_options[] = {
      "careful!",
      (G_PTR *)&xtrabackup_incremental, (G_PTR *)&xtrabackup_incremental, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
+      {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS, "destination directory",
+      (G_PTR *)&xtrabackup_redo_log_arch_dir, (G_PTR *)&xtrabackup_redo_log_arch_dir, 0,
+      GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+
     {"incremental-basedir", OPT_XTRA_INCREMENTAL_BASEDIR,
      "(for --backup): copy only .ibd pages newer than backup at specified "
      "directory.",

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -844,10 +844,6 @@ struct my_option xb_client_options[] = {
      "careful!",
      (G_PTR *)&xtrabackup_incremental, (G_PTR *)&xtrabackup_incremental, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
-     "redo log archive directory",
-     (G_PTR *)&xtrabackup_redo_log_arch_dir, (G_PTR *)&xtrabackup_redo_log_arch_dir, 0,
-     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
     {"incremental-basedir", OPT_XTRA_INCREMENTAL_BASEDIR,
      "(for --backup): copy only .ibd pages newer than backup at specified "
      "directory.",
@@ -906,7 +902,12 @@ struct my_option xb_client_options[] = {
      "'xbstream'.",
      (G_PTR *)&xtrabackup_stream_str, (G_PTR *)&xtrabackup_stream_str, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-
+  
+   {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+    "redo log archive directory",
+    (G_PTR *)&xtrabackup_redo_log_arch_dir, (G_PTR *)&xtrabackup_redo_log_arch_dir, 0,
+    GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+  
     {"compress", OPT_XTRA_COMPRESS,
      "Compress individual backup files using the specified compression "
      "algorithm. Supported algorithms are 'quicklz', 'lz4' and 'zstd'. The "

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -72,6 +72,7 @@ extern char *xtrabackup_target_dir;
 extern char xtrabackup_real_target_dir[FN_REFLEN];
 extern char *xtrabackup_incremental_dir;
 extern char *xtrabackup_incremental_basedir;
+extern char *xtrabackup_redo_log_arch_dir;
 extern char *innobase_data_home_dir;
 extern char *innobase_buffer_pool_filename;
 extern ds_ctxt_t *ds_meta;


### PR DESCRIPTION
Backup utilities that copy redo log records may sometimes fail to keep pace with redo log generation while a backup operation is in progress, resulting in lost redo log records due to those records being overwritten. 
If the MySQL server innodb_redo_log_archive_dirs =NULL  and   the redo log file storage media operates at a faster speed than the backup storage media,then result in backup fail.
Add a option   --redo_log_arch_dir=tmp_redo_dir:redo_dir  can solve this backup fail, 
If innodb_redo_log_archive_dirs =NULL ,then after backup innodb_redo_log_archive_dirs is always NULL not change user setting.
