### PR TITLE
PXB-3199 - Unable to upload to S3 if object lock and retention periods are enabled.

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -113,7 +113,10 @@ std::string S3_signerV4::build_hashed_canonical_request(
 
   std::string content_sha256 = hex_encode(request.payload().sha256());
   request.add_header(AWS_CONTENT_SHA256_HEADER, content_sha256);
-
+  
+  std::string content_md5 = base64_encode(request.payload().md5());
+  request.add_header("Content-MD5", content_md5);
+  
   /* canonical URI */
   canonical_request << request.path() << "\n";
 


### PR DESCRIPTION
PXB-3199: Unable to upload to S3 if object lock and retention periods are enabled.

https://jira.percona.com/browse/PXB-3199

Problem:
------------
xbcloud cannot upload to S3 if object lock and retention periods are enabled.
It fails with error message:

S3 error message: Content-MD5 OR x-amz-checksum- HTTP header is required for Put Object requests with Object Lock parameters

Amazon S3 requires MD5 checksum to be part of header if object lock and retention periods are enabled.
See https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
"The Content-MD5 or x-amz-sdk-checksum-algorithm header is required for any request to upload an object with a retention period configured using Amazon S3 Object Lock."

Fix:
-----
As required by S3 documentation,  add the MD5 checksum to the header.
