### PR TITLE
PXB-3059 add a innodb_redo_log archive option to xtrabackup

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1030,7 +1030,8 @@ void Archived_Redo_Log_Monitor::thread_func() {
   if (res == nullptr) {
     xb::info() << "Redo Log Archiving is not used.";
     if (!innodb_redo_log_archive) {
-	xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);	    
+      xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",
+                     false, true);
     }
     mysql_close(mysql);
     my_thread_end();
@@ -1062,7 +1063,8 @@ void Archived_Redo_Log_Monitor::thread_func() {
     if (file < 0) {
       xb::error() << "cannot open " << SQUOTE(archive.filename.c_str());
       if (!innodb_redo_log_archive) {
-	 xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
+        xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",
+                       false, true);
       }
       mysql_close(mysql);
       my_thread_end();
@@ -1100,9 +1102,11 @@ void Archived_Redo_Log_Monitor::thread_func() {
         if (n_read == MY_FILE_ERROR) {
           xb::error() << "cannot read from " << archive.filename.c_str();
           if (!innodb_redo_log_archive) {
-	      xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
-	  }
-	  mysql_close(mysql);
+            xb_mysql_query(mysql,
+                           "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",
+                           false, true);
+          }
+          mysql_close(mysql);
           my_thread_end();
           return;
         }
@@ -1118,9 +1122,11 @@ void Archived_Redo_Log_Monitor::thread_func() {
         if (n_read == MY_FILE_ERROR) {
           xb::error() << "cannot read from " << archive.filename.c_str();
           if (!innodb_redo_log_archive) {
-             xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
+            xb_mysql_query(mysql,
+                           "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",
+                           false, true);
           }
-	  mysql_close(mysql);
+          mysql_close(mysql);
           my_thread_end();
           return;
         }

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1029,6 +1029,9 @@ void Archived_Redo_Log_Monitor::thread_func() {
 
   if (res == nullptr) {
     xb::info() << "Redo Log Archiving is not used.";
+    if (!innodb_redo_log_archive) {
+	xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);	    
+    }
     mysql_close(mysql);
     my_thread_end();
     return;
@@ -1058,6 +1061,9 @@ void Archived_Redo_Log_Monitor::thread_func() {
     file = my_open(archive.filename.c_str(), O_RDONLY, MYF(MY_WME));
     if (file < 0) {
       xb::error() << "cannot open " << SQUOTE(archive.filename.c_str());
+      if (!innodb_redo_log_archive) {
+	 xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
+      }
       mysql_close(mysql);
       my_thread_end();
       return;
@@ -1093,7 +1099,10 @@ void Archived_Redo_Log_Monitor::thread_func() {
         size_t n_read = my_read(file, buf2, hdr_len, MYF(MY_WME));
         if (n_read == MY_FILE_ERROR) {
           xb::error() << "cannot read from " << archive.filename.c_str();
-          mysql_close(mysql);
+          if (!innodb_redo_log_archive) {
+	      xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
+	  }
+	  mysql_close(mysql);
           my_thread_end();
           return;
         }
@@ -1108,7 +1117,10 @@ void Archived_Redo_Log_Monitor::thread_func() {
         size_t n_read = my_read(file, buf, hdr_len, MYF(MY_WME));
         if (n_read == MY_FILE_ERROR) {
           xb::error() << "cannot read from " << archive.filename.c_str();
-          mysql_close(mysql);
+          if (!innodb_redo_log_archive) {
+             xb_mysql_query(mysql, "SET GLOBAL innodb_redo_log_archive_dirs = NULL;",false, true);
+          }
+	  mysql_close(mysql);
           my_thread_end();
           return;
         }

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -271,6 +271,9 @@ class Archived_Redo_Log_Monitor {
   /** readiness flag. */
   std::atomic<bool> ready;
 
+  /** redo arch flag. */
+  std::atomic<bool> redo_arch;
+
   /** first log block no. */
   uint32_t first_log_block_no;
 

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -271,8 +271,8 @@ class Archived_Redo_Log_Monitor {
   /** readiness flag. */
   std::atomic<bool> ready;
 
-  /** redo arch flag. */
-  std::atomic<bool> redo_arch;
+  /** controls if xtrabackup has set redo log arch. */
+  std::atomic<bool> innodb_redo_log_archive;
 
   /** first log block no. */
   uint32_t first_log_block_no;

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -255,6 +255,9 @@ class Archived_Redo_Log_Monitor {
   /** Parse the value of innodb_redo_log_archive_dirs. */
   void parse_archive_dirs(const std::string &s);
 
+  /**In case of error return the configuration back to the original value  */
+  void archive_error_handle(auto mysql, bool archive_set);
+
   /** Start log archiving on server if supported, open archive file,
       wait for stop signal and remove the archive. */
   void thread_func();

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -231,6 +231,10 @@ bool io_watching_thread_running = false;
 bool xtrabackup_logfile_is_renamed = false;
 
 int xtrabackup_parallel;
+int xtrabackup_fifo_streams;
+bool xtrabackup_fifo_streams_set = false;
+uint xtrabackup_fifo_timeout = 60;
+char *xtrabackup_fifo_dir = NULL;
 bool opt_strict = true;
 
 char *xtrabackup_stream_str = NULL;
@@ -616,7 +620,10 @@ enum options_xtrabackup {
   OPT_XTRA_DATABASES_FILE,
   OPT_XTRA_CREATE_IB_LOGFILE,
   OPT_XTRA_PARALLEL,
+  OPT_XTRA_FIFO_STREAMS,
   OPT_XTRA_STREAM,
+  OPT_XTRA_FIFO_DIR,
+  OPT_XTRA_FIFO_TIMEOUT,
   OPT_XTRA_STRICT,
   OPT_XTRA_COMPRESS,
   OPT_XTRA_COMPRESS_THREADS,
@@ -844,7 +851,7 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_incremental_basedir,
      (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
      0, 0, 0, 0},
-    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+	{"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
      "redo log archive destination directory",
      (G_PTR *)&xtrabackup_redo_log_arch_dir,
      (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0,
@@ -896,11 +903,11 @@ struct my_option xb_client_options[] = {
      0},
 
     {"stream", OPT_XTRA_STREAM,
-     "Stream all backup files to the standard output "
-     "in the specified format. Currently supported formats are 'tar' and "
-     "'xbstream'.",
+     "Stream all backup files using xbstream format. Files are streamed to "
+     "STDOUT or FIFO files depending on --fifo-streams option. The only "
+     "supported stream format is 'xbstream'.",
      (G_PTR *)&xtrabackup_stream_str, (G_PTR *)&xtrabackup_stream_str, 0,
-     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
 
     {"compress", OPT_XTRA_COMPRESS,
      "Compress individual backup files using the specified compression "
@@ -1367,6 +1374,23 @@ struct my_option xb_client_options[] = {
      "The default value is 1.",
      (G_PTR *)&xtrabackup_parallel, (G_PTR *)&xtrabackup_parallel, 0, GET_INT,
      REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
+
+    {"fifo-streams", OPT_XTRA_FIFO_STREAMS,
+     "Number of FIFO files to use for parallel datafiles stream. Setting this "
+     "parameter to 1 disables FIFO and stream is sent to STDOUT.",
+     (G_PTR *)&xtrabackup_fifo_streams, (G_PTR *)&xtrabackup_fifo_streams, 0,
+     GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
+
+    {"fifo-dir", OPT_XTRA_FIFO_DIR,
+     "Directory to write Named Pipe. If ommited, we use --target-dir",
+     &xtrabackup_fifo_dir, &xtrabackup_fifo_dir, 0, GET_STR_ALLOC, REQUIRED_ARG,
+     0, 0, 0, 0, 0, 0},
+
+    {"fifo-timeout", OPT_XTRA_FIFO_TIMEOUT,
+     "How many seconds to wait for other end to open the fifo stream for "
+     "reading. Default 60 seconds",
+     (G_PTR *)&xtrabackup_fifo_timeout, (G_PTR *)&xtrabackup_fifo_timeout, 0,
+     GET_INT, REQUIRED_ARG, 60, 1, INT_MAX, 0, 0, 0},
 
     {"strict", OPT_XTRA_STRICT,
      "Fail with error when invalid arguments were passed to the xtrabackup.",
@@ -1844,13 +1868,16 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
       xtrabackup_target_dir = xtrabackup_real_target_dir;
       break;
     case OPT_XTRA_STREAM:
-      if (!strcasecmp(argument, "xbstream"))
+      if (argument == NULL || !strcasecmp(argument, "xbstream"))
         xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
       else {
         xb::error() << "Invalid --stream argument: " << argument;
         return 1;
       }
       xtrabackup_stream = true;
+      break;
+    case OPT_XTRA_FIFO_STREAMS:
+      xtrabackup_fifo_streams_set = true;
       break;
     case OPT_XTRA_COMPRESS:
       if (argument == NULL) {
@@ -3213,9 +3240,20 @@ files first, and then streams them in a serialized way when closed. */
 static void xtrabackup_init_datasinks(void) {
   /* Start building out the pipelines from the terminus back */
   if (xtrabackup_stream) {
-    /* All streaming goes to stdout */
-    ds_data = ds_meta = ds_redo =
-        ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
+    if (xtrabackup_fifo_streams > 1) {
+      /* Use Named PIPEs */
+      xb::info() << "Creating " << xtrabackup_fifo_streams
+                 << " Named Pipes(FIFO) at folder " << xtrabackup_target_dir
+                 << ". Waiting up to " << xtrabackup_fifo_timeout
+                 << " second(s) for xbstream/xbcloud to open the "
+                    "files for reading.\n";
+      ds_data = ds_meta = ds_redo =
+          ds_create(xtrabackup_target_dir, DS_TYPE_FIFO);
+    } else {
+      /* All streaming goes to stdout */
+      ds_data = ds_meta = ds_redo =
+          ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
+    }
   } else {
     /* Local filesystem */
     ds_data = ds_meta = ds_redo =
@@ -4104,6 +4142,25 @@ void xtrabackup_backup_func(void) {
     xb::error() << "cannot mkdir: " << my_errno() << " "
                 << xtrabackup_extra_lsndir;
     exit(EXIT_FAILURE);
+  }
+
+  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir != NULL) {
+    xtrabackup_target_dir = xtrabackup_fifo_dir;
+  }
+
+  if (xtrabackup_fifo_streams_set && !xtrabackup_stream) {
+    xb::info() << "Option --fifo-streams require xbstream format. Setting "
+                  "--stream to xbstream.";
+    xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
+    xtrabackup_stream = true;
+  }
+
+  if (xtrabackup_fifo_streams_set &&
+      xtrabackup_fifo_streams > xtrabackup_parallel) {
+    xb::info() << "Option --fifo-streams set higer than --parallel. "
+                  "Adjusting --parallel to "
+               << xtrabackup_fifo_streams;
+    xtrabackup_parallel = xtrabackup_fifo_streams;
   }
 
   /* create target dir if not exist */
@@ -7796,6 +7853,12 @@ int main(int argc, char **argv) {
       (strcmp(mysql_data_home, "./") == 0)) {
     if (!xtrabackup_print_param) usage();
     xb::error() << "Please set parameter 'datadir'";
+    exit(EXIT_FAILURE);
+  }
+
+  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir == NULL &&
+      strcmp(xtrabackup_target_dir, "./xtrabackup_backupfiles/") == 0) {
+    xb::error() << "Option --fifo-streams requires --fifo-dir to be set.";
     exit(EXIT_FAILURE);
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -185,6 +185,7 @@ pagetracking::xb_space_map *changed_page_tracking = nullptr;
 char *xtrabackup_incremental_basedir = NULL; /* for --backup */
 char *xtrabackup_extra_lsndir = NULL;    /* for --backup with --extra-lsndir */
 char *xtrabackup_incremental_dir = NULL; /* for --prepare */
+char *xtrabackup_redo_log_arch_dir = NULL;
 
 char xtrabackup_real_incremental_basedir[FN_REFLEN];
 char xtrabackup_real_extra_lsndir[FN_REFLEN];
@@ -637,6 +638,7 @@ enum options_xtrabackup {
   OPT_INNODB_FAST_SHUTDOWN,
   OPT_INNODB_FILE_PER_TABLE,
   OPT_INNODB_FLUSH_LOG_AT_TRX_COMMIT,
+  OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
   OPT_INNODB_FLUSH_METHOD,
   OPT_INNODB_LOG_ARCH_DIR,
   OPT_INNODB_LOG_ARCHIVE,
@@ -842,6 +844,11 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_incremental_basedir,
      (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
      0, 0, 0, 0},
+    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+     "redo log archive destination directory",
+     (G_PTR *)&xtrabackup_redo_log_arch_dir,
+     (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0,
+     0},
     {"incremental-dir", OPT_XTRA_INCREMENTAL_DIR,
      "(for --prepare): apply .delta files and logfile in the specified "
      "directory.",

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -854,8 +854,8 @@ struct my_option xb_client_options[] = {
     {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
      "redo log archive destination directory",
      (G_PTR *)&xtrabackup_redo_log_arch_dir,
-     (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0,
-     0},
+     (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
+     0, 0, 0},
     {"incremental-dir", OPT_XTRA_INCREMENTAL_DIR,
      "(for --prepare): apply .delta files and logfile in the specified "
      "directory.",

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -851,7 +851,7 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_incremental_basedir,
      (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
      0, 0, 0, 0},
-	{"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
      "redo log archive destination directory",
      (G_PTR *)&xtrabackup_redo_log_arch_dir,
      (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, OPT_ARG, 0, 0, 0, 0, 0,

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -231,10 +231,6 @@ bool io_watching_thread_running = false;
 bool xtrabackup_logfile_is_renamed = false;
 
 int xtrabackup_parallel;
-int xtrabackup_fifo_streams;
-bool xtrabackup_fifo_streams_set = false;
-uint xtrabackup_fifo_timeout = 60;
-char *xtrabackup_fifo_dir = NULL;
 bool opt_strict = true;
 
 char *xtrabackup_stream_str = NULL;
@@ -620,10 +616,7 @@ enum options_xtrabackup {
   OPT_XTRA_DATABASES_FILE,
   OPT_XTRA_CREATE_IB_LOGFILE,
   OPT_XTRA_PARALLEL,
-  OPT_XTRA_FIFO_STREAMS,
   OPT_XTRA_STREAM,
-  OPT_XTRA_FIFO_DIR,
-  OPT_XTRA_FIFO_TIMEOUT,
   OPT_XTRA_STRICT,
   OPT_XTRA_COMPRESS,
   OPT_XTRA_COMPRESS_THREADS,
@@ -903,11 +896,11 @@ struct my_option xb_client_options[] = {
      0},
 
     {"stream", OPT_XTRA_STREAM,
-     "Stream all backup files using xbstream format. Files are streamed to "
-     "STDOUT or FIFO files depending on --fifo-streams option. The only "
-     "supported stream format is 'xbstream'.",
+     "Stream all backup files to the standard output "
+     "in the specified format. Currently supported formats are 'tar' and "
+     "'xbstream'.",
      (G_PTR *)&xtrabackup_stream_str, (G_PTR *)&xtrabackup_stream_str, 0,
-     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 
     {"compress", OPT_XTRA_COMPRESS,
      "Compress individual backup files using the specified compression "
@@ -1374,23 +1367,6 @@ struct my_option xb_client_options[] = {
      "The default value is 1.",
      (G_PTR *)&xtrabackup_parallel, (G_PTR *)&xtrabackup_parallel, 0, GET_INT,
      REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
-
-    {"fifo-streams", OPT_XTRA_FIFO_STREAMS,
-     "Number of FIFO files to use for parallel datafiles stream. Setting this "
-     "parameter to 1 disables FIFO and stream is sent to STDOUT.",
-     (G_PTR *)&xtrabackup_fifo_streams, (G_PTR *)&xtrabackup_fifo_streams, 0,
-     GET_INT, REQUIRED_ARG, 1, 1, INT_MAX, 0, 0, 0},
-
-    {"fifo-dir", OPT_XTRA_FIFO_DIR,
-     "Directory to write Named Pipe. If ommited, we use --target-dir",
-     &xtrabackup_fifo_dir, &xtrabackup_fifo_dir, 0, GET_STR_ALLOC, REQUIRED_ARG,
-     0, 0, 0, 0, 0, 0},
-
-    {"fifo-timeout", OPT_XTRA_FIFO_TIMEOUT,
-     "How many seconds to wait for other end to open the fifo stream for "
-     "reading. Default 60 seconds",
-     (G_PTR *)&xtrabackup_fifo_timeout, (G_PTR *)&xtrabackup_fifo_timeout, 0,
-     GET_INT, REQUIRED_ARG, 60, 1, INT_MAX, 0, 0, 0},
 
     {"strict", OPT_XTRA_STRICT,
      "Fail with error when invalid arguments were passed to the xtrabackup.",
@@ -1868,16 +1844,13 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
       xtrabackup_target_dir = xtrabackup_real_target_dir;
       break;
     case OPT_XTRA_STREAM:
-      if (argument == NULL || !strcasecmp(argument, "xbstream"))
+      if (!strcasecmp(argument, "xbstream"))
         xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
       else {
         xb::error() << "Invalid --stream argument: " << argument;
         return 1;
       }
       xtrabackup_stream = true;
-      break;
-    case OPT_XTRA_FIFO_STREAMS:
-      xtrabackup_fifo_streams_set = true;
       break;
     case OPT_XTRA_COMPRESS:
       if (argument == NULL) {
@@ -3240,20 +3213,9 @@ files first, and then streams them in a serialized way when closed. */
 static void xtrabackup_init_datasinks(void) {
   /* Start building out the pipelines from the terminus back */
   if (xtrabackup_stream) {
-    if (xtrabackup_fifo_streams > 1) {
-      /* Use Named PIPEs */
-      xb::info() << "Creating " << xtrabackup_fifo_streams
-                 << " Named Pipes(FIFO) at folder " << xtrabackup_target_dir
-                 << ". Waiting up to " << xtrabackup_fifo_timeout
-                 << " second(s) for xbstream/xbcloud to open the "
-                    "files for reading.\n";
-      ds_data = ds_meta = ds_redo =
-          ds_create(xtrabackup_target_dir, DS_TYPE_FIFO);
-    } else {
-      /* All streaming goes to stdout */
-      ds_data = ds_meta = ds_redo =
-          ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
-    }
+    /* All streaming goes to stdout */
+    ds_data = ds_meta = ds_redo =
+        ds_create(xtrabackup_target_dir, DS_TYPE_STDOUT);
   } else {
     /* Local filesystem */
     ds_data = ds_meta = ds_redo =
@@ -4142,25 +4104,6 @@ void xtrabackup_backup_func(void) {
     xb::error() << "cannot mkdir: " << my_errno() << " "
                 << xtrabackup_extra_lsndir;
     exit(EXIT_FAILURE);
-  }
-
-  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir != NULL) {
-    xtrabackup_target_dir = xtrabackup_fifo_dir;
-  }
-
-  if (xtrabackup_fifo_streams_set && !xtrabackup_stream) {
-    xb::info() << "Option --fifo-streams require xbstream format. Setting "
-                  "--stream to xbstream.";
-    xtrabackup_stream_fmt = XB_STREAM_FMT_XBSTREAM;
-    xtrabackup_stream = true;
-  }
-
-  if (xtrabackup_fifo_streams_set &&
-      xtrabackup_fifo_streams > xtrabackup_parallel) {
-    xb::info() << "Option --fifo-streams set higer than --parallel. "
-                  "Adjusting --parallel to "
-               << xtrabackup_fifo_streams;
-    xtrabackup_parallel = xtrabackup_fifo_streams;
   }
 
   /* create target dir if not exist */
@@ -7853,12 +7796,6 @@ int main(int argc, char **argv) {
       (strcmp(mysql_data_home, "./") == 0)) {
     if (!xtrabackup_print_param) usage();
     xb::error() << "Please set parameter 'datadir'";
-    exit(EXIT_FAILURE);
-  }
-
-  if (xtrabackup_fifo_streams_set && xtrabackup_fifo_dir == NULL &&
-      strcmp(xtrabackup_target_dir, "./xtrabackup_backupfiles/") == 0) {
-    xb::error() << "Option --fifo-streams requires --fifo-dir to be set.";
     exit(EXIT_FAILURE);
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -72,6 +72,7 @@ extern char *xtrabackup_target_dir;
 extern char xtrabackup_real_target_dir[FN_REFLEN];
 extern char *xtrabackup_incremental_dir;
 extern char *xtrabackup_incremental_basedir;
+extern char *xtrabackup_redo_log_arch_dir;
 extern char *innobase_data_home_dir;
 extern char *innobase_buffer_pool_filename;
 extern ds_ctxt_t *ds_meta;


### PR DESCRIPTION

Backup utilities that copy redo log records may sometimes fail to keep pace with redo log generation while a backup operation is in progress, resulting in lost redo log records due to those records being overwritten.
If the MySQL server innodb_redo_log_archive_dirs =NULL and the redo log file storage media operates at a faster speed than the backup storage media,then result in backup fail.
Add a option --redo_log_arch_dir=tmp_redo_dir:redo_dir can solve this backup fail,
If innodb_redo_log_archive_dirs =NULL ,then after backup innodb_redo_log_archive_dirs is always NULL not change user setting.