### PR TITLE
PXB-3281 : With lock-ddl=REDUCED, STL containers used by reduced code…

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -11618,7 +11618,7 @@ std::tuple<dberr_t, space_id_t> fil_open_for_xtrabackup(
     xb::error() << "Failed to open tablespace " << space->name;
   } else if (ddl_tracker) {
     /* Note that we have opened and loaded the table to cache for copying */
-    ddl_tracker->add_table(space_id, path);
+    ddl_tracker->add_table_from_ibd_scan(space_id, path);
   }
 
   if (!srv_backup_mode || srv_close_files) {

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -30,80 +30,34 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 void ddl_tracker_t::backup_file_op(uint32_t space_id, mlog_id_t type,
                                    const byte *buf, ulint len,
                                    lsn_t start_lsn) {
-  // TODO: Do we need a mutex here?
-  // this will be populated by redo log parsing thread, which is single threaded
-  // this will be read by main thread once we are under LTFB/LIFB
-  // so no new entry will be added
   byte *ptr = (byte *)buf;
-  ulint name_len;
-  char *name;
-  std::string old_space_name, new_space_name;
   switch (type) {
-    case MLOG_FILE_CREATE:
+    case MLOG_FILE_CREATE: {
       assert(len > 6);
       ptr += 4;  // flags
       ptr += 2;  // len
-      name = reinterpret_cast<char *>(ptr);
-      new_space_name = name;
-      Fil_path::normalize(new_space_name);
-      if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
-        new_space_name.erase(0, 2);
-      }
-      new_tables[space_id] = new_space_name;
-      xb::info() << "DDL tracking : LSN: " << start_lsn
-                 << " create table ID: " << space_id
-                 << " Name: " << new_space_name;
-      break;
-    case MLOG_FILE_RENAME:
-      name_len = mach_read_from_2(ptr);
+      const char *name = reinterpret_cast<char *>(ptr);
+      add_create_table_from_redo(space_id, start_lsn, name);
+    } break;
+    case MLOG_FILE_RENAME: {
+      ulint name_len = mach_read_from_2(ptr);
       ptr += 2;  // from len
-      name = reinterpret_cast<char *>(ptr);
-      old_space_name = name;
+      const char *old_name = reinterpret_cast<char *>(ptr);
       ptr += name_len;  // from name
       ptr += 2;         // to len
-      name = reinterpret_cast<char *>(ptr);
-      new_space_name = name;
-      Fil_path::normalize(old_space_name);
-      Fil_path::normalize(new_space_name);
-      if (Fil_path::has_prefix(old_space_name, Fil_path::DOT_SLASH)) {
-        old_space_name.erase(0, 2);
-      }
-      if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
-        new_space_name.erase(0, 2);
-      }
-
-      if (renames.find(space_id) != renames.end()) {
-        renames[space_id].second = new_space_name;
-      } else {
-        renames[space_id] = std::make_pair(old_space_name, new_space_name);
-      }
-      xb::info() << "DDL tracking : LSN: " << start_lsn
-                 << " rename table ID: " << space_id
-                 << " From: " << old_space_name << " To: " << new_space_name;
-      break;
-    case MLOG_FILE_DELETE:
+      const char *new_name = reinterpret_cast<char *>(ptr);
+      add_rename_table_from_redo(space_id, start_lsn, old_name, new_name);
+    } break;
+    case MLOG_FILE_DELETE: {
       ptr += 2;  // len
-      name = reinterpret_cast<char *>(ptr);
-      new_space_name = name;
-      Fil_path::normalize(new_space_name);
-      if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
-        new_space_name.erase(0, 2);
-      }
-      drops[space_id] = new_space_name;
-
-      xb::info() << "DDL tracking : LSN: " << start_lsn
-                 << " delete table ID: " << space_id
-                 << " Name: " << new_space_name;
-      break;
+      const char *name = reinterpret_cast<char *>(ptr);
+      add_drop_table_from_redo(space_id, start_lsn, name);
+    } break;
     case MLOG_INDEX_LOAD:
