### PR TITLE
Trunk Fix PXB-3170 - Test failure in keyring_pxb_2275.sh 

### DIFF
--- a/storage/innobase/xtrabackup/test/suites/keyring/keyring_pxb_2275.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/keyring_pxb_2275.sh
@@ -10,14 +10,15 @@ then
     skip_test "Requires server version 5.7"
 fi
 
-start_server --innodb-log-file-size=8M
+start_server --innodb-log-file-size=80M
 load_dbase_schema sakila
 load_dbase_data sakila
 mkdir $topdir/backup
 
 # Test 1 - should fail since we don't have any entry on keyring file yet
-run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
---target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
+vlog "Test 1 - Should fail as keyring file does not have encryption information"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=80M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
+--target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" 2> >(tee $topdir/backup.log)&
 
 job_pid=$!
 
@@ -43,11 +44,19 @@ kill -SIGCONT $xb_pid
 
 # wait's return code will be the code returned by the background process
 run_cmd wait $job_pid
+if ! grep -q "is missing encryption information" $topdir/backup.log ; then
+      die "Backup did not fail as expected"
+fi
+
 rm -rf $topdir/backup
 mkdir $topdir/backup
 
 # Clean-up
 $MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1, tmp2" sakila
+
+
+# Test 2 - Should pass as keyring file already have encryption information
+vlog "Test 2 - Should pass as keyring file already have encryption information"
 
 # Write data on Redo log so advance checkpoint to after creation of 1st encryption table
 $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE tmp1 ENGINE=InnoDB SELECT * FROM payment" sakila
@@ -70,8 +79,7 @@ $MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1" sakila
 innodb_wait_for_flush_all
 
 
-# Test 2 - Should pass as keyring file alwady have encryption information
-run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=8M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
+run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=80M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
 --target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" &
 
 job_pid=$!
@@ -110,5 +118,5 @@ rm -rf $mysql_datadir
 
 xtrabackup --copy-back --target-dir=$topdir/backup
 
-start_server --innodb-log-file-size=8M
+start_server --innodb-log-file-size=80M
 run_cmd $MYSQL $MYSQL_ARGS -Ns -e "SELECT * FROM tmp2;" sakila


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3170

Test was failing because we were generating an amount of data that was in a range that could cause the server to delete the required redo log. Also the test was failing due to missing redo log file, but we were not checking the error log for that which was a false positive.

Fix:
Adjusted the test to have a slightly higher redo log capacity. Added a check for the error log to make sure we fail due to missing keyring key.
