### PR TITLE
fix: ignore chunks too short OR not not seems to pattern .00...N

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1038,10 +1038,16 @@ cleanup:
 @return true in case of success or false otherwise */
 bool chunk_name_to_file_name(const std::string &chunk_name,
                              std::string &file_name, my_off_t &idx) {
-  if (chunk_name.size() < 22 && chunk_name[chunk_name.size() - 21] != '.') {
+  if (chunk_name.size() < 22 || chunk_name[chunk_name.size() - 21] != '.') {
     /* chunk name is invalid */
     return false;
   }
+  auto slash_pos = chunk_name.find('/');
+  if (slash_pos && chunk_name.size() - slash_pos < 22) {
+    /* '/' must be placed left side from '.' */
+    return false;
+  }
+
   file_name = chunk_name.substr(0, chunk_name.size() - 21);
   idx = atoll(&chunk_name.c_str()[chunk_name.size() - 20]);
   return true;


### PR DESCRIPTION
I tried download backup from S3 and got error:
```
> GET /racktables-mysql-backup/20.00000000000000000000 HTTP/1.1
< HTTP/1.1 404 Not Found
xbcloud: S3 error message: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Resource>/racktables-mysql-backup/20.00000000000000000000</Resource><RequestId>07abc2ecb27c437f</RequestId></Error>
xbcloud: Download failed. Cannot download 20.00000000000000000000.
```


Some debug output for chunks processing:
```
241107 10:12:15 xbcloud: add key: '20241105-shrinked2/ddl_log.log.qp.00000000000000000001' 
241107 10:12:15 xbcloud: add key: '20241105-shrinked2/done' 
241107 10:12:15 xbcloud: add key: '20241105-shrinked2/ib_buffer_pool.qp.00000000000000000000' 
-- 
241107 10:12:15 xbcloud: Check chunk: '20241105-shrinked2/ddl_log.log.qp.00000000000000000001' 
241107 10:12:15 xbcloud: Append chunk: '20241105-shrinked2/ddl_log.log.qp' : 1 
241107 10:12:15 xbcloud: Check chunk: '20241105-shrinked2/done' 
241107 10:12:15 xbcloud: Append chunk: '20' : 41105
```

Chunk name '20241105-shrinked2/done' has 23 chars (but not contains '.'), so it splits to filename '20' and idx '241105-shrinked2/done', then atoll cast idx to '241105'.

File 'done' uploaded to bucket by my backup script as finish-flag.

I append checks for right placement for `/` also:  it must be left side of '.'