### PR TITLE
Fixed PXB-3110 - pxb-2357.sh is unstable

### DIFF
--- a/storage/innobase/xtrabackup/test/t/pxb-2357.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2357.sh
@@ -1,5 +1,7 @@
 # PXB-2357: hang in backup with redo log archive#
 
+skip_test "This test is not testing what it is intended to. Check PXB-3110"
+
 require_debug_pxb_version
 
 require_server_version_higher_than 8.0.16


### PR DESCRIPTION
Issue:
test pxb-2357.sh is unstable, it fails randomly after the introduction of redo log archiving on PXB. We now take more time on checking if redo is enabled and this triggers this particular test to have t2 as part of files to be copied, however sometimes when we get to the point to copy t2.ibd, we just executed the DROP TABLE, causing the test to fail. Analyzing the original issue, there is no evidence that the DROP TABLE is necessary to reproduce the issue. Also, after creating the TABLE we are adding rows from it, we do it via SELECT * from t, however, TABLE t is empty.
Removing the code changes introduced on PXB-2357 and keeping the original test case does not reproduce the issue, so our test is not covering what is intended to cover.

Fix:
We are disabling the test.