### PR TITLE
PXB-3278 : Wrong parsing of MLOG_FILE_ redo log records with lock-ddl…

### DIFF
--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -2110,12 +2110,12 @@ inline fil_space_t *fil_space_get_sys_space() {
 @param[in]      page_id         Tablespace Id and first page in file
 @param[in]      parsed_bytes    Number of bytes parsed so far
 @param[in]      parse_only      Don't apply, parse only
+@param[in]      start_lsn       LSN of the redo record
 @return pointer to next redo log record
 @retval nullptr if this log record was truncated */
-[[nodiscard]] byte *fil_tablespace_redo_create(byte *ptr, const byte *end,
-                                               const page_id_t &page_id,
-                                               ulint parsed_bytes,
-                                               bool parse_only);
+[[nodiscard]] byte *fil_tablespace_redo_create(
+    byte *ptr, const byte *end, const page_id_t &page_id, ulint parsed_bytes,
+    bool parse_only IF_XB(, lsn_t start_lsn));
 
 /** Redo a tablespace delete.
 @param[in]      ptr             redo log record
@@ -2123,12 +2123,12 @@ inline fil_space_t *fil_space_get_sys_space() {
 @param[in]      page_id         Tablespace Id and first page in file
 @param[in]      parsed_bytes    Number of bytes parsed so far
 @param[in]      parse_only      Don't apply, parse only
+@param[in]      start_lsn       LSN of the redo record
 @return pointer to next redo log record
 @retval nullptr if this log record was truncated */
-[[nodiscard]] byte *fil_tablespace_redo_delete(byte *ptr, const byte *end,
-                                               const page_id_t &page_id,
-                                               ulint parsed_bytes,
-                                               bool parse_only);
+[[nodiscard]] byte *fil_tablespace_redo_delete(
+    byte *ptr, const byte *end, const page_id_t &page_id, ulint parsed_bytes,
+    bool parse_only IF_XB(, lsn_t start_lsn));
 
 /** Redo a tablespace rename.
 This function doesn't do anything, simply parses the redo log record.
@@ -2137,12 +2137,12 @@ This function doesn't do anything, simply parses the redo log record.
 @param[in]      page_id         Tablespace Id and first page in file
 @param[in]      parsed_bytes    Number of bytes parsed so far
 @param[in]      parse_only      Don't apply, parse only
+@param[in]      start_lsn       LSN of the redo record
 @return pointer to next redo log record
 @retval nullptr if this log record was truncated */
-[[nodiscard]] byte *fil_tablespace_redo_rename(byte *ptr, const byte *end,
-                                               const page_id_t &page_id,
-                                               ulint parsed_bytes,
-                                               bool parse_only);
+[[nodiscard]] byte *fil_tablespace_redo_rename(
+    byte *ptr, const byte *end, const page_id_t &page_id, ulint parsed_bytes,
+    bool parse_only IF_XB(, lsn_t start_lsn));
 
 /** Redo a tablespace extend
 @param[in]      ptr             redo log record

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1679,10 +1679,6 @@ static byte *recv_parse_or_apply_log_rec_body(
             << " operation later or with --lock-ddl";
         exit(EXIT_FAILURE);
       }
-      if (ddl_tracker && redo_catchup_completed)
-        ddl_tracker->backup_file_op(space_id, MLOG_FILE_DELETE, ptr,
-                                    static_cast<ulint>(end_ptr - ptr),
-                                    start_lsn);
 #endif /* XTRABACKUP */
 
       return fil_tablespace_redo_delete(
@@ -1691,38 +1687,29 @@ static byte *recv_parse_or_apply_log_rec_body(
               0 IF_XB(||
                       recv_sys->recovered_lsn + parsed_bytes <
                           backup_redo_log_flushed_lsn ||
-                      opt_lock_ddl == LOCK_DDL_REDUCED));
+                      opt_lock_ddl == LOCK_DDL_REDUCED),
+          start_lsn);
 
     case MLOG_FILE_CREATE:
 
-#ifdef XTRABACKUP
-      if (ddl_tracker && redo_catchup_completed)
-        ddl_tracker->backup_file_op(space_id, MLOG_FILE_CREATE, ptr,
-                                    static_cast<ulint>(end_ptr - ptr),
-                                    start_lsn);
-#endif /* XTRABACKUP */
       return fil_tablespace_redo_create(
           ptr, end_ptr, page_id_t(space_id, page_no), parsed_bytes,
           recv_sys->bytes_to_ignore_before_checkpoint !=
               0 IF_XB(||
                       recv_sys->recovered_lsn + parsed_bytes <
                           backup_redo_log_flushed_lsn ||
-                      opt_lock_ddl == LOCK_DDL_REDUCED));
+                      opt_lock_ddl == LOCK_DDL_REDUCED),
+          start_lsn);
 
     case MLOG_FILE_RENAME:
-#ifdef XTRABACKUP
-      if (ddl_tracker && redo_catchup_completed)
-        ddl_tracker->backup_file_op(space_id, MLOG_FILE_RENAME, ptr,
-                                    static_cast<ulint>(end_ptr - ptr),
-                                    start_lsn);
-#endif /* XTRABACKUP */
       return fil_tablespace_redo_rename(
           ptr, end_ptr, page_id_t(space_id, page_no), parsed_bytes,
           recv_sys->bytes_to_ignore_before_checkpoint !=
               0 IF_XB(||
                       recv_sys->recovered_lsn + parsed_bytes <
                           backup_redo_log_flushed_lsn ||
-                      opt_lock_ddl == LOCK_DDL_REDUCED));
+                      opt_lock_ddl == LOCK_DDL_REDUCED),
+          start_lsn);
 
     case MLOG_FILE_EXTEND:
 


### PR DESCRIPTION
…=REDUCED

Problem:
--------
ddl_tracker_t::backup_file_op assumes the required redo bytes are always present. see the assertion len < 6. But it may happen we sometimes receive redo less than that. In such cases, we return nullptr and let the caller read more read and retry

Fix:
----
fil_tablespace_redo_create()/rename()/delete() variants handle this problem by returning nullptr and reading more redo and retry. Moved ddl tracker calls to track after the validation is done.