-      add_to_recopy_tables(space_id);
-      xb::info() << "DDL tracking : LSN: " << start_lsn
-                 << " direct write on table ID: " << space_id;
+      add_to_recopy_tables(space_id, start_lsn, "add index");
       break;
     case MLOG_WRITE_STRING:
-      add_to_recopy_tables(space_id);
-      xb::info() << "DDL tracking :  LSN: " << start_lsn
-                 << " encryption operation on table ID: " << space_id;
+      add_to_recopy_tables(space_id, start_lsn, "encryption");
       break;
     default:
 #ifdef UNIV_DEBUG
@@ -113,11 +67,14 @@ void ddl_tracker_t::backup_file_op(uint32_t space_id, mlog_id_t type,
   }
 }
 
-void ddl_tracker_t::add_table(const space_id_t &space_id, std::string name) {
+void ddl_tracker_t::add_table_from_ibd_scan(const space_id_t space_id,
+                                            std::string name) {
   Fil_path::normalize(name);
   if (Fil_path::has_prefix(name, Fil_path::DOT_SLASH)) {
     name.erase(0, 2);
   }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
   tables_in_backup[space_id] = name;
 }
 
@@ -128,9 +85,12 @@ void ddl_tracker_t::add_corrupted_tablespace(const space_id_t space_id,
   corrupted_tablespaces[space_id] = path;
 }
 
-void ddl_tracker_t::add_to_recopy_tables(space_id_t space_id) {
+void ddl_tracker_t::add_to_recopy_tables(space_id_t space_id, lsn_t start_lsn,
+                                         const std::string operation) {
   std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
   recopy_tables.insert(space_id);
+  xb::info() << "DDL tracking : LSN: " << start_lsn << " " << operation
+             << " on space ID: " << space_id;
 }
 
 void ddl_tracker_t::add_missing_table(std::string path) {
@@ -138,7 +98,66 @@ void ddl_tracker_t::add_missing_table(std::string path) {
   if (Fil_path::has_prefix(path, Fil_path::DOT_SLASH)) {
     path.erase(0, 2);
   }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
   missing_tables.insert(path);
+}
+void ddl_tracker_t::add_create_table_from_redo(const space_id_t space_id,
+                                               lsn_t start_lsn,
+                                               const char *name) {
+  std::string new_space_name = name;
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, 2);
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  new_tables[space_id] = new_space_name;
+  xb::info() << "DDL tracking : LSN: " << start_lsn
+             << " create space ID: " << space_id << " Name: " << new_space_name;
+}
+
+void ddl_tracker_t::add_rename_table_from_redo(const space_id_t space_id,
+                                               lsn_t start_lsn,
+                                               const char *old_name,
+                                               const char *new_name) {
+  std::string old_space_name{old_name};
+  std::string new_space_name{new_name};
+
+  Fil_path::normalize(old_space_name);
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(old_space_name, Fil_path::DOT_SLASH)) {
+    old_space_name.erase(0, 2);
+  }
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, 2);
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  if (renames.find(space_id) != renames.end()) {
+    renames[space_id].second = new_space_name;
+  } else {
+    renames[space_id] = std::make_pair(old_space_name, new_space_name);
+  }
+  xb::info() << "DDL tracking : LSN: " << start_lsn
+             << " rename space ID: " << space_id << " From: " << old_space_name
+             << " To: " << new_space_name;
+}
+
+void ddl_tracker_t::add_drop_table_from_redo(const space_id_t space_id,
+                                             lsn_t start_lsn,
+                                             const char *name) {
+  std::string new_space_name{name};
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, 2);
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  drops[space_id] = new_space_name;
+
+  xb::info() << "DDL tracking : LSN: " << start_lsn
+             << " delete space ID: " << space_id << " Name: " << new_space_name;
 }
 
 bool ddl_tracker_t::is_missing_table(const std::string &name) {
@@ -154,6 +173,7 @@ void ddl_tracker_t::add_renamed_table(const space_id_t &space_id,
   if (Fil_path::has_prefix(new_name, Fil_path::DOT_SLASH)) {
     new_name.erase(0, 2);
   }
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
   renamed_during_scan[space_id] = new_name;
 }
 

--- a/storage/innobase/xtrabackup/src/ddl_tracker.h
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.h
@@ -57,7 +57,29 @@ class ddl_tracker_t {
   /** Add a new table in the DDL tracker table list.
    @param[in]	space_id	tablespace identifier
    @param[in]	name      tablespace name */
-  void add_table(const space_id_t &space_id, std::string name);
+  void add_table_from_ibd_scan(const space_id_t space_id, std::string name);
+
+  /** Track a new table from the MLOG_FILE_CREATE redo log record
+   @param[in]	space_id	tablespace identifier
+   @param[in]	start_lsn LSN of redo record
+   @param[in]	name      tablespace name */
+  void add_create_table_from_redo(const space_id_t space_id, lsn_t start_lsn,
+                                  const char *name);
+
+  /** Track tables from the MLOG_FILE_RENAME redo log record
+   @param[in]	space_id	tablespace identifier
+   @param[in]	start_lsn LSN of redo record
+   @param[in]	old_name  RENAME from name
+   @param[in]	new_name  RENAME to name */
+  void add_rename_table_from_redo(const space_id_t space_id, lsn_t start_lsn,
+                                  const char *old_name, const char *new_name);
+
+  /** Track tables from the MLOG_FILE_DELTE redo log record
+   @param[in]	space_id	tablespace identifier
+   @param[in]	start_lsn LSN of redo record
+   @param[in]	name      RENAME to name */
+  void add_drop_table_from_redo(const space_id_t space_id, lsn_t start_lsn,
+                                const char *name);
 
   /** Add a table to the corrupted tablespace list. The list is later
   converted to  tablespacename.ibd.corrupt files on disk
@@ -70,7 +92,8 @@ class ddl_tracker_t {
   1. had ADD INDEX while the backup is in progress
   2. tablespace encryption change from 'y' to 'n' or viceversa
   @param[in] space_id Tablespace id  */
-  void add_to_recopy_tables(space_id_t space_id);
+  void add_to_recopy_tables(space_id_t space_id, lsn_t start_lsn,
+                            const std::string operation);
 
   /** Report an operation to create, delete, or rename a file during backup.
   @param[in]	space_id	tablespace identifier

--- a/storage/innobase/xtrabackup/test/suites/lockless/basic_operation.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/basic_operation.sh
@@ -67,19 +67,19 @@ function run_test() {
   kill -SIGCONT $xb_pid
   run_cmd wait $job_pid
 
-  if ! egrep -q "DDL tracking : LSN: [0-9]* delete table ID: [0-9]* Name: test/${DELETE_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+  if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/${DELETE_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
      die "xtrabackup did not handle delete table DDL"
   fi
 
-  if ! egrep -q "DDL tracking : LSN: [0-9]* create table ID: [0-9]* Name: test/${NEW_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+  if ! egrep -q "DDL tracking : LSN: [0-9]* create space ID: [0-9]* Name: test/${NEW_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
      die "xtrabackup did not handle new table DDL"
   fi
 
-  if ! egrep -q "DDL tracking : LSN: [0-9]* rename table ID: [0-9]* From: test/${ORIGINAL_TABLE_IN_DISK}.ibd To: test/${RENAMED_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+  if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/${ORIGINAL_TABLE_IN_DISK}.ibd To: test/${RENAMED_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
      die "xtrabackup did not handle rename table DDL"
   fi
 
-  if ! egrep -q "DDL tracking : LSN: [0-9]* direct write on table ID: [0-9]*" $topdir/backup_with_new_table.log ; then
+  if ! egrep -q "DDL tracking : LSN: [0-9]* add index on space ID: [0-9]*" $topdir/backup_with_new_table.log ; then
      die "xtrabackup did not handle Bulk Index Load DDL"
   fi
 

--- a/storage/innobase/xtrabackup/test/suites/lockless/ddl_between_discovery_and_file_open.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/ddl_between_discovery_and_file_open.sh
@@ -40,15 +40,15 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-if ! egrep -q "DDL tracking : LSN: [0-9]* delete table ID: [0-9]* Name: test/drop_table.ibd" $topdir/backup.log ; then
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $topdir/backup.log ; then
     die "xtrabackup did not handle delete table DDL"
 fi
 
-if ! egrep -q "DDL tracking : LSN: [0-9]* rename table ID: [0-9]* From: test/rename_table.ibd To: test/new_rename_table.ibd" $topdir/backup.log ; then
+if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/rename_table.ibd To: test/new_rename_table.ibd" $topdir/backup.log ; then
     die "xtrabackup did not handle rename table DDL"
 fi
 
-if ! egrep -q "DDL tracking : LSN: [0-9]* rename table ID: [0-9]* From: test/alter_rename_table.ibd To: test/new_alter_rename_table.ibd" $topdir/backup.log ; then
+if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/alter_rename_table.ibd To: test/new_alter_rename_table.ibd" $topdir/backup.log ; then
     die "xtrabackup did not handle alter table rename DDL"
 fi
 
@@ -85,7 +85,7 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $XB_PID
 run_cmd wait $XB_PID
 
-if ! egrep -q "DDL tracking : LSN: [0-9]* delete table ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
     die "xtrabackup did not handle delete table DDL"
 fi
 
@@ -123,7 +123,7 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $XB_PID
 run_cmd wait $XB_PID
 
-if ! egrep -q "DDL tracking : LSN: [0-9]* delete table ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
     die "xtrabackup did not handle delete table DDL"
 fi
 

--- a/storage/innobase/xtrabackup/test/suites/lockless/rename_table_different_database.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/rename_table_different_database.sh
@@ -30,7 +30,7 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 # Ensure we have DDL tracking in the log renaming the table
-if ! egrep -q 'DDL tracking : LSN: [0-9]* rename table ID: [0-9]* From: test/original_table.ibd To: test2/renamed_table.ibd' $topdir/backup.log ; then
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/original_table.ibd To: test2/renamed_table.ibd' $topdir/backup.log ; then
     die "xtrabackup did not handle rename table DDL"
 fi
 

--- a/storage/innobase/xtrabackup/test/suites/lockless/rename_table_within_checkpoint_age.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/rename_table_within_checkpoint_age.sh
@@ -30,7 +30,7 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 # Ensure we have DDL tracking in the log renaming the table
-if ! egrep -q 'DDL tracking : LSN: [0-9]* rename table ID: [0-9]* From: test/original_table.ibd To: test/renamed_table.ibd' $topdir/backup.log ; then
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/original_table.ibd To: test/renamed_table.ibd' $topdir/backup.log ; then
     die "xtrabackup did not handle rename table DDL"
 fi
 

--- a/storage/innobase/xtrabackup/test/suites/lockless/undo.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/undo.sh
@@ -57,11 +57,11 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-if ! egrep -q 'DDL tracking : LSN: [0-9]* delete table ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
+if ! egrep -q 'DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
     die "xtrabackup did not handle delete table DDL"
 fi
 
-if ! egrep -q 'DDL tracking : LSN: [0-9]* create table ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
+if ! egrep -q 'DDL tracking : LSN: [0-9]* create space ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
     die "xtrabackup did not handle new table DDL"
 fi
 


### PR DESCRIPTION
… are not thread safe

Problem:
-------
xtrabackup uses multiple threads to scan the *.ibd files. With lock-ddl=reduced, we use several STL maps to track of missing, dropped or renamed tables.

Multiple threads are used only when number of IBDs are more than 8K

Unsafe calls:
  ddl_tracker->add_missing_table(phy_filename);
  ddl_tracker->add_renamed_table(space_id, path);

These calls from multiple threads operate on std::map/unordered_map and can cause race conditions.

Fix:
----
1. stream line mutex usage for entire ddl_tracker class. Currently used only for corrupted STL map.
2. Use space id instead of table id in messages
3. Rename add_table() since the name is confusing. Actual map elements should be renamed. it will be done later