### PR TITLE
PXB-3139: Fix gcc-13 and clang-16 compilation issues

### DIFF
--- a/components/keyrings/common/data/data.h
+++ b/components/keyrings/common/data/data.h
@@ -23,6 +23,7 @@
 #ifndef DATA_INCLUDED
 #define DATA_INCLUDED
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include "pfs_string.h"

--- a/plugin/keyring/common/keyring_memory.h
+++ b/plugin/keyring/common/keyring_memory.h
@@ -59,9 +59,9 @@ class Secure_allocator : public std::allocator<T> {
   struct rebind {
     typedef Secure_allocator<U> other;
   };
+
   Secure_allocator() noexcept {}
-  Secure_allocator(const Secure_allocator &secure_allocator) noexcept
-      : std::allocator<T>(secure_allocator) {}
+
   template <class U>
   Secure_allocator(const Secure_allocator<U> &) noexcept {}
 

--- a/plugin/keyring/common/system_keys_container.h
+++ b/plugin/keyring/common/system_keys_container.h
@@ -38,7 +38,7 @@ namespace keyring {
 class System_keys_container : public ISystem_keys_container {
  public:
   System_keys_container(ILogger *logger) : logger(logger) {}
-  ~System_keys_container();
+  ~System_keys_container() override;
 
   /**
     Returns key with latest version when called with plain system key (ex.

--- a/plugin/keyring_vault/vault_curl.h
+++ b/plugin/keyring_vault/vault_curl.h
@@ -44,7 +44,7 @@ class Vault_curl final : public IVault_curl, private boost::noncopyable {
         directory_path_(),
         resolved_secret_mount_point_version_(Vault_version_unknown) {}
 
-  ~Vault_curl() {
+  ~Vault_curl() override {
     if (list != nullptr) curl_slist_free_all(list);
   }
 

--- a/plugin/keyring_vault/vault_io.h
+++ b/plugin/keyring_vault/vault_io.h
@@ -34,7 +34,7 @@ class Vault_io final : public IVault_io, private boost::noncopyable {
            IVault_parser_composer *vault_parser)
       : logger(logger), vault_curl(vault_curl), vault_parser(vault_parser) {}
 
-  ~Vault_io();
+  ~Vault_io() override;
 
   virtual bool retrieve_key_type_and_data(IKey *key) override;
 

--- a/plugin/keyring_vault/vault_key.cc
+++ b/plugin/keyring_vault/vault_key.cc
@@ -20,12 +20,12 @@
 
 namespace keyring {
 
-bool Vault_key::get_next_key(IKey **key) {
+bool Vault_key::get_next_key(IKey **key_out) {
   if (was_key_retrieved) {
-    *key = nullptr;
+    *key_out = nullptr;
     return true;
   }
-  *key = new Vault_key(*this);
+  *key_out = new Vault_key(*this);
   was_key_retrieved = true;
   return false;
 }

--- a/plugin/keyring_vault/vault_keys_container.cc
+++ b/plugin/keyring_vault/vault_keys_container.cc
@@ -20,11 +20,11 @@
 #include "i_vault_io.h"
 
 namespace keyring {
-bool Vault_keys_container::init(IKeyring_io *keyring_io,
-                                std::string keyring_storage_url) {
-  vault_io = dynamic_cast<IVault_io *>(keyring_io);
+bool Vault_keys_container::init(IKeyring_io *keyring_io_value,
+                                std::string keyring_storage_url_value) {
+  vault_io = dynamic_cast<IVault_io *>(keyring_io_value);
   assert(vault_io != nullptr);
-  return Keys_container::init(keyring_io, keyring_storage_url);
+  return Keys_container::init(keyring_io_value, keyring_storage_url_value);
 }
 
 IKey *Vault_keys_container::fetch_key(IKey *key) {

--- a/plugin/keyring_vault/vault_keys_container.h
+++ b/plugin/keyring_vault/vault_keys_container.h
@@ -27,7 +27,8 @@ class IVault_io;
 
 class Vault_keys_container : public Keys_container, private boost::noncopyable {
  public:
-  Vault_keys_container(ILogger *logger) noexcept : Keys_container(logger) {}
+  Vault_keys_container(ILogger *logger_value) noexcept
+      : Keys_container(logger_value) {}
 
   bool init(IKeyring_io *keyring_io, std::string keyring_storage_url) override;
   IKey *fetch_key(IKey *key) override;

--- a/plugin/keyring_vault/vault_keys_list.h
+++ b/plugin/keyring_vault/vault_keys_list.h
@@ -32,7 +32,7 @@ class Vault_keys_list final : public ISerialized_object,
   void push_back(IKey *key);
   size_t size() const;
 
-  ~Vault_keys_list();
+  ~Vault_keys_list() override;
 
  private:
   typedef std::list<IKey *> Keys_list;

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -441,6 +441,15 @@ static constexpr const char *auto_event_names[] = {
     "ut0vec",
     "ut0wqueue",
     "zipdecompress",
+#ifdef XTRABACKUP
+    /* added for Percona XtraBackup */
+    "backup_copy",
+    "changed_page_tracking",
+    "fil_cur",
+    "redo_log",
+    "write_filt",
+    "xtrabackup",
+#endif
 };
 
 static constexpr size_t n_auto = UT_ARR_SIZE(auto_event_names);

--- a/storage/innobase/xtrabackup/src/ds_fifo.cc
+++ b/storage/innobase/xtrabackup/src/ds_fifo.cc
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "file_utils.h"
 #include "msg.h"
 
-typedef struct {
+struct ds_fifo_ctxt_t {
   /* List of FIFO files to be used for stream */
   std::unordered_map<std::string, File> FIFO_list;
   /* Mutex protecting FIFO list */
@@ -65,7 +65,9 @@ typedef struct {
     }
     FIFO_list.clear();
   }
-} ds_fifo_ctxt_t;
+};
+
+typedef struct ds_fifo_ctxt_t ds_fifo_ctxt_t;
 
 typedef struct {
   File fd;

--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -186,9 +186,10 @@ dberr_t xb_set_encryption(fil_space_t *space) {
   return (fil_set_encryption(space->id, Encryption::AES, key, iv));
 }
 
-const char *TRANSITION_KEY_PREFIX = "XBKey";
-const size_t TRANSITION_KEY_PREFIX_LEN =
-    sizeof(TRANSITION_KEY_PREFIX) / sizeof(char);
+#define TRANSITION_KEY_PREFIX_STR "XBKey"
+
+const char *TRANSITION_KEY_PREFIX = TRANSITION_KEY_PREFIX_STR;
+const size_t TRANSITION_KEY_PREFIX_LEN = sizeof(TRANSITION_KEY_PREFIX_STR) - 1;
 const size_t TRANSITION_KEY_RANDOM_DATA_LEN = 32;
 const size_t TRANSITION_KEY_NAME_MAX_LEN_V1 =
     Encryption::SERVER_UUID_LEN + 2 + 45;

--- a/storage/innobase/xtrabackup/src/rapidxml/rapidxml.hpp
+++ b/storage/innobase/xtrabackup/src/rapidxml/rapidxml.hpp
@@ -82,10 +82,7 @@ namespace rapidxml
 
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
-        virtual const char *what() const throw() override
-        {
-            return m_what;
-        }
+        virtual const char *what() const noexcept override { return m_what; }
 
         //! Gets pointer to character data where error happened.
         //! Ch should be the same as char type of xml_document that produced the error.

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1154,10 +1154,10 @@ void download_func(download_thread_ctxt_t &cntx) {
     cntx.store->async_download_object(
         *cntx.container, chunk, &h,
         std::bind(
-            [&cntx, &thread_state](bool success, const Http_buffer &contents,
-                                   std::string chunk, my_off_t idx,
-                                   std::atomic<bool> *error, uint thread_id,
-                                   File fd, file_metadata_t file) {
+            [&thread_state](bool success, const Http_buffer &contents,
+                            std::string chunk, my_off_t idx,
+                            std::atomic<bool> *error, uint thread_id, File fd,
+                            file_metadata_t file) {
               if (!success) {
                 error->store(true);
                 msg_ts("%s: [%d] Download failed. Cannot download %s.\n",

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -493,7 +493,7 @@ static void extract_worker_thread_func(extract_ctxt_t &ctxt) {
   xb_rstream_t *stream = NULL;
   xb_rstream_chunk_t chunk;
   file_entry_t *entry;
-  xb_rstream_result_t res;
+  xb_rstream_result_t res = XB_STREAM_READ_CHUNK;
 
   ctxt.mutex->lock();
   stream = ctxt.streams->front();


### PR DESCRIPTION
Fix the following issues:
1.
```
/data/percona-xtrabackup/8.0/storage/innobase/xtrabackup/src/keyring_plugins.cc:191:35: error: 'sizeof (TRANSITION_KEY_PREFIX)' will return the size of the pointer, not the array itself [-Werror,-Wsizeof-pointer-div]
    sizeof(TRANSITION_KEY_PREFIX) / sizeof(char);
```
2. All files that use `UT_NEW_THIS_FILE_PSI_KEY` should be added to `auto_event_names` in `storage/innobase/include/ut0new.h` because in another case we have:
```
/data/percona-xtrabackup/8.0/storage/innobase/xtrabackup/src/backup_copy.cc:440:74: error: array index -1 is before the beginning of the array [-Werror,-Warray-bounds]
  data_threads = (datadir_thread_ctxt_t *)(ut::malloc_withkey(UT_NEW_THIS_FILE_PSI_KEY, length));
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~~
/data/percona-xtrabackup/8.0/storage/innobase/include/ut0new.h:566:34: note: expanded from macro 'UT_NEW_THIS_FILE_PSI_KEY'
       : ut::make_psi_memory_key(auto_event_keys[UT_NEW_THIS_FILE_PSI_INDEX]))
                                 ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/percona-xtrabackup/8.0/storage/innobase/include/ut0new.h:447:1: note: array 'auto_event_keys' declared here
extern PSI_memory_key auto_event_keys[n_auto];
```

3. Add `#include <cstdint>` to fix:
```
/data/percona-xtrabackup/8.0/components/keyrings/common/data/data.h:69:24: error: no member named 'uintptr_t' in namespace 'std'
        std::hash<std::uintptr_t>{}(reinterpret_cast<std::uintptr_t>(this));
                  ~~~~~^
/data/percona-xtrabackup/8.0/components/keyrings/common/data/data.h:69:54: error: no type named 'uintptr_t' in namespace 'std'; did you mean simply 'uintptr_t'?
        std::hash<std::uintptr_t>{}(reinterpret_cast<std::uintptr_t>(this));
                                                     ^~~~~~~~~~~~~~
                                                     uintptr_t
```

4. Port fixes from Percona Server related to "not marked 'override'" e.g.:
```
In file included from /data/percona-xtrabackup/8.0/plugin/keyring/common/keys_container.cc:30:
/data/percona-xtrabackup/8.0/plugin/keyring/common/system_keys_container.h:41:3: error: '~System_keys_container' overrides a destructor but is not marked 'override' [-Werror,-Winconsistent-missing-destructor-override]
  ~System_keys_container();
  ^
/data/percona-xtrabackup/8.0/plugin/keyring/common/i_system_keys_container.h:30:11: note: overridden virtual function is here
  virtual ~ISystem_keys_container() {}
```

5. Port fixes from Percona Server related to "shadows member inherited from" e.g.:
```
/data/percona-xtrabackup/8.0/plugin/keyring_vault/vault_keys_container.h:30:33: error: parameter 'logger' shadows member inherited from type 'Keys_container' [-Werror,-Wshadow-field]
  Vault_keys_container(ILogger *logger) noexcept : Keys_container(logger) {}
```

6.
```
/data/percona-xtrabackup/8.0/plugin/keyring/common/keyring_memory.h:63:3: error: definition of implicit copy assignment operator for 'Secure_allocator<char>' is deprecated because it has a user-provided copy constructor [-Werror,-Wdeprecated-copy-with-user-provided-copy]
  Secure_allocator(const Secure_allocator &secure_allocator) noexcept
```

7.
```
/data/percona-xtrabackup/8.0/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc:1157:15: error: lambda capture 'cntx' is not used [-Werror,-Wunused-lambda-capture]
            [&cntx, &thread_state](bool success, const Http_buffer &contents,
```

8.
```
/data/percona-xtrabackup/8.0/storage/innobase/xtrabackup/src/rapidxml/rapidxml.hpp:85:42: error: dynamic exception specifications are deprecated [-Werror,-Wdeprecated-dynamic-exception-spec]
        virtual const char *what() const throw() override
```

9.
```
/data/percona-xtrabackup/pxb-8.0/storage/innobase/xtrabackup/src/ds_fifo.cc:33:15: error: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Werror,-Wnon-c-typedef-for-linkage]
typedef struct {
              ^
               ds_fifo_ctxt_t
/data/percona-xtrabackup/pxb-8.0/storage/innobase/xtrabackup/src/ds_fifo.cc:40:3: note: type is not C-compatible due to this member declaration
  void populate_list(std::string fullpath, File fd) {
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/percona-xtrabackup/pxb-8.0/storage/innobase/xtrabackup/src/ds_fifo.cc:68:3: note: type is given name 'ds_fifo_ctxt_t' for linkage purposes by this typedef declaration
} ds_fifo_ctxt_t;
```
