### PR TITLE
Fix xbcloud out of range memory read

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1038,7 +1038,7 @@ cleanup:
 @return true in case of success or false otherwise */
 bool chunk_name_to_file_name(const std::string &chunk_name,
                              std::string &file_name, my_off_t &idx) {
-  if (chunk_name.size() < 22 && chunk_name[chunk_name.size() - 21] != '.') {
+  if (chunk_name.size() < 22 || chunk_name[chunk_name.size() - 21] != '.') {
     /* chunk name is invalid */
     return false;
   }


### PR DESCRIPTION
Fix a memory out of bounds read when `chunk_name.size() < 21`

```diff
- if (chunk_name.size() < 22 && chunk_name[chunk_name.size() - 21] != '.') {
+ if (chunk_name.size() < 22 || chunk_name[chunk_name.size() - 21] != '.') {
```

| chunk_name.size() |  Before (&&) | After (\|\|) |
| ------------------------- | ---------- | ------ |
| < 21                        |   - 1st condition is true <br> - 2nd condition **use negative index**           |   - 1st condition is true <br> - 2nd condition not evaluated      |
| == 21                     |   - 1st condition is true <br> - 2nd condition using index 0, ok but useless if we want names longer than 21 chars | - 1st condition is true <br> - 2nd condition not evaluated |
| >= 22                    |  - 1st condition is false <br> - 2nd condition is not evaluated | - 1st condition is false <br> - 2nd condition is evaluated with an index always > 0 |
