### PR TITLE
Implemented PXB-3059 - Add an option to set innodb_redo_log archive.

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -255,6 +255,9 @@ class Archived_Redo_Log_Monitor {
   /** Parse the value of innodb_redo_log_archive_dirs. */
   void parse_archive_dirs(const std::string &s);
 
+  /** In case of error return the configuration back to the original value  */
+  void archive_error_handle(MYSQL *mysql);
+
   /** Start log archiving on server if supported, open archive file,
       wait for stop signal and remove the archive. */
   void thread_func();
@@ -270,6 +273,10 @@ class Archived_Redo_Log_Monitor {
 
   /** readiness flag. */
   std::atomic<bool> ready;
+
+  /** controls if xtrabackup has set redo log arch. Can only happen if it was
+      set to null */
+  std::atomic<bool> xb_has_set_redo_log_arch;
 
   /** first log block no. */
   uint32_t first_log_block_no;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -185,6 +185,7 @@ pagetracking::xb_space_map *changed_page_tracking = nullptr;
 char *xtrabackup_incremental_basedir = NULL; /* for --backup */
 char *xtrabackup_extra_lsndir = NULL;    /* for --backup with --extra-lsndir */
 char *xtrabackup_incremental_dir = NULL; /* for --prepare */
+char *xtrabackup_redo_log_arch_dir = NULL;
 
 char xtrabackup_real_incremental_basedir[FN_REFLEN];
 char xtrabackup_real_extra_lsndir[FN_REFLEN];
@@ -644,6 +645,7 @@ enum options_xtrabackup {
   OPT_INNODB_FAST_SHUTDOWN,
   OPT_INNODB_FILE_PER_TABLE,
   OPT_INNODB_FLUSH_LOG_AT_TRX_COMMIT,
+  OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
   OPT_INNODB_FLUSH_METHOD,
   OPT_INNODB_LOG_ARCH_DIR,
   OPT_INNODB_LOG_ARCHIVE,
@@ -849,6 +851,12 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_incremental_basedir,
      (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
      0, 0, 0, 0},
+    {"redo_log_arch_dir", OPT_INNODB_REDO_LOG_ARCHIVE_DIRS,
+     "Set redo log archive destination directory if not already set in the "
+     "server",
+     (G_PTR *)&xtrabackup_redo_log_arch_dir,
+     (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
+     0, 0, 0},
     {"incremental-dir", OPT_XTRA_INCREMENTAL_DIR,
      "(for --prepare): apply .delta files and logfile in the specified "
      "directory.",

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -72,6 +72,7 @@ extern char *xtrabackup_target_dir;
 extern char xtrabackup_real_target_dir[FN_REFLEN];
 extern char *xtrabackup_incremental_dir;
 extern char *xtrabackup_incremental_basedir;
+extern char *xtrabackup_redo_log_arch_dir;
 extern char *innobase_data_home_dir;
 extern char *innobase_buffer_pool_filename;
 extern ds_ctxt_t *ds_meta;

--- a/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
+++ b/storage/innobase/xtrabackup/test/inc/xb_log_archiving.sh
@@ -2,7 +2,7 @@
 # common test for log archiving
 #
 
-mysql -e "set global innodb_redo_log_archive_dirs='b:$TEST_VAR_ROOT/dir_b;a:$TEST_VAR_ROOT/dir_a'"
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs='b:$TEST_VAR_ROOT/dir_b;a:$TEST_VAR_ROOT/dir_a'"
 
 load_sakila
 
@@ -41,7 +41,7 @@ mysql -e "CHECKSUM TABLE t" test
 
 # PXB-1928: PXB does not use the redo log archiving feature if label is not specified
 
-mysql -e "set global innodb_redo_log_archive_dirs=':$TEST_VAR_ROOT/dir_b'"
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs=':$TEST_VAR_ROOT/dir_b'"
 
 xtrabackup --backup --target-dir=$topdir/bakup_pxb_1928 2> >( tee $topdir/pxb-1928 )
 
@@ -56,3 +56,54 @@ ls $TEST_VAR_ROOT/dir_b
 
 [ "$( ls -A $TEST_VAR_ROOT/dir_a )" ] && die "directory $TEST_VAR_ROOT/dir_a is not empty" || true
 [ "$( ls -A $TEST_VAR_ROOT/dir_b )" ] && die "directory $TEST_VAR_ROOT/dir_b is not empty" || true
+
+# PXB-3059 add a innodb_redo_log archive option to xtrabackup
+
+#PXB-3059-1 mysql and xtrabackup all set and not null
+ARCH_DIR="temp:$TEST_VAR_ROOT/dir_set_1"
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs='${ARCH_DIR}'"
+xtrabackup  --backup  --target-dir=$topdir/backup1  --redo_log_arch_dir=temp:$topdir/dir_1 2> >( tee $topdir/pxb-3059-1 )
+redo_dir_1=$(mysql  -e "SHOW VARIABLES LIKE '%innodb_redo_log_archive_dirs%'"  2> /dev/null  | grep innodb_redo_log_archive_dirs| awk -F ' '  '{print $2}')
+if [ "$redo_dir_1" != "${ARCH_DIR}" ]
+then
+    die "innodb_redo_log_archive_dirs has been changed on test 1"
+fi
+if ! grep -q "xtrabackup redo_log_arch_dir is set to ${ARCH_DIR}" $topdir/pxb-3059-1 ; then
+    die "xtrabackup redo_log_arch_dir not set to ${ARCH_DIR} on test 1"
+fi
+
+#PXB-3059-2 mysql not set  ,  xtrabackup  set
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs=NULL"
+ARCH_DIR="temp:$topdir/dir_2"
+xtrabackup  --backup  --target-dir=$topdir/backup2   --redo_log_arch_dir=${ARCH_DIR} 2> >( tee $topdir/pxb-3059-2 )
+redo_dir_after_backup=$(mysql  -e "SHOW VARIABLES LIKE '%innodb_redo_log_archive_dirs%'"  2> /dev/null  | grep innodb_redo_log_archive_dirs| awk -F ' '  '{print $2}')
+[ ${redo_dir_after_backup}  ] && die  "innodb_redo_log_archive_dirs has not been reset on test 2"
+if ! grep -q "xtrabackup redo_log_arch_dir is set to ${ARCH_DIR}" $topdir/pxb-3059-2 ; then
+    die "xtrabackup redo_log_arch_dir not set to ${ARCH_DIR} on test 2"
+fi
+
+#PXB-3059-3 mysql set  ,  xtrabackup  not set
+ARCH_DIR="temp:$TEST_VAR_ROOT/dir_set_3"
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs='${ARCH_DIR}'"
+xtrabackup  --backup  --target-dir=$topdir/backup3 2> >( tee $topdir/pxb-3059-3 )
+redo_dir_3=$(mysql  -e "SHOW VARIABLES LIKE '%innodb_redo_log_archive_dirs%'"  2> /dev/null  | grep innodb_redo_log_archive_dirs| awk -F ' '  '{print $2}')
+if [ "$redo_dir_3" != "${ARCH_DIR}" ]
+then
+    die "innodb_redo_log_archive_dirs has been changed on test 3"
+fi
+if ! grep -q "xtrabackup redo_log_arch_dir is set to ${ARCH_DIR}" $topdir/pxb-3059-3 ; then
+    die "xtrabackup redo_log_arch_dir not set to ${ARCH_DIR} on test 3"
+fi
+
+
+#PXB-3059-4   mysql  and  xtrabackup all not  set
+mysql -e "SET GLOBAL innodb_redo_log_archive_dirs=NULL"
+xtrabackup  --backup  --target-dir=$topdir/backup4
+redo_dir_4=$(mysql  -e "SHOW VARIABLES LIKE '%innodb_redo_log_archive_dirs%'"  2> /dev/null  | grep innodb_redo_log_archive_dirs| awk -F ' '  '{print $2}')
+[  $redo_dir_4  ] && die  "innodb_redo_log_archive_dirs has been changed on test 4" || true
+
+
+
+
+
+

--- a/storage/innobase/xtrabackup/test/suites/keyring/redo_log_archive.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/redo_log_archive.sh
@@ -32,6 +32,8 @@ function run_test() {
   if [ "with_encryption" = $1 ]; then
     mysql -e "set global innodb_redo_log_encrypt=on"
   fi
+  run_inserts
+  innodb_wait_for_flush_all
 
   mkdir $topdir/backup
 

--- a/storage/innobase/xtrabackup/test/suites/keyring/xb_log_archiving_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/xb_log_archiving_encrypt.sh
@@ -4,7 +4,6 @@
 
 require_server_version_higher_than 8.0.16
 
-skip_if_asan
 
 MYSQLD_EXTRA_MY_CNF_OPTS="
 innodb_redo_log_encrypt

--- a/storage/innobase/xtrabackup/test/t/xb_log_archiving.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_archiving.sh
@@ -4,8 +4,6 @@
 
 require_server_version_higher_than 8.0.16
 
-skip_if_asan
-
 . inc/keyring_file.sh
 
 start_server


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3059

Added an option to set innodb_redo_log_archive_dirs. xtrabackup only sets the option if the server innodb_redo_log_archive_dirs is currently set to NULL. We always restore it back to NULL in the end of the backup.

Thanks wangbincmss for the patch.

Closes #1465 