### PR TITLE
Update xtrabackup.cc   Linux native AIO option print

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2305,7 +2305,6 @@ static bool innodb_init_param(void) {
 #elif defined(LINUX_NATIVE_AIO)
 
   if (srv_use_native_aio) {
-    ut_print_timestamp(stderr);
     ib::info() << "Using Linux native AIO";
   }
 #else


### PR DESCRIPTION
 when ./xtrabackup    --innodb-use-native-aio=true
2023-10-24T18:20:58.174714+08:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 2147483648
2023-10-24 18:20:58 1402668759925762023-10-24T18:20:58.174761+08:00 0 [Note] [MY-011825] [InnoDB] Using Linux native AIO
2023-10-24T18:20:58.174776+08:00 0 [Note] [MY-011825] [Xtrabackup] using O_DIRECT

the print message timestamp is confused
2023-10-24 18:20:58 1402668759925762023-10-24T18:20:58.174761+08:00 0 [Note] [MY-011825] [InnoDB] Using Linux native AIO

after change 
2023-10-24T18:50:00.137254+08:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 2147483648 
2023-10-24T18:50:00.137286+08:00 0 [Note] [MY-011825] [InnoDB] Using Linux native AIO 
2023-10-24T18:50:00.137314+08:00 0 [Note] [MY-011825] [Xtrabackup] using O_DIRECT
 the timestamp is consistent format