### PR TITLE
8.0 Fix PXB-3181 - Duplicate timestamp printed when using innodb-use-nati…

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2305,7 +2305,6 @@ static bool innodb_init_param(void) {
 #elif defined(LINUX_NATIVE_AIO)
 
   if (srv_use_native_aio) {
-    ut_print_timestamp(stderr);
     ib::info() << "Using Linux native AIO";
   }
 #else


### PR DESCRIPTION
…ve-aio=true

https://jira.percona.com/browse/PXB-3181

Problem:

when ./xtrabackup    --innodb-use-native-aio=true
2023-10-24T18:20:58.174714+08:00 0 [Note] [MY-011825] [Xtrabackup] innodb_log_file_size = 2147483648
2023-10-24 18:20:58 1402668759925762023-10-24T18:20:58.174761+08:00 0 [Note] [MY-011825] [InnoDB] Using Linux native AIO
2023-10-24T18:20:58.174776+08:00 0 [Note] [MY-011825] [Xtrabackup] using O_DIRECT

the print message timestamp is confused
2023-10-24 18:20:58 1402668759925762023-10-24T18:20:58.174761+08:00 0 [Note] [MY-011825] [InnoDB] Using Linux native AIO

Fix:
Remove ut_print_timestamp call since ib::info() from the line below already print timestamp.

Thanks to Bin Wang from China Mobile for the patch.

Closes #1510 