### PR TITLE
PXB-3359 - PXC concurrent backups - metadata lock hang with xtrabackup_history

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1886,7 +1886,7 @@ bool write_xtrabackup_info(MYSQL *connection) {
                                             "WHERE TABLE_SCHEMA = 'PERCONA_SCHEMA' "
                                             "AND TABLE_NAME  = 'xtrabackup_history' "
                                             "AND COLUMN_NAME = 'binlog_pos' "
-                                            "AND DATA_TYPE = 'TEXT'");
+                                            "AND DATA_TYPE = 'text'");
 
   if (strcmp(column_is_changed, "0") == 0) {
     // Only alter table if it's required to avoid requesting metadata lock


### PR DESCRIPTION
Hi Percona,

We have found a hang while executing XtraBackup concurrently in multiple PXC nodes.
We cannot reproduce always the problem, but when it happens we see "metadata lock" in the wsrep_applier thread and the only fix is to kill one of the xtrabackup processes.

The metadata lock corresponds to the "CREATE DATABASE IF NOT EXISTS PERCONA_SCHEMA" statement in XtraBackup code.
It makes us suspect that TOI is causing this issue, because it creates the lock that conflicts with the backup in other nodes, even when the object exists.

**Reproduce Scenario**
PXC - 3 nodes
Execute XtraBackup with xtrabackup_history enabled, full backup, in all 3 at the same time

**Fix**
Execute DDL only if the object doesn't exist.

1. Check if database PERCONA_SCHEMA exists - Create if not
2. Check if table XTRABACKUP_HISTORY exists - Create if not
3. Check if column BINLOG_POS has the required type - Alter if not (I believe we don't need this migration anymore)

With those changes the hang is not happening anymore. I will raise a pull request so you can review them.