### PR TITLE
PXB-3295 : Undo tablespaces are not tracked properly with lock-ddl=RE…

### DIFF
--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -2240,12 +2240,13 @@ void fil_set_scan_dir(const std::string &directory, bool is_undo_dir = false);
 void fil_set_scan_dirs(const std::string &directories);
 
 /** Discover tablespaces by reading the header from .ibd files.
-@param[in]  populate_fil_cache Whether to load tablespaces into fil cache
-@param[in]  is_prep_handle_ddls Whether loading tablespaces on prepare phase
-                                to handle the ddls
+@param[in] populate_fil_cache  Whether to load tablespaces into fil cache
+@param[in] is_prep_handle_ddls Whether loading tablespaces on prepare phase
+                               to handle the ddls
+@param[in] only_undo           if true, only the undo tablespaces are discovered
 @return DB_SUCCESS if all goes well */
 dberr_t fil_scan_for_tablespaces(bool populate_fil_cache,
-                                 bool is_prep_handle_ddls);
+                                 bool is_prep_handle_ddls, bool only_undo);
 
 /** Open the tablespace and also get the tablespace filenames, space_id must
 already be known.

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3708,8 +3708,8 @@ void Dir_Walker::walk_posix(const Path &basedir, bool recursive, Function &&f) {
         continue;
       }
 
-      if (file_type == OS_FILE_TYPE_DIR && recursive) {
-        directories.push(Entry(path, current.m_depth + 1));
+      if (file_type == OS_FILE_TYPE_DIR) {
+        if (recursive) directories.push(Entry(path, current.m_depth + 1));
       } else {
         f(path, current.m_depth + 1);
       }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -657,10 +657,12 @@ dberr_t srv_undo_tablespace_open(undo::Tablespace &undo_space) {
   }
 
   DBUG_EXECUTE_IF(
-      "undo_space_open",
-      if (strncmp(file_name, "./undo_1.ibu", strlen("./undo_1.ibu")) == 0) {
-        *const_cast<const char **>(&xtrabackup_debug_sync) = "undo_space_open";
-        debug_sync_point("undo_space_open");
+      "undo_space_open", if (!is_server_locked()) {
+        if (strncmp(file_name, "./undo_1.ibu", strlen("./undo_1.ibu")) == 0) {
+          *const_cast<const char **>(&xtrabackup_debug_sync) =
+              "undo_space_open";
+          debug_sync_point("undo_space_open");
+        }
       });
 
   /* Now that space and node exist, make sure this undo tablespace

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -271,9 +271,9 @@ std::string ddl_tracker_t::convert_file_name(space_id_t space_id,
 }
 
 // Helper function to print the contents of a vector of pairs
-void printVector(const filevec &vec) {
+void printVector(const std::string &operation, const filevec &vec) {
   for (const auto &element : vec) {
-    xb::info() << element.first << ": " << element.second << " ";
+    xb::info() << operation << element.first << " : " << element.second << " ";
   }
 }
 
@@ -328,10 +328,10 @@ std::tuple<filevec, filevec> ddl_tracker_t::handle_undo_ddls() {
 
   // Print the results
   xb::info() << "New UNDO files: ";
-  printVector(newfiles);
+  printVector("New undo file: ", newfiles);
 
   xb::info() << "Deleted or truncated UNDO files: ";
-  printVector(deletedOrChangedFiles);
+  printVector("Deleted undo file: ", deletedOrChangedFiles);
 
   return {newfiles, deletedOrChangedFiles};
 }

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -342,4 +342,6 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
 @param[in,out]	buf		log header buffer
 @param[in]	lsn		lsn to update */
 void update_log_temp_checkpoint(byte *buf, lsn_t lsn);
+
+void xb_scan_for_tablespaces(bool is_prep_handle_ddls, bool only_undo);
 #endif /* XB_XTRABACKUP_H */

--- a/storage/innobase/xtrabackup/test/suites/lockless/undo.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/undo.sh
@@ -54,11 +54,11 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-if ! egrep -q 'DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
+if ! egrep -q 'Deleted undo file: ./undo_1.ibu : [0-9]*' $topdir/backup.log ; then
     die "xtrabackup did not handle delete table DDL"
 fi
 
-if ! egrep -q 'DDL tracking : LSN: [0-9]* create space ID: [0-9]* Name: undo_1.ibu' $topdir/backup.log ; then
+if ! egrep -q 'New undo file: ./undo_1.ibu : [0-9]*' $topdir/backup.log ; then
     die "xtrabackup did not handle new table DDL"
 fi
 

