### PR TITLE
Fixed test cases and bootstrap - trunk

### DIFF
--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -14,15 +14,15 @@ function test_do()
   vlog "-- transition_key: ${transition_key} --"
   vlog "-- keyring_type: ${keyring_type} --"
   if [[ "$transition_key" = "generate" ]] ; then
-    backup_options="--generate-transition-key"
+    backup_options="--generate-transition-key --xtrabackup-plugin-dir=${plugin_dir}"
     prepare_options="--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}"
     copyback_options="--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}"
   elif [[ "$transition_key" = "none" ]] ; then
-    backup_options=
+    backup_options="--xtrabackup-plugin-dir=${plugin_dir}"
     prepare_options="--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}"
     copyback_options="--xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}"
   else
-    backup_options="--transition-key=$transition_key"
+    backup_options="--transition-key=$transition_key --xtrabackup-plugin-dir=${plugin_dir}"
     prepare_options="--transition-key=$transition_key"
     copyback_options="--transition-key=$transition_key --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}"
   fi
@@ -36,7 +36,7 @@ function test_do()
   run_cmd $MYSQL $MYSQL_ARGS test -e "SELECT @@server_uuid"
 
   # PXB-1540: XB removes and recreate keyring file of 0 size
-  xtrabackup --backup --target-dir=$topdir/backup0
+  xtrabackup --backup --target-dir=$topdir/backup0 $backup_options
 
   rm -rf $topdir/backup0
 

--- a/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/xbcloud_common.sh
@@ -23,8 +23,10 @@ secure-file-priv=$TEST_VAR_ROOT
 is_galera && skip_test "skipping"
 
 function is_xbcloud_credentials_set() {
-  [ "${XBCLOUD_CREDENTIALS:-unset}" == "unset" ] && \
-  skip_test "Requires XBCLOUD_CREDENTIALS"
+  if [ -z ${XBCLOUD_CREDENTIALS+x} ];
+  then
+    skip_test "Requires XBCLOUD_CREDENTIALS"
+  fi
 }
 
 now=$(date +%s)

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_mix_plugins.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_mix_plugins.sh
@@ -4,6 +4,8 @@
 
 require_server_version_higher_than 5.7.10
 
+is_xtradb || skip_test "Keyring vault requires Percona Server"
+
 vlog setup keyring_file
 . inc/keyring_file.sh
 


### PR DESCRIPTION
Adjusted keyring to always pass plugin dir.
Adjusted mix plugins to ensure we are running on PS Bootstrap to download correct glibc version
Bumped default server version

Added python3 version of subunit2junitxml
(cherry picked from commit d9d47b5ec598c17f8ae98927d934ab8699a55329)

Fixed is_xbcloud_credentials_set:
On centos7 the expanded command "${XBCLOUD_CREDENTIALS:-unset}" == "unset" return 1 to the caller rather than 0. Fixed by properly adjusting the function to have an if statement.

(cherry picked from commit 65c9ac767d118c93e51a71e90077786244f2e975)