### PR TITLE
PXB-3100 : Remove mach_parse_compressed_v3

### DIFF
--- a/storage/innobase/mach/mach0data.cc
+++ b/storage/innobase/mach/mach0data.cc
@@ -32,7 +32,6 @@ this program; if not, write to the Free Software Foundation, Inc.,
  ***********************************************************************/
 
 #include "mach0data.h"
-#include "log0log.h"
 
 #include <stddef.h>
 
@@ -77,106 +76,7 @@ uint64_t mach_parse_u64_much_compressed(const byte **ptr, const byte *end_ptr) {
 advanced by the number of bytes consumed, or set NULL if out of space
 @param[in]      end_ptr end of the buffer
 @return unsigned value */
-static uint32_t mach_parse_compressed_v3(const byte **ptr,
-                                         const byte *end_ptr) {
-  ulint val;
-
-  if (*ptr >= end_ptr) {
-    *ptr = NULL;
-    return (0);
-  }
-
-  val = mach_read_from_1(*ptr);
-
-  if (val < 0x80) {
-    /* 0nnnnnnn (7 bits) */
-    ++*ptr;
-    return (static_cast<uint32_t>(val));
-  }
-
-  /* Workaround GCC bug
-  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77673:
-  the compiler moves mach_read_from_4 right to the beginning of the
-  function, causing and out-of-bounds read if we are reading a short
-  integer close to the end of buffer. */
-#if defined(__GNUC__) && (__GNUC__ >= 5) && !defined(__clang__)
-#define DEPLOY_FENCE
-#endif
-
-#ifdef DEPLOY_FENCE
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-#endif
-
-  if (val < 0xC0) {
-    /* 10nnnnnn nnnnnnnn (14 bits) */
-    if (end_ptr >= *ptr + 2) {
-      val = mach_read_from_2(*ptr) & 0x3FFF;
-      ut_ad(val > 0x7F);
-      *ptr += 2;
-      return (static_cast<uint32_t>(val));
-    }
-    *ptr = NULL;
-    return (0);
-  }
-
-#ifdef DEPLOY_FENCE
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-#endif
-
-  if (val < 0xE0) {
-    /* 110nnnnn nnnnnnnn nnnnnnnn (21 bits) */
-    if (end_ptr >= *ptr + 3) {
-      val = mach_read_from_3(*ptr) & 0x1FFFFF;
-      ut_ad(val > 0x3FFF);
-      *ptr += 3;
-      return (static_cast<uint32_t>(val));
-    }
-    *ptr = NULL;
-    return (0);
-  }
-
-#ifdef DEPLOY_FENCE
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-#endif
-
-  if (val < 0xF0) {
-    /* 1110nnnn nnnnnnnn nnnnnnnn nnnnnnnn (28 bits) */
-    if (end_ptr >= *ptr + 4) {
-      val = mach_read_from_4(*ptr) & 0xFFFFFFF;
-      ut_ad(val > 0x1FFFFF);
-      *ptr += 4;
-      return (static_cast<uint32_t>(val));
-    }
-    *ptr = NULL;
-    return (0);
-  }
-
-#ifdef DEPLOY_FENCE
-  __atomic_thread_fence(__ATOMIC_ACQUIRE);
-#endif
-
-#undef DEPLOY_FENCE
-
-  ut_ad(val == 0xF0);
-
-  /* 11110000 nnnnnnnn nnnnnnnn nnnnnnnn nnnnnnnn (32 bits) */
-  if (end_ptr >= *ptr + 5) {
-    val = mach_read_from_4(*ptr + 1);
-    ut_ad(val > 0xFFFFFFF);
-    *ptr += 5;
-    return (static_cast<uint32_t>(val));
-  }
-
-  *ptr = NULL;
-  return (0);
-}
-
-/** Read a 32-bit integer in a compressed form.
-@param[in,out]	ptr	pointer to memory where to read;
-advanced by the number of bytes consumed, or set NULL if out of space
-@param[in]	end_ptr	end of the buffer
-@return unsigned value */
-uint32_t mach_parse_compressed_v4(const byte **ptr, const byte *end_ptr) {
+uint32_t mach_parse_compressed(const byte **ptr, const byte *end_ptr) {
   ulint val;
 
   if (*ptr >= end_ptr) {
@@ -316,29 +216,5 @@ uint32_t mach_parse_compressed_v4(const byte **ptr, const byte *end_ptr) {
   }
 
   *ptr = nullptr;
-  return (0);
-}
-
-/** Read a 32-bit integer in a compressed form.
-@param[in,out]	ptr	pointer to memory where to read;
-advanced by the number of bytes consumed, or set NULL if out of space
-@param[in]	end_ptr	end of the buffer
-@return unsigned value */
-uint32_t mach_parse_compressed(const byte **ptr, const byte *end_ptr) {
-  switch (log_sys->m_format) {
-    case Log_format::VERSION_5_7_9:
-    case Log_format::LEGACY:
-      ut_a(0);
-      return (0);
-    case Log_format::VERSION_8_0_1:
-    case Log_format::VERSION_8_0_3:
-      return (mach_parse_compressed_v3(ptr, end_ptr));
-    case Log_format::VERSION_8_0_19:
-    case Log_format::VERSION_8_0_28:
-    case Log_format::VERSION_8_0_30:
-      return (mach_parse_compressed_v4(ptr, end_ptr));
-  }
-  /* make compiler happy */
-  ut_a(0);
   return (0);
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3100

Introduced as part of 8.0.20. Upstream changed redo log format
and removed parsing for older mach_parse_compressed() formats.
    
Upstream commit: 3ee5f8b

We had to retain multiple versions of it because PXB has to
backup and prepare server versions before 8.0.20 too.

PXB merge commit: c3649b3

Remove this code as it is no longer used. Dead code.
