### PR TITLE
PXB-2797: Schema mismatch when importing table with full-text index f…

### DIFF
--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -438,6 +438,7 @@ ulint get_innobase_type_from_dd(const dd::Column *col, ulint &unsigned_type) {
   return MYSQL_TYPE_LONG;
 }
 
+#ifdef XTRABACKUP
 dict_table_t *dd_table_create_on_dd_obj(const dd::Table *dd_table,
                                         const dd::Partition *dd_part,
                                         const dd::String_type *schema_name,
@@ -981,7 +982,11 @@ dict_table_t *dd_table_create_on_dd_obj(const dd::Table *dd_table,
         if (c->is_virtual() == dd_col->is_virtual()) col_pos++;
       }
 
-      bool is_asc = (idx_elem->order() == dd::Index_element::ORDER_ASC);
+      /* FULLTEXT and HASH indexes can have UNDEF order, we should treat UNDEF
+       * as ASC */
+      bool is_asc = (idx_elem->order() == dd::Index_element::ORDER_ASC ||
+                     idx_elem->order() == dd::Index_element::ORDER_UNDEF);
+
       ulint prefix_len = 0;
 
       if (dd_index->type() == dd::Index::IT_SPATIAL) {
@@ -1211,6 +1216,7 @@ dict_table_t *dd_table_create_on_dd_obj(const dd::Table *dd_table,
 
   return (table);
 }
+#endif /* XTRABACKUP */
 
 table_id_t dd_table_id_and_part(space_id_t space_id, const dd::Table &dd_table,
                                 const dd::Partition *&dd_part) {


### PR DESCRIPTION
…rom xtrabackup backup

https://jira.percona.com/browse/PXB-2797

When importing a single table (IMPORT TABLESPACE) from a backup made using xtrabackup and the table contains a full-text index the import process will error out with: `ERROR 1808 (HY000) at line 132: Schema mismatch (Index xxxxxx field xxxxxx is ascending which does not match metadata file which is descending)`

The problem occurs because FTS tables are created internally by InnoDB Storage engine and they do not choose any ordering flag. Default is UNDEF. This patch solves the issue by treating UNDEF order as ASC when creating dict_table_t on `--prepare` step.