### PR TITLE
PXB-2514-8.0 - Postfix Fifo Stream

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_fifo.h
+++ b/storage/innobase/xtrabackup/src/ds_fifo.h
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 *******************************************************/
 
+// clang-format off
 /* FIFO Datasink implementation
 
 at xtrabackup_init_datasinks we initialize ds_data as DS_TYPE_FIFO, and create a ds object as XB_STREAM_FMT_XBSTREAM (xbstream).
@@ -58,10 +59,14 @@ Now:
  * copy_thread->parallel_stream_ctxt->stream_context->fifo
 
 */
+// clang-format on
 #ifndef DS_FIFO_H
 #define DS_FIFO_H
 
 #include "datasink.h"
+
+/* Character sent to indicate both sides are ready */
+#define DS_FIFO_CONTROL_CHAR "S"
 
 extern uint ds_fifo_threads;
 

--- a/storage/innobase/xtrabackup/src/xbstream.h
+++ b/storage/innobase/xtrabackup/src/xbstream.h
@@ -24,7 +24,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_base.h>
 #include <my_dir.h>
 #include <my_io.h>
+#include <mutex>
 #include <string>
+
 #include "datasink.h"
 
 /* Magic value in a chunk header */
@@ -39,6 +41,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
   ((sizeof(XB_STREAM_CHUNK_MAGIC) - 1) + 1 + 1 + 4)
 #define CHUNK_TYPE_OFFSET (sizeof(XB_STREAM_CHUNK_MAGIC) - 1 + 1)
 #define PATH_LENGTH_OFFSET (sizeof(XB_STREAM_CHUNK_MAGIC) - 1 + 1 + 1)
+
+struct xb_rstream_struct {
+  my_off_t offset;
+  File fd;
+  std::mutex *mutex;
+};
 
 typedef struct xb_wstream_struct xb_wstream_t;
 

--- a/storage/innobase/xtrabackup/src/xbstream_write.cc
+++ b/storage/innobase/xtrabackup/src/xbstream_write.cc
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define XB_STREAM_MIN_CHUNK_SIZE (10 * 1024 * 1024)
 
 struct xb_wstream_struct {
-  std::mutex mutex;
+  std::mutex *mutex;
 };
 
 struct xb_wstream_file_struct {
@@ -71,9 +71,11 @@ static ssize_t xb_stream_default_write_callback(xb_wstream_file_t *file
 
 xb_wstream_t *xb_stream_write_new(void) {
   xb_wstream_t *stream;
+  std::mutex *mutex = new std::mutex();
 
   stream = (xb_wstream_t *)my_malloc(PSI_NOT_INSTRUMENTED, sizeof(xb_wstream_t),
                                      MYF(MY_FAE | MY_ZEROFILL));
+  stream->mutex = mutex;
   return stream;
 }
 
@@ -152,6 +154,7 @@ int xb_stream_write_close(xb_wstream_file_t *file) {
 }
 
 int xb_stream_write_done(xb_wstream_t *stream) {
+  delete stream->mutex;
   my_free(stream);
 
   return 0;
@@ -233,7 +236,7 @@ static int xb_stream_write_chunk(xb_wstream_file_t *file, const void *buf,
                     4 * 2 * sparse_map_size);
   checksum = crc32_iso3309(checksum, static_cast<const uchar *>(buf), len);
 
-  stream->mutex.lock();
+  stream->mutex->lock();
 
   int8store(ptr, file->offset); /* Payload offset */
   ptr += 8;
@@ -256,13 +259,13 @@ static int xb_stream_write_chunk(xb_wstream_file_t *file, const void *buf,
     file->offset += sparse_map[i].skip;
   file->offset += len;
 
-  stream->mutex.unlock();
+  stream->mutex->unlock();
 
   return 0;
 
 err:
 
-  stream->mutex.unlock();
+  stream->mutex->unlock();
 
   return 1;
 }
@@ -273,7 +276,7 @@ static int xb_stream_write_eof(xb_wstream_file_t *file) {
   uchar *ptr;
   xb_wstream_t *stream = file->stream;
 
-  stream->mutex.lock();
+  stream->mutex->lock();
 
   /* Write xbstream header */
   ptr = tmpbuf;
@@ -298,12 +301,12 @@ static int xb_stream_write_eof(xb_wstream_file_t *file) {
       -1)
     goto err;
 
-  stream->mutex.unlock();
+  stream->mutex->unlock();
 
   return 0;
 err:
 
-  stream->mutex.unlock();
+  stream->mutex->unlock();
 
   return 1;
 }

--- a/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
+++ b/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
@@ -33,7 +33,7 @@ vlog "Test 2 - Taking inc1 backup"
 take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${topdir}/full" "-x -C ${topdir}/inc1 --fifo-streams=3"
 wait ${insert_pid}
 vlog "Test 2 - Taking inc2 backup"
-take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${topdir}/inc1" "-x -C ${topdir}/inc2 --fifo-streams=3"
+take_backup_fifo_xbstream ${topdir}/stream "--parallel=2 --fifo-streams=3 --incremental-basedir=${topdir}/inc1" "-x -C ${topdir}/inc2 --fifo-streams=3 --parallel=6"
 record_db_state test
 
 stop_server


### PR DESCRIPTION
- Adjusted xtrabackup cleanup
 - Added MacOS support for kqueue (epoll equivalent).
 - Fixed missing mutex initialization.
 - Added Backup --parallel on xbstream. Which triggered below problem:

1 Write side Open operation happens on a single thread (xtrabackup)
2 for each fifo-streams; do
 2.1 open it on non blocking mode
 2.2 if the other side is open for read - set it back to blocking mode
 2.3 loop again to open next fifo stream
3 Read side open operation happens on a single thread (xbstream/xbcloud)
4 similar to write, for each fifo-streams; do
  4.1 open it on non blocking mode - this always succeed
  4.2 then we add the FD to epoll and wait for EPOLLIN. Once that event
is triggered we set it back to blocking mode.
  4.3 loop again to open next fifo stream

The problem is EPOLLIN event is only set when there is data to be read
in the FD. Essentially, this will happen when Write side opens all fifo
files and progress to writing data (redo follow thread and copy threads)
However, this will never happen because now read side is on a single
thread (while before we opened all fifo files) in parallel, now we open
one after the other, meaning the first fifo file will be blocked on 4.2
waiting for data to be available on the fifo file, and write will be
waiting on 2.2 for the second fifo file, because the read side has not
open the second file for read and is waiting data to be available on the
pipe to trigger EPOLLIN event.

Fix:
Added a controll character that the write side will send on the fifo
file triggering EPOLLIN event on the read side. This will allow the read
to open the next fifo file and so on. On the read side, we will read
this 1 byte character to reset the fifo (consume the available) data
and ensure we have a clear buffer for real data.