### PR TITLE
Fix PXB-3141 - fix folder permission on fifo get

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_fifo.cc
+++ b/storage/innobase/xtrabackup/src/ds_fifo.cc
@@ -109,7 +109,7 @@ static ds_ctxt_t *fifo_init(const char *root) {
   ds_ctxt_t *ctxt = new ds_ctxt_t;
   char fullpath[FN_REFLEN];
 
-  if (my_mkdir(root, 0600, MYF(0)) < 0 && my_errno() != EEXIST &&
+  if (my_mkdir(root, 0777, MYF(0)) < 0 && my_errno() != EEXIST &&
       my_errno() != EISDIR) {
     char errbuf[MYSYS_STRERROR_SIZE];
     my_error(EE_CANT_MKDIR, MYF(0), root, my_errno(),

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1218,7 +1218,7 @@ bool xbcloud_download(Object_store *store, const std::string &container,
   /* Create FIFO files if necessary */
 
   if (opt_threads > 1) {
-    if (my_mkdir(opt_fifo_dir, 0600, MYF(0)) < 0 && my_errno() != EEXIST &&
+    if (my_mkdir(opt_fifo_dir, 0777, MYF(0)) < 0 && my_errno() != EEXIST &&
         my_errno() != EISDIR) {
       char errbuf[MYSYS_STRERROR_SIZE];
       msg_ts("%s: Error creating dir: %s. (%d) %s\n", my_progname, opt_fifo_dir,

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
@@ -28,6 +28,7 @@ take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --incre
 record_db_state test
 
 vlog "download & prepare"
+rm -rf ${topdir}/stream
 download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${full_backup_name}" "-x -C ${topdir}/full --fifo-streams=3"
 download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc_backup_name}" "-x -C ${topdir}/inc1 --fifo-streams=3"
 download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc2_backup_name}" "-x -C ${topdir}/inc2 --fifo-streams=3"


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3141

Problem
When creating a folder without executing permission, a user gets limited action on that folder. For a folder, the x privilege means the user can cd into the folder.
Currently, if we are doing a xbcloud get and the folder does not exists, xbcloud will create it as 600. The same problem does no happens with xtrabackup as the thread stream-dir as target-dir, and that is created as 777.

Fix
Adjusted folder creation on ds_fifo.cc and xbcloud to use 777 as permission. The same mask is used on xtrabackup.