--- a/storage/innobase/xtrabackup/test/suites/lockless/undo_2.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/undo_2.sh
@@ -1,0 +1,116 @@
+########################################################################
+# PXB-3295 : Undo tablespaces are not tracked properly with lock-ddl=REDUCED
+########################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+echo
+echo PXB-3295 : Undo tablespaces are not tracked properly
+echo
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_3 ADD DATAFILE 'undo_3.ibu'"
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$BACKUP_DIR \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $XB_ERROR_LOG)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+UNDO_2_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "ALTER UNDO TABLESPACE UNDO_2 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 1
+UNDO_2_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "DROP UNDO TABLESPACE UNDO_2"
+
+# before inactive
+UNDO_3_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_3 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 2
+
+# after inactive
+UNDO_3_AI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "CREATE UNDO TABLESPACE UNDO_4 ADD DATAFILE 'undo_4.ibu'"
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+UNDO_1_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_1'")
+UNDO_4_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_4'")
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+stop_server
+
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+
+UNDO_BACKUP_1_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_1'")
+UNDO_BACKUP_2_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_2'")
+UNDO_BACKUP_3_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+UNDO_BACKUP_4_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_4'")
+
+echo "UNDO_1 space_id is $UNDO_BACKUP_1_SPACE_ID"
+echo "UNDO_2 space_id is $UNDO_BACKUP_2_SPACE_ID"
+echo "UNDO_3 space_id is $UNDO_BACKUP_3_SPACE_ID"
+echo "UNDO_4 space_id is $UNDO_BACKUP_4_SPACE_ID"
+
+# UNDO_1 no space_id change
+if [ $UNDO_1_SPACE_ID != $UNDO_BACKUP_1_SPACE_ID ]; then
+ echo "space_id of undo_01 shouldn't have changed. Before backup: undo_1 space_id $UNDO_1_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_1_SPACE_ID"
+ exit 1
+fi
+
+## UNDO_4 no space_id change. If we get this it means undo_04 is copied.
+#FILE=$BACKUP_DIR/undo_4.ibu
+#[ -f $FILE ] || die "$FILE did NOT exist. It should have been backuped. It is created before end of backup. Server did CREATE UNDO TABLESPACE undo_04, right before DDL lock is taken"
+#
+#if [ -z ${UNDO_BACKUP_4_SPACE_ID+x} ]; then
+# echo "UNDO TABLESPACE 4 should have been present in backup. But it is not found."
+# exit 1
+#if
+#
+#if [ $UNDO_4_SPACE_ID != $UNDO_BACKUP_4_SPACE_ID ]; then
+# echo "space_id of undo_04 shouldn't have changed. Before backup: undo_4 space_id $UNDO_4_SPACE_ID. After backup and restore undo_4 space_id is $UNDO_BACKUP_4_SPACE_ID"
+# exit 1
+#fi
+
+# UND0_3 should have AI space_id and not BI space_id
+if [ $UNDO_3_AI_SPACE_ID != $UNDO_BACKUP_3_SPACE_ID ]; then
+ echo "space_id of undo_03 should have space_id after truncation. space_id at time of the backup: undo_3 space_id $UNDO_3_AF_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_3_SPACE_ID"
+ exit 1
+fi
+
+# UNDO_3 shouldn't have space_id before truncation
+if [ $UNDO_3_BI_SPACE_ID == $UNDO_BACKUP_3_SPACE_ID ]; then
+ echo "space_id of undo_03 should NOT have space_id before truncation. space_id  before_truncation undo_3 space_id $UNDO_3_BI_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_3_SPACE_ID"
+ exit 1
+fi
+
+FILE=$BACKUP_DIR/undo_2.ibu
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server did DROP UNDO TABLESPACE undo_02"
+
+# UNDO_2 should be empty because it was dropped. We should also check physical presence of undo_02.ibu file
+if [ ! -z "${UNDO_BACKUP_2_SPACE_ID}" ]; then
+ echo "UNDO TABLESPACE 2 should have been dropped in backup. Found UNDO_2 with space_id: $UNDO_BACKUP_2_SPACE_ID"
+ exit 1
+fi
+
+
+stop_server
+
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG


### PR DESCRIPTION
…DUCED

Problem:
--------
1.
Undo tablespaces are not tracked properly. Since undo tablespaces are not opened via fil_open_for_xtrabackup(), they are not tracked as 'copied'. This leads to wrong decisions in handle_ddl_operations.

2.
When new undo tablespaces are created,
Server doesn't write a MLOG_FILE_CREATE record and so these are missed by the tracking system.

Fix:
----
1. track undo tablespaces that xtrabackup copies without lock (before lock state)
2. After lock is taken, undo tablespces are discovered again (after lock state)

With this before and after states, we now determine undo files to be deleted, undo files to be copied. Truncated undo tablespace use different tablespace id, so old undo file is marked as deleted and new version of undo tablespace is copied

For example undo_001.ibu of space_id 10 is truncated, the filename remains same but it space_id becomes 11. xtrabackup creates 11.ibu.del for undo tablespace to be deleted. then undo_001.ibu.new with space_id 11 is copied under lock