### PR TITLE
PXB-3088 : Assertion failure:log0files_capacity.cc:555:file_size <=LO…

### DIFF
--- a/storage/innobase/log/log0files_capacity.cc
+++ b/storage/innobase/log/log0files_capacity.cc
@@ -552,7 +552,14 @@ os_offset_t Log_files_capacity::next_file_size(os_offset_t physical_capacity) {
   const auto file_size =
       ut_uint64_align_down(physical_capacity / LOG_N_FILES, UNIV_PAGE_SIZE);
   ut_a(LOG_FILE_MIN_SIZE <= file_size);
+  /* The filesize/physical_capacity is the size of xtrabackup_logfile. This is
+  also used for hard_logical_capacity calculation. At recovery, the margin is
+  size of xtrabackup_logfile + 1G for MLOG_DYNAMIC_METADATA records. For prepare
+  phase, we resize the redo logs. So the max file size limit is not applicable
+  */
+#ifndef XTRABACKUP
   ut_a(file_size <= LOG_FILE_MAX_SIZE);
+#endif
   ut_a(file_size % UNIV_PAGE_SIZE == 0);
   return file_size;
 }


### PR DESCRIPTION
…G_FILE_MAX_SIZE

Problem
--------
xtrabackup unable to prepare if redo copied is more than 128G

Analysis
--------
PXB initializes redo log system and we calculate a hard logical capacity of redo log. This is not same as physical size of redo log file because of the headers, trailers, file headers etc.

When calculating hard logical capacity, we also subtract the "header space" occupied all files (redo subsystem may create new files. so it takes into account of this).

As part of the calculation, we check the margin of a redo file. In this, it checks the possible file size shouldn't exceed based on the max log file size. The assertion is not valid because, we do not create multiple files at redo apply phase and the capacity is size of xtrabackup_logfile (renamed as ib_redo0) plus 1G for MLOG_DYNAMIC_TABLE redo.

Where do we use this hard logical capacity
(log_capacity.m_exposed.hard_logical_capacity)? It is currently used by log writer threads and checkpointer threads. Although at recovery, there is not much redo generated. The only redo generated would be from the MLOG_DYNAMIC_TABLE redo records.

Fix:
----
Relax the assertion (and updating capacity.m_exposed.hard_logical_capacity) this means, we tell the log writers there is enough margin in the redo and not panic for the small redo generated by MLOG_DYNAMIC_TABLE redo records.

This fix is contributed by Ahmed Et-tanany. Thank you!