### PR TITLE
PXB-3221 : Assertion failure: page0cur.cc:1177:ib::fatal triggered du…

### DIFF
--- a/storage/innobase/fsp/fsp0sysspace.cc
+++ b/storage/innobase/fsp/fsp0sysspace.cc
@@ -942,6 +942,12 @@ dberr_t SysTablespace::open_or_create(bool is_temp, bool create_new_db,
     }
   }
 
+  // Add system tablespace for tracking purpose. We might have
+  // to recopy it
+  if (ddl_tracker && opt_lock_ddl == LOCK_DDL_REDUCED) {
+    ddl_tracker->add_table_from_ibd_scan(space->id, space->name);
+  }
+
   return (err);
 }
 #endif /* !UNIV_HOTBACKUP */

--- a/storage/innobase/xtrabackup/test/suites/lockless/system_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/suites/lockless/system_tablespace.sh
@@ -1,0 +1,57 @@
+# PXB-3221 : Assertion failure: page0cur.cc:1177:ib::fatal triggered during prepare
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t1(a INT, KEY k1(a)) TABLESPACE=innodb_system;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 VALUES (1),(2),(3),(4)" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+
+innodb_wait_for_flush_all
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$BACKUP_DIR \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $XB_ERROR_LOG)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+mysql -e "ALTER TABLE t1 ADD INDEX k2(a)" test
+mysql -e "ALTER TABLE t1 DROP INDEX k1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+stop_server
+
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+#mysql -e "ALTER TABLE t1 DROP INDEX k1" test
+mysql -e "DELETE FROM t1 WHERE a = 2" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+mysql -e "DELETE FROM t1 WHERE a = 2" test
+
+stop_server
+
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG


### PR DESCRIPTION
…ring prepare/or next server startup

Problem:
--------
If there are tables created in system tablespace and if ALTER ADD INDEX/DROP INDEX is executed before the backup lock is taken, system tablespace could end up in corrupted state.

This is because this operation is not redologged and we are supposed to recopy the system tablespace files. But we dont track system tablesapce, neither reopen and recopy them. Hence this issue.

Fix:
----
1. Track system tablespace in the list of tables tracked/backedup
2. Removing tracking for tables in system tablespace except of recopy. Other operations can be played via redolog
3. Reopen system tablespace and recopy them as ibdata1.new/ ibdata2.new