### PR TITLE
Fix PXB-3003 - Race Condition in log_files_find_and_analyze

### DIFF
--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -101,4 +101,10 @@ const std::string KEYRING_NOT_LOADED =
     "--keyring_file_data. If keyring component is used, check if "
     "--component-keyring-config points to valid configuration";
 
+/** pause xtrabackup and wait for resume.
+@param[in]	name	sync point name */
+void debug_sync_point(const char *name);
+
+extern char *xtrabackup_debug_sync;
+
 #endif

--- a/storage/innobase/log/log0files_io.cc
+++ b/storage/innobase/log/log0files_io.cc
@@ -247,8 +247,13 @@ Log_file_handle::Log_file_handle(const Log_files_context &ctx, Log_file_id id,
   const dberr_t err = open();
   if (err != DB_SUCCESS) {
     ut_a(!m_is_open);
+#ifdef XTRABACKUP
+    ib::info(ER_IB_MSG_LOG_FILE_OPEN_FAILED, m_file_path.c_str(),
+             static_cast<int>(err));
+#else
     ib::error(ER_IB_MSG_LOG_FILE_OPEN_FAILED, m_file_path.c_str(),
               static_cast<int>(err));
+#endif /* XTRABACKUP */
   }
 }
 

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -46,6 +46,7 @@ static bool archive_first_block_zero = false;
 std::atomic<bool> Redo_Log_Reader::m_error;
 lsn_t Redo_Log_Reader::checkpoint_lsn_start;
 os_offset_t Redo_Log_Reader::checkpoint_offset_start;
