### PR TITLE
trunk  Fix PXB-3147: Xtrabackup failed to execute query 'DO innodb_redo_log_consumer_register("PXB");'

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -1185,6 +1185,10 @@ bool Redo_Log_Data_Manager::init() {
         xtrabackup_register_redo_log_consumer = false;
         return (false);
       }
+      /* Consumer queries might not work on some sql_mode.
+       * Forcing it to be empty.
+       */
+      xb_mysql_query(redo_log_consumer_cnx, "SET sql_mode=''", false, true);
       redo_log_consumer.init(redo_log_consumer_cnx);
       redo_log_consumer_can_advance.store(true);
     }

--- a/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
+++ b/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
@@ -72,3 +72,13 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 xtrabackup --prepare --target-dir=$topdir/backup
+
+# PXB-3147 - register redo log consumer fails with ANSI_QUOTES
+stop_server
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+sql_mode = 'ANSI_QUOTES'
+"
+
+start_server
+xtrabackup --backup --stream --register-redo-log-consumer > /dev/null


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3147

Problem:
Xtrabackup failed to execute query
'DO innodb_redo_log_consumer_register("PXB");' with double quotes were interpreted as identifiers.

Fix:
Force empty sql_mode for redo log consumer connection.