### PR TITLE
Fixed PXB-2811 - Fix compilation warnings 

### DIFF
--- a/cmake/procps.cmake
+++ b/cmake/procps.cmake
@@ -1,0 +1,32 @@
+# Copyright (c) 2023 Percona LLC and/or its affiliates
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA 
+
+MACRO (FIND_PROCPS)
+  FIND_FILE(PROCPS_INCLUDE_DIR NAMES proc/procps.h NO_CACHE)
+  IF (PROCPS_INCLUDE_DIR)
+    MESSAGE("-- Found proc/sysinfo.h in ${PROCPS_INCLUDE_DIR} Procps version 3.")
+    ADD_DEFINITIONS(-DHAVE_PROCPS_V3)
+    SET(PROCPS_VERSION "3")
+  ELSE()
+  FIND_FILE(PROCPS_INCLUDE_DIR NAMES libproc2/meminfo.h NO_CACHE)
+    IF (PROCPS_INCLUDE_DIR)
+      MESSAGE("-- Found libproc2/meminfo.h in ${PROCPS_INCLUDE_DIR}. Procps version 4.")
+      ADD_DEFINITIONS(-DHAVE_PROCPS_V4)
+      SET(PROCPS_VERSION "4")
+    ELSE()
+      MESSAGE(SEND_ERROR "Cannot find proc/sysinfo.h or libproc2/meminfo.h in ${PROCPS_INCLUDE_PATH}. You can pass it to CMake with -DPROCPS_INCLUDE_PATH=<path> or install procps-devel/procps-ng-devel/libproc2-dev package")
+    ENDIF()
+  ENDIF()
+ENDMACRO()

