### PR TITLE
Fixed PXB-3029 - Xtrabackup keeps locking table even with the use of …

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -2176,47 +2176,47 @@ void mdl_unlock_all() {
     mysql_close(mdl_con);
   }
 }
-bool is_fts_index(const std::string &tablespace) {
+bool is_fts_index(const std::string &table_name) {
   const char *pattern =
       "^(FTS|fts)_[0-9a-fA-f]{16}_(([0-9a-fA-]{16}_(INDEX|index)_[1-6])|"
       "DELETED_CACHE|deleted_cache|DELETED|deleted|CONFIG|config|BEING_DELETED|"
       "being_deleted|BEING_DELETED_CACHE|beign_deleted_cache)$";
   const char *error_context = "is_fts_index";
-  return check_regexp_table_name(tablespace, error_context, pattern);
+  return check_regexp_table_name(table_name, error_context, pattern);
 }
 
-bool is_tmp_table(const std::string &tablespace) {
+bool is_tmp_table(const std::string &table_name) {
   const char *pattern = "^#sql";
   const char *error_context = "is_tmp_table";
-  return check_regexp_table_name(tablespace, error_context, pattern);
+  return check_regexp_table_name(table_name, error_context, pattern);
 }
 
-bool is_access_blocked(const std::string &tablespace) {
+bool is_access_blocked(const std::string &table_name) {
   const char *pattern = "compression_dictionary";
   const char *error_context = "is_blocked_table";
-  return check_regexp_table_name(tablespace, error_context, pattern);
+  return check_regexp_table_name(table_name, error_context, pattern);
 }
 
-bool check_regexp_table_name(std::string tablespace, const char *error_context,
+bool check_regexp_table_name(std::string table_name, const char *error_context,
                              const char *pattern) {
   bool result = false;
-  get_table_name_from_tablespace(tablespace);
+  get_table_name_from_fq(table_name);
   xb_regex_t preg;
   size_t nmatch = 1;
   xb_regmatch_t pmatch[1];
   compile_regex(pattern, error_context, &preg);
 
-  if (xb_regexec(&preg, tablespace.c_str(), nmatch, pmatch, 0) != REG_NOMATCH) {
+  if (xb_regexec(&preg, table_name.c_str(), nmatch, pmatch, 0) != REG_NOMATCH) {
     result = true;
   }
   xb_regfree(&preg);
   return result;
 }
-void get_table_name_from_tablespace(std::string &tablespace) {
-  std::size_t pos = tablespace.find("`.`");  //`db`.`table` separator
+void get_table_name_from_fq(std::string &fq_table_name) {
+  std::size_t pos = fq_table_name.find("`.`");  //`db`.`table` separator
   if (pos != std::string::npos) {
-    tablespace = tablespace.substr(pos + 3);
-    tablespace.erase(tablespace.size() - 1);  // remove leading `
+    fq_table_name = fq_table_name.substr(pos + 3);
+    fq_table_name.erase(fq_table_name.size() - 1);  // remove leading `
   }
 }
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -235,34 +235,35 @@ void parse_show_engine_innodb_status(MYSQL *connection);
 /** Acquires MDL lock on all tables */
 void mdl_lock_tables();
 
-/** Identifies if tablespace is a Full Text Index.
-@param[in]	tablespace		tablespace
-@return true if tablespace is FTS. */
-bool is_fts_index(const std::string &tablespace);
+/** Identifies if table_name is a Full Text Index.
+@param[in]	table_name		table_name
+@return true if table_name is FTS. */
+bool is_fts_index(const std::string &table_name);
 
-/** Identifies if tablespace is a temporary table (#sql-)
-@param[in]	tablespace		tablespace
-@return true if tablespace is temporary table. */
-bool is_tmp_table(const std::string &tablespace);
+/** Identifies if table_name is a temporary table (#sql-)
+@param[in]	table_name		table_name
+@return true if table_name is temporary table. */
+bool is_tmp_table(const std::string &table_name);
 
-/** Identifies if table is blocked by select - PS compression dictionary.
-@param[in]	tablespace		tablespace
-@return true if tablespace is blocked. */
-bool is_access_blocked(const std::string &tablespace);
+/** Identifies if table is blocked by select
+SELECT from mysql.compression_* tables is not allowed by Server.
+@param[in]	table_name		table_name
+@return true if table_name is blocked. */
+bool is_access_blocked(const std::string &table_name);
 
 /** Runs a regexp against a table name
-@param[in]	tablespace		tablespace
+@param[in]	table_name		table_name
 @param[in]	error_context		error to be return in case of errors
 @param[in]	pattern		regexp pattern to try a match
 @return true if there is a match, or false otherwise */
-bool check_regexp_table_name(std::string tablespace, const char *error_context,
+bool check_regexp_table_name(std::string table_name, const char *error_context,
                              const char *pattern);
 
 /** Extract the table name from a full qualified `db`.`table` string
 removing escape string. Replace the name inplace
-@param[in/out]	tablespace		tablespace
+@param[in/out]	fq_table_name		full qualified table name
  */
-void get_table_name_from_tablespace(std::string &tablespace);
+void get_table_name_from_fq(std::string &fq_table_name);
 
 void mdl_unlock_all();
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -245,6 +245,11 @@ bool is_fts_index(const std::string &tablespace);
 @return true if tablespace is temporary table. */
 bool is_tmp_table(const std::string &tablespace);
 
+/** Identifies if table is blocked by select - PS compression dictionary.
+@param[in]	tablespace		tablespace
+@return true if tablespace is blocked. */
+bool is_access_blocked(const std::string &tablespace);
+
 /** Runs a regexp against a table name
 @param[in]	tablespace		tablespace
 @param[in]	error_context		error to be return in case of errors


### PR DESCRIPTION
…--tables-exclude and –lock-ddl-per-table.

https://jira.percona.com/browse/PXB-2860

Problem:
When running lock-ddl-per-table, xtrabackup places an MDL on all known tables at the start of the backup.  This is to prevent DDL from happening until we close the connection to the server.  However, if user has opted for a selective backup, we are not taking it into consideration and still locking all tables.

Fix:
Adjust mdl_lock_tables to only lock tables that are being backed up. Also added a check to skip Percona Server compression dictionary tables. Those tables show up on the list but they do not accept queries.