### PR TITLE
Fix PXB-3173 - Partial download functionality regression

### DIFF
--- a/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
@@ -67,7 +67,7 @@ xbstream -xv -C $topdir/partial < $topdir/partial/partial.xbs \
 
 sort -o $topdir/partial/partial.list $topdir/partial/partial.list
 
-diff -u $topdir/partial/partial.list - <<EOF
+run_cmd diff -u $topdir/partial/partial.list - <<EOF
 ibdata1
 sakila/payment.ibd
 EOF


### PR DESCRIPTION
https://jira.percona.com/browse/PXB-3173

Problem:
As part of FIFO redesign work, the xbcloud code was refactored to use multiple threads and a global list of files. This list was not taken into consideration that the user might want just a subset of files to be downloaded.
The test case was missing to enforce it should fail in case diff command return non zero return code.

Fix:
Re-implemented partial download functionality as a new function. Renamed the original variable to be more descriptive. Adjusted test to exit in case diff yields non-zero return code.