### PR TITLE
Implemented PXB-3073 - Implement --timeout on xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -515,6 +515,10 @@ void Http_client::setup_request(
   if (!cacert.empty()) {
     curl_easy_setopt(curl, CURLOPT_CAINFO, cacert.c_str());
   }
+
+  if (timeout > 0) {
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+  }
 }
 
 int Http_client::upload_callback(char *ptr, size_t size, size_t nmemb,

--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -353,6 +353,7 @@ class Http_client {
       CURLcode::CURLE_SEND_FAIL_REWIND,  CURLcode::CURLE_PARTIAL_FILE,
       CURLcode::CURLE_SSL_CONNECT_ERROR, CURLcode::CURLE_OBSOLETE16};
   std::vector<long> http_retriable_errors{503, 500, 504, 408};
+  ulong timeout = 0;
   mutable curl_easy_unique_ptr curl{nullptr, curl_easy_cleanup};
 
   static void async_result_callback(async_callback_t user_callback,
@@ -385,6 +386,7 @@ class Http_client {
                 ulong count) const;
   void set_verbose(bool val) { verbose = val; }
   void set_insecure(bool val) { insecure = val; }
+  void set_timeout(ulong val) { timeout = val; }
   void set_cacaert(const std::string &val) { cacert = val; }
   void set_curl_retriable_errors(CURLcode code) {
     if (code < CURLcode::CURL_LAST) {

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -128,6 +128,7 @@ static ulong opt_parallel = 1;
 static ulong opt_threads = 1;
 static char *opt_fifo_dir = nullptr;
 static ulong opt_fifo_timeout = 60;
+static ulong opt_timeout = 120;
 static ulong opt_max_retries = 10;
 static u_int32_t opt_max_backoff = 300000;
 
@@ -202,6 +203,7 @@ enum {
   OPT_THREADS,
   OPT_FIFO_DIR,
   OPT_FIFO_TIMEOUT,
+  OPT_TIMEOUT,
   OPT_MAX_RETRIES,
   OPT_MAX_BACKOFF,
   OPT_CACERT,
@@ -321,6 +323,12 @@ static struct my_option my_long_options[] = {
      "Default 60 seconds",
      &opt_fifo_timeout, &opt_fifo_timeout, 0, GET_INT, REQUIRED_ARG, 60, 1,
      INT_MAX, 0, 0, 0},
+
+    {"timeout", OPT_TIMEOUT,
+     "How many seconds to wait for activity on TCP connection. Setting this to "
+     "0 means no timeout. Default 120 seconds",
+     &opt_timeout, &opt_timeout, 0, GET_INT, REQUIRED_ARG, 120, 0, INT_MAX, 0,
+     0, 0},
 
     {"max-retries", OPT_MAX_RETRIES,
      "Number of retries of chunk uploads/downloads after a failure (Default "
@@ -1292,6 +1300,9 @@ int main(int argc, char **argv) {
   }
   if (opt_cacert != nullptr) {
     http_client.set_cacaert(opt_cacert);
+  }
+  if (opt_timeout > 0) {
+    http_client.set_timeout(opt_timeout);
   }
 
   std::string container_name;


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3073

Problem:
Currently there is no timeout for xbcloud. If there are any issues on the connection, xbcloud will hang forever.

Fix:
Implement --timeout option for xbcloud. If there is no activity during this period of seconds, xbcloud will exit with error.