--- a/sql/dd/impl/sdi.cc
+++ b/sql/dd/impl/sdi.cc
@@ -375,24 +375,27 @@ Sdi_type serialize(const Tablespace &tablespace) {
    compatibility check: MYSQL_VERSION less than or equal, dd_version
    equal, and sdi_version equal.
 */
-bool CheckDefaultCompatibility(const RJ_Document &doc) {
+bool CheckDefaultCompatibility(const RJ_Document &doc __attribute__((unused))) {
   assert(doc.HasMember("mysqld_version_id"));
-
+#if defined(XTRABACKUP)
+  assert(doc["mysqld_version_id"].IsUint64());
+  assert(doc.HasMember("dd_version"));
+  assert(doc["dd_version"].IsUint());
+  assert(doc.HasMember("sdi_version"));
+  assert(doc["sdi_version"].IsUint64());
+#else
   const RJ_Value &mysqld_version_id = doc["mysqld_version_id"];
   assert(mysqld_version_id.IsUint64());
-#if !defined(XTRABACKUP)
   if (mysqld_version_id.GetUint64() > std::uint64_t(MYSQL_VERSION_ID)) {
     // Cannot deserialize SDIs from newer versions.
     my_error(ER_IMP_INCOMPATIBLE_MYSQLD_VERSION, MYF(0),
              mysqld_version_id.GetUint64(), std::uint64_t(MYSQL_VERSION_ID));
     return true;
   }
-#endif /* !XTRABACKUP */
 
   assert(doc.HasMember("dd_version"));
   const RJ_Value &dd_version_val = doc["dd_version"];
   assert(dd_version_val.IsUint());
-#if !defined(XTRABACKUP)
   uint dd_version = dd_version_val.GetUint();
   if (dd_version != Dictionary_impl::get_target_dd_version()) {
     // Incompatible change
@@ -400,12 +403,10 @@ bool CheckDefaultCompatibility(const RJ_Document &doc) {
              Dictionary_impl::get_target_dd_version());
     return true;
   }
-#endif /* !XTRABACKUP */
 
   assert(doc.HasMember("sdi_version"));
   const RJ_Value &sdi_version_val = doc["sdi_version"];
   assert(sdi_version_val.IsUint64());
-#if !defined(XTRABACKUP)
   std::uint64_t sdi_version_ = sdi_version_val.GetUint64();
   if (sdi_version_ != SDI_VERSION) {
     // Incompatible change

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -14,12 +14,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 INCLUDE(gcrypt)
+INCLUDE(procps)
 
 OPTION(WITH_VERSION_CHECK "Build with version check" ON)
 
 INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/compile_flags.cmake)
 
 FIND_GCRYPT()
+FIND_PROCPS()
 
 CHECK_TYPE_SIZE("unsigned long" SIZEOF_UNSIGNED_LONG)
 
@@ -134,9 +136,11 @@ TARGET_LINK_LIBRARIES(xtrabackup
   )
 
 IF(NOT APPLE)
-  TARGET_LINK_LIBRARIES(xtrabackup
-    procps
-    )
+  IF(PROCPS_VERSION EQUAL 4)
+    TARGET_LINK_LIBRARIES(xtrabackup proc2)
+  ELSE()
+    TARGET_LINK_LIBRARIES(xtrabackup procps)
+  ENDIF()
 ENDIF()
 
  # We depend on protobuf because of the mysqlx plugin and replication.

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -70,12 +70,12 @@ INCLUDE_DIRECTORIES(
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/plugin/keyring "${CMAKE_CURRENT_BINARY_DIR}/keyring")
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/plugin/keyring_vault "${CMAKE_CURRENT_BINARY_DIR}/keyring_vault")
 
-ADD_COMPILE_FLAGS(
+MY_ADD_COMPILE_DEFINITIONS(
   xtrabackup.cc
   backup_mysql.cc
   file_utils.cc
   xb_dict.cc
-  COMPILE_FLAGS -DMYSQL_CLIENT)
+  COMPILE_DEFINITIONS MYSQL_CLIENT)
 
 MYSQL_ADD_EXECUTABLE(xtrabackup
   xtrabackup.cc

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -641,8 +641,11 @@ static bool move_file(ds_ctxt_t *datasink, const char *src_file_path,
   char dst_dir_abs[FN_REFLEN];
   size_t dirname_length;
 
-  snprintf(dst_file_path_abs, sizeof(dst_file_path_abs), "%s/%s", dst_dir,
-           dst_file_path);
+  if (snprintf(dst_file_path_abs, sizeof(dst_file_path_abs) - 1, "%s/%s",
+               dst_dir, dst_file_path) > (int)(sizeof(dst_file_path_abs) - 1)) {
+    xb::error() << "Cannot format dst_file_path_abs";
+    return (false);
+  }
 
   dirname_part(dst_dir_abs, dst_file_path_abs, &dirname_length);
 

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -130,14 +130,14 @@ xb_fil_cur_result_t xb_fil_cur_open(
   cursor->is_system = fsp_is_system_or_temp_tablespace(node->space->id);
   cursor->is_ibd = fsp_is_ibd_tablespace(node->space->id);
 
-  strncpy(cursor->abs_path, node->name, sizeof(cursor->abs_path));
+  strncpy(cursor->abs_path, node->name, sizeof(cursor->abs_path) - 1);
 
   /* Get the relative path for the destination tablespace name, i.e. the
   one that can be appended to the backup root directory. Non-system
   tablespaces may have absolute paths for remote tablespaces in MySQL
   5.6+. We want to make "local" copies for the backup. */
   strncpy(cursor->rel_path, xb_get_relative_path(node->space, cursor->abs_path),
-          sizeof(cursor->rel_path));
+          sizeof(cursor->rel_path) - 1);
 
   /* In the backup mode we should already have a tablespace handle created
   by fil_load_single_table_tablespace() unless it is a system

--- a/storage/innobase/xtrabackup/src/file_utils.cc
+++ b/storage/innobase/xtrabackup/src/file_utils.cc
@@ -214,14 +214,14 @@ bool datafile_open(const char *file, datafile_cur_t *cursor, bool read_only,
                    uint buffer_size) {
   memset(cursor, 0, sizeof(datafile_cur_t));
 
-  strncpy(cursor->abs_path, file, sizeof(cursor->abs_path));
+  strncpy(cursor->abs_path, file, sizeof(cursor->abs_path) - 1);
 
   /* Get the relative path for the destination tablespace name, i.e. the
   one that can be appended to the backup root directory. Non-system
   tablespaces may have absolute paths for remote tablespaces in MySQL
   5.6+. We want to make "local" copies for the backup. */
   strncpy(cursor->rel_path, get_relative_path(cursor->abs_path),
-          sizeof(cursor->rel_path));
+          sizeof(cursor->rel_path) - 1);
 
   cursor->fd =
       my_open(cursor->abs_path, (read_only) ? O_RDONLY : O_RDWR, MYF(MY_WME));

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2905,7 +2905,7 @@ bool check_if_skip_table(
     return (false);
   }
 
-  strncpy(buf, dbname, FN_REFLEN);
+  strncpy(buf, dbname, FN_REFLEN - 1);
   buf[tbname - 1 - dbname] = 0;
 
   const skip_database_check_result skip_database = check_if_skip_database(buf);
@@ -3039,7 +3039,7 @@ static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
     goto error;
   }
 
-  strncpy(dst_name, cursor.rel_path, sizeof(dst_name));
+  strcpy(dst_name, cursor.rel_path);
 
   /* Setup the page write filter */
   if (xtrabackup_incremental) {
@@ -5354,8 +5354,11 @@ static pfs_os_file_t xb_delta_open_matching_space(
     snprintf(dest_space_name, sizeof(dest_space_name), "%s", name);
   }
 
-  snprintf(real_name, real_name_len, "%s/%s", xtrabackup_target_dir,
-           dest_space_name);
+  if (snprintf(real_name, real_name_len - 1, "%s/%s", xtrabackup_target_dir,
+               dest_space_name) > (int)(real_name_len - 1)) {
+    xb::error() << "Cannot format real_name.";
+    return file;
+  }
   Fil_path::normalize(real_name);
   /* Truncate ".ibd" */
   dest_space_name[strlen(dest_space_name) - 4] = '\0';
@@ -5489,11 +5492,11 @@ static pfs_os_file_t xb_delta_open_matching_space(
   fil_space = fil_space_get(space_id);
 
   if (fil_space != NULL) {
-    char tmpname[FN_REFLEN];
+    char tmpname[FN_REFLEN * 2 + 2];
     bool exists;
     os_file_type_t type;
 
-    strncpy(tmpname, dest_space_name, FN_REFLEN);
+    strncpy(tmpname, dest_space_name, sizeof(tmpname) - 1);
 
     char *oldpath, *space_name;
 
@@ -5607,7 +5610,7 @@ static bool xtrabackup_apply_delta(
   }
   dst_path[strlen(dst_path) - 6] = '\0';
 
-  strncpy(space_name, entry.file_name.c_str(), FN_REFLEN);
+  strncpy(space_name, entry.file_name.c_str(), FN_REFLEN - 1);
   space_name[strlen(space_name) - 6] = 0;
 
   if (!get_meta_path(src_path, meta_path)) {
@@ -7780,7 +7783,7 @@ void setup_error_messages() {
 
 void xb_set_plugin_dir() {
   if (opt_xtra_plugin_dir != NULL) {
-    strncpy(opt_plugin_dir, opt_xtra_plugin_dir, FN_REFLEN);
+    strncpy(opt_plugin_dir, opt_xtra_plugin_dir, FN_REFLEN - 1);
   } else {
     strcpy(opt_plugin_dir, PLUGINDIR);
   }


### PR DESCRIPTION
-- CMakeLists Warning
CMake Warning at cmake/compile_flags.cmake:36 (MESSAGE):
  -DMYSQL_CLIENT should be in COMPILE_DEFINITIONS not COMPILE_FLAGS
Call Stack (most recent call first):
  storage/innobase/xtrabackup/src/CMakeLists.txt:73 (ADD_COMPILE_FLAGS)

Modified ADD_COMPILER_FLAGS to use ADD_COMPILE_DEFINITIONS (https://github.com/percona/percona-xtrabackup/commit/6198ce663e0aec822523f2bc2e46bfe5291888b3 / https://github.com/percona/percona-xtrabackup/commit/898f86afc0d67baf2370249215683ed599d74cbb)

-- libkmip Warning

Adjusted submodule pointer to pick up d87d916

-- Truncate string by strncopy / snprintf
Adjuster functions to safely consider the null terminator / avoid
buffer overflows.

-- sdi.cc

warning: unused variable 'mysqld_version_id' [-Wunused-variable]

left only the assert to be compiled when xtrabackup is defined

Fixed Issue with procps version 4.
Now we detect the version during cmake and use the correct library
when linking xbtrabackup

This also fixes PXB-3066 - Compilation issues on Debian 12


