### PR TITLE
Fix authentication for Azure API in xbcloud

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -197,8 +197,6 @@ void Azure_signer::sign_request(const std::string &container,
 
   std::string decoded_access_key = base64_decode(access_key);
 
-  trim(decoded_access_key);
-
   auto signature =
       base64_encode(hmac_sha256(decoded_access_key, string_to_sign));
 

--- a/storage/innobase/xtrabackup/src/xbcloud/util.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/util.h
@@ -132,14 +132,15 @@ std::string base64_encode(const T &s) {
 
 template <typename T>
 std::string base64_decode(const T &s) {
-  uint64 decoded_size = ::base64_needed_decoded_length(s.size());
-  std::unique_ptr<char[]> buf(new char[decoded_size]);
+  uint64 max_decoded_size = ::base64_needed_decoded_length(s.size());
+  std::unique_ptr<char[]> buf(new char[max_decoded_size]);
 
-  if (::base64_decode(&s[0], s.size(), buf.get(), NULL, 0) == 0) {
+  auto decoded_size = ::base64_decode(&s[0], s.size(), buf.get(), NULL, 0);
+  if (decoded_size <= 0) {
     return std::string();
   }
 
-  return std::string(buf.get());
+  return std::string(buf.get(), decoded_size);
 }
 
 template <typename T>

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
@@ -558,15 +558,15 @@ TEST(azure_signer, basicDNS) {
   req.append_payload("test", 4);
   Azure_signer signer(
       "my-storage-account",
-      "zUfvsKXc6+2RMJCwvnElnG/"
-      "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/b3OAg==",
+      "zUfvsKXcAO2RMJCwvnElnG/"
+      "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/i3ODQ==",
       0);
   signer.sign_request("mycontainer", "myblob", req, 1555892546);
 
   ASSERT_STREQ(
       req.headers().at("Authorization").c_str(),
       "SharedKey "
-      "my-storage-account:uZABJWDbfXO/SuDZbxrJnd00kCDV61cevqi423k21A4=");
+      "my-storage-account:3RNUoT7aggagRnzDebBh1JDGhJocV0e2MKb9ChNvAcM=");
 }
 
 TEST(azure_signer, storageClass) {
@@ -579,13 +579,13 @@ TEST(azure_signer, storageClass) {
   req.append_payload("test", 4);
   Azure_signer signer(
       "my-storage-account",
-      "zUfvsKXc6+2RMJCwvnElnG/"
-      "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/i3OAg==",
+      "zUfvsKXcAO2RMJCwvnElnG/"
+      "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/i3ODQ==",
       0, "storage_class");
   signer.sign_request("mycontainer", "myblob", req, 1555892546);
 
   ASSERT_STREQ(
       req.headers().at("Authorization").c_str(),
       "SharedKey "
-      "my-storage-account:vq5FiJaSj9mrTxeEyp3RRfptEFug4PEozawQG5A+ZHs=");
+      "my-storage-account:b/lbriWK8eQ9uMx97nP0vR894wm+oYsq99Sz0JoH/9k=");
 }


### PR DESCRIPTION
There was a problem when an Azure key contained a null byte, the result when decoding base64 was trimmed and part of the key was lost.

Also if the decoded binary key started or ended with white space, some bytes would be discarded.

This PR fixes both problems