+IF_DEBUG(bool force_reopen = false;);
 
 Redo_Log_Reader::Redo_Log_Reader() {
   log_hdr_buf.alloc_withkey(UT_NEW_THIS_FILE_PSI_KEY,
@@ -138,7 +139,6 @@ not.
 
 static bool reopen_log_files(lsn_t desired_lsn) {
   log_t &log = *log_sys;
-
   Log_files_dict files{log.m_files_ctx};
   Log_format format;
   std::string creator_name;
@@ -153,7 +153,14 @@ static bool reopen_log_files(lsn_t desired_lsn) {
     return false;
   }
 
-  ut_a(res == Log_files_find_result::FOUND_VALID_FILES);
+  if (res != Log_files_find_result::FOUND_VALID_FILES) {
+    xb::error()
+        << "reopen_log_files did not find valid files. Possibly the "
+           "redo log files have been removed by the server. Consider "
+           "using redo log archiving via --redo-log-arch-dir=name or "
+           "registering redo log consumer via --register-redo-log-consumer.";
+    return false;
+  }
 
   log.m_format = format;
   log.m_creator_name = creator_name;
@@ -245,11 +252,22 @@ lsn_t Redo_Log_Reader::read_log_seg_8030(log_t &log, byte *buf, lsn_t start_lsn,
   ut_a(start_lsn < end_lsn);
 
   // update the in-memory structure log files by scanning
-  if (log.m_files.find(start_lsn) == log.m_files.end() &&
-      !reopen_log_files(start_lsn)) {
+  if (IF_DEBUG((force_reopen && !reopen_log_files(start_lsn)) ||)(
+          log.m_files.find(start_lsn) == log.m_files.end() &&
+          !reopen_log_files(start_lsn))) {
     m_error = true;
     return 0;
   }
+
+  DBUG_EXECUTE_IF(
+      "xtrabackup_reopen_files_after_catchup",
+      if (xtrabackup_debug_sync != nullptr &&
+          strstr(xtrabackup_debug_sync, "log_files_find_and_analyze") !=
+              nullptr) {
+        *const_cast<const char **>(&xtrabackup_debug_sync) = nullptr;
+        DBUG_SET("-d,xtrabackup_reopen_files_after_catchup");
+        force_reopen = false;
+      });
 
   auto file = log.m_files.find(start_lsn);
 
@@ -1288,6 +1306,11 @@ bool Redo_Log_Data_Manager::start() {
   }
 
   debug_sync_point("xtrabackup_pause_after_redo_catchup");
+
+  DBUG_EXECUTE_IF("xtrabackup_reopen_files_after_catchup",
+                  const char *key = "log_files_find_and_analyze";
+                  *const_cast<const char **>(&xtrabackup_debug_sync) = key;
+                  force_reopen = true;);
 
   thread.start();
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -364,7 +364,7 @@ it every INNOBASE_WAKE_INTERVAL'th step. */
 #define INNOBASE_WAKE_INTERVAL 32
 ulong innobase_active_counter = 0;
 
-static char *xtrabackup_debug_sync = NULL;
+char *xtrabackup_debug_sync = NULL;
 static const char *dbug_setting = nullptr;
 
 bool xtrabackup_incremental_force_scan = false;
@@ -8023,9 +8023,7 @@ int main(int argc, char **argv) {
   }
 
 #ifndef __WIN__
-  if (xtrabackup_debug_sync) {
-    signal(SIGCONT, sigcont_handler);
-  }
+  signal(SIGCONT, sigcont_handler);
 #endif
 
   /* --backup */

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -261,9 +261,6 @@ bool check_if_skip_database_by_path(
     const char *path /*!< in: path to the db directory. */
 );
 
-/* pause xtrabackup and wait for resume */
-void debug_sync_point(const char *name);
-
 /************************************************************************
 Check if parameter is set in defaults file or via command line argument
 @return true if parameter is set. */

--- a/storage/innobase/xtrabackup/test/t/pxb-3003-redo-log-purge-race.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-3003-redo-log-purge-race.sh
@@ -1,0 +1,97 @@
+########################################################################
+# PXB-3003 Race Condition in log_files_find_and_analyze
+########################################################################
+# Test 1 - ensure that xtrabackup continue when some files are gone,
+# but the file containing the required lsn still exists.
+#
+# Test 2 - ensures xtrabackup fails when all files are gone.
+########################################################################
+. inc/common.sh
+
+require_server_version_higher_than 8.0.29
+require_debug_pxb_version
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_redo_log_capacity=8M
+"
+start_server
+
+function run_inserts()
+{
+  for i in $(seq 1000);
+  do
+    $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))";
+  done
+}
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE redo_log_consumer (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  str BLOB
+);" test
+
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))"
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))"
+
+mkdir -p $topdir/backup/
+
+vlog "Test 1 - Some files are gone, but not all (--register-redo-log-consumer ensures that)"
+
+xtrabackup --backup --target-dir=$topdir/backup --register-redo-log-consumer --debug="d,xtrabackup_reopen_files_after_catchup" 2> >( tee $topdir/xtrabackup_reopen_files_after_catchup.log) &
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+vlog "backup pid is $job_pid"
+
+INITIAL_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+
+run_inserts &
+insert_pid=$!
+CURRENT_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+while [ "${INITIAL_MIN_FILEID}" -eq "${CURRENT_MIN_FILEID}" ]
+do
+  sleep 1;
+  vlog "Waiting for redo log files to be created. Current MIN_FILEID: $CURRENT_MIN_FILEID Initial MIN_FILEID: $INITIAL_MIN_FILEID"
+  CURRENT_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+done
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+if ! grep "Unable to open './#innodb_redo/#ib_redo" $topdir/xtrabackup_reopen_files_after_catchup.log
+then
+	die "xtrabackup did not show warning about missing files"
+fi
+run_cmd wait $insert_pid
+
+
+
+vlog "Test 2 - All files are gone"
+
+run_inserts &
+insert_pid=$!
+
+run_cmd_expect_failure xtrabackup --backup --target-dir=$topdir/backup2 --debug="d,xtrabackup_reopen_files_after_catchup" &
+job_pid=$!
+pid_file=$topdir/backup2/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+vlog "backup pid is $job_pid"
+
+INITIAL_MAX_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MAX(file_id) FROM performance_schema.innodb_redo_log_files"`
+
+CURRENT_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+while [ "${CURRENT_MIN_FILEID}" -le "${INITIAL_MAX_FILEID}" ]
+do
+  sleep 1;
+  CURRENT_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+done
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $insert_pid
+rm -rf $topdir/backup/* $topdir/backup2/*
+


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3003

Problem:
log_files_find_and_analyze has a potential race condition when we list the available files and when we try to open them. In between those two operations, the log files might be deleted by the server causing the function to return an error.

Fix:
Adjust the function to tolerate missing files and return the list of valid files. Later we check if we found at least one file and if any of the files has the desired LSN.

Adjusted error message to info to make it more user-friendly, since we no longer error out in case of missing files.