### PR TITLE
PXB-3269 : Reduce the time the Server is locked by xtrabackup

### DIFF
--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -122,9 +122,17 @@ dberr_t Datafile::open_read_only(bool strict) {
   }
 
   set_open_flags(OS_FILE_OPEN);
+
+#ifdef XTRABACKUP
+  m_handle = os_file_create(
+      innodb_data_file_key, m_filepath,
+      OS_FILE_OPEN | OS_FILE_ON_ERROR_SILENT | OS_FILE_ON_ERROR_NO_EXIT,
+      OS_FILE_NORMAL, OS_DATA_FILE, OS_FILE_READ_ONLY, &success);
+#else
   m_handle = os_file_create_simple_no_error_handling(
       innodb_data_file_key, m_filepath, m_open_flags, OS_FILE_READ_ONLY, true,
       &success);
+#endif /* XTRABACKUP */
 
   if (success) {
     m_exists = true;
@@ -666,17 +674,13 @@ dberr_t Datafile::validate_first_page(space_id_t space_id, lsn_t *flush_lsn,
       bool found = false;
 
       if (srv_backup_mode) {
-        mutex_enter(&recv_sys->mutex);
-        if (recv_sys->keys != nullptr) {
-          for (const auto &recv_key : *recv_sys->keys) {
-            if (recv_key.space_id == m_space_id) {
-              memcpy(m_encryption_key, recv_key.ptr, Encryption::KEY_LEN);
-              memcpy(m_encryption_iv, recv_key.iv, Encryption::KEY_LEN);
-              found = true;
-            }
-          }
+        recv_sys_t::Encryption_Key *recv_key = nullptr;
+        std::tie(found, recv_key) = recv_find_encryption_key(m_space_id);
+
+        if (found) {
+          memcpy(m_encryption_key, recv_key->ptr, Encryption::KEY_LEN);
+          memcpy(m_encryption_iv, recv_key->iv, Encryption::KEY_LEN);
         }
-        mutex_exit(&recv_sys->mutex);
       }
 
       if (!found) {

--- a/storage/innobase/fsp/fsp0sysspace.cc
+++ b/storage/innobase/fsp/fsp0sysspace.cc
@@ -929,6 +929,14 @@ dberr_t SysTablespace::open_or_create(bool is_temp, bool create_new_db,
     }
   }
 
+#ifdef XTRABACKUP
+  // Add system tablespace for tracking purpose. We might have
+  // to recopy it
+  if (ddl_tracker && opt_lock_ddl == LOCK_DDL_REDUCED && !is_server_locked()) {
+    ddl_tracker->add_table_from_ibd_scan(space->id, space->name, space->flags);
+  }
+#endif /* XTRABACKUP */
+
   return (err);
 }
 #endif /* !UNIV_HOTBACKUP */

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -796,6 +796,9 @@ bool recv_sys_resize_buf();
 hash table to wait merging to file pages. */
 void recv_parse_log_recs();
 
+std::tuple<bool, recv_sys_t::Encryption_Key *> recv_find_encryption_key(
+    space_id_t space_id);
+
 #include "log0recv.ic"
 
 #endif

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -1844,10 +1844,14 @@ class Dir_Walker {
  public:
   using Path = std::string;
 
+#ifdef XTRABACKUP
+  static std::tuple<bool, os_file_type_t> is_directory(const Path &path);
+#else
   /** Check if the path is a directory. The file/directory must exist.
   @param[in]    path            The path to check
   @return true if it is a directory */
   static bool is_directory(const Path &path);
+#endif /* XTRABACKUP */
 
   /** Depth first traversal of the directory starting from basedir
   @param[in]  basedir    Start scanning from this directory

--- a/storage/innobase/include/xb0xb.h
+++ b/storage/innobase/include/xb0xb.h
@@ -20,13 +20,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #ifndef xb0xb_h
 #define xb0xb_h
+#include "storage/innobase/xtrabackup/src/ddl_tracker.h"
 
 extern bool innodb_log_checksums_specified;
 extern bool innodb_checksum_algorithm_specified;
 
 extern bool opt_lock_ddl_per_table;
-extern bool opt_lock_ddl;
 extern bool redo_catchup_completed;
+extern bool xtrabackup_prepare;
 extern bool opt_page_tracking;
 extern char *xtrabackup_incremental;
 extern lsn_t incremental_start_checkpoint_lsn;
@@ -34,7 +35,10 @@ extern lsn_t xtrabackup_start_checkpoint;
 extern bool use_dumped_tablespace_keys;
 extern unsigned long xb_backup_version;
 extern bool xb_generated_redo;
+enum lock_ddl_type_t { LOCK_DDL_OFF, LOCK_DDL_ON, LOCK_DDL_REDUCED };
+extern lock_ddl_type_t opt_lock_ddl;
 
+extern ddl_tracker_t *ddl_tracker;
 extern std::vector<ulint> invalid_encrypted_tablespace_ids;
 
 /** Fetch tablespace key from "xtrabackup_keys".
@@ -103,6 +107,21 @@ const std::string KEYRING_NOT_LOADED =
 @param[in]	name	sync point name */
 void debug_sync_point(const char *name);
 
+#ifdef UNIV_DEBUG
+/** Pause xtrabackup thread and wait for resume.
+Thread can be resumed by deleting the sync_point filename
+@param[in]	name	sync point name */
+void debug_sync_thread(const char *name);
+#else
+#define debug_sync_thread(A)
+#endif /* UNIV_DEBUG */
+
 extern char *xtrabackup_debug_sync;
+
+/** @return true if xtrabackup has locked Server with LOCK INSTANCE FOR BACKP or
+LOCK TABLES FOR BACKUP */
+bool is_server_locked();
+
+bool xb_check_and_set_open_files_limit(size_t num_files);
 
 #endif

--- a/storage/innobase/os/os0enc.cc
+++ b/storage/innobase/os/os0enc.cc
@@ -664,7 +664,13 @@ bool Encryption::decode_encryption_info(space_id_t space_id,
     encryption info maybe hasn't written into datafile when
     the table is newly created. For clone encryption information
     should have been already correct. */
-    return (recv_recovery_is_on() ? true : false);
+
+    /* With reduced lock ddl, we open just for space_id and filename mapping.
+    Tolerate missing encryption information */
+
+    bool prep_lock_ddl_reduced =
+        !srv_backup_mode && opt_lock_ddl == LOCK_DDL_REDUCED;
+    return (recv_recovery_is_on() || prep_lock_ddl_reduced ? true : false);
   } else {
     ib::error(ER_IB_MSG_837) << "Failed to decrypt encryption information,"
                              << " found unexpected version of it!";

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -91,6 +91,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 #include "mysqld.h"
 
 #include <sys/types.h>
+#include <xb0xb.h>
 #include <zlib.h>
 #include <ctime>
 #include <functional>
@@ -3154,8 +3155,15 @@ pfs_os_file_t os_file_create_func(const char *name, ulint create_mode,
   int create_flag;
   const char *mode_str = nullptr;
 
-  on_error_no_exit = create_mode & OS_FILE_ON_ERROR_NO_EXIT ? true : false;
-  on_error_silent = create_mode & OS_FILE_ON_ERROR_SILENT ? true : false;
+#ifdef XTRABACKUP
+  if (opt_lock_ddl == LOCK_DDL_REDUCED && !is_server_locked()) {
+    on_error_no_exit = true;
+    on_error_silent = true;
+  } else {
+    on_error_no_exit = create_mode & OS_FILE_ON_ERROR_NO_EXIT ? true : false;
+    on_error_silent = create_mode & OS_FILE_ON_ERROR_SILENT ? true : false;
+  }
+#endif /* XTRABACKUP */
 
   create_mode &= ~OS_FILE_ON_ERROR_NO_EXIT;
   create_mode &= ~OS_FILE_ON_ERROR_SILENT;
@@ -3630,13 +3638,24 @@ void Dir_Walker::walk_posix(const Path &basedir, bool recursive, Function &&f) {
     DIR *parent = opendir(current.m_path.c_str());
 
     if (parent == nullptr) {
-      ib::info(ER_IB_MSG_784) << "Failed to walk directory"
-                              << " '" << current.m_path << "'";
-
+      if (opt_lock_ddl != LOCK_DDL_REDUCED) {
+        ib::info(ER_IB_MSG_784) << "Failed to walk directory"
+                                << " '" << current.m_path << "'";
+      }
       continue;
     }
 
-    if (!is_directory(current.m_path)) {
+    auto [exists, file_type] = is_directory(current.m_path);
+
+    if (!exists) {
+      if (opt_lock_ddl != LOCK_DDL_REDUCED) {
+        ib::info(ER_IB_MSG_784) << "Failed to walk directory"
+                                << " '" << current.m_path << "'";
+      }
+      continue;
+    }
+
+    if (file_type == OS_FILE_TYPE_FILE) {
       f(current.m_path, current.m_depth);
     }
 
@@ -3668,8 +3687,25 @@ void Dir_Walker::walk_posix(const Path &basedir, bool recursive, Function &&f) {
         continue;
       }
 
-      if (is_directory(path) && recursive) {
-        directories.push(Entry(path, current.m_depth + 1));
+      DBUG_EXECUTE_IF(
+          "dir_walker_dbug", if (strncmp(dirent->d_name, "drop_table.ibd",
+                                         strlen("drop_table.ibd")) == 0) {
+            *const_cast<const char **>(&xtrabackup_debug_sync) = "dir_walker";
+
+            debug_sync_point("dir_walker");
+          });
+
+      auto [exists, file_type] = is_directory(path);
+
+      if (!exists) {
+        if (opt_lock_ddl != LOCK_DDL_REDUCED) {
+          ib::info() << "Path: " << path << " is missing ";
+        }
+        continue;
+      }
+
+      if (file_type == OS_FILE_TYPE_DIR) {
+        if (recursive) directories.push(Entry(path, current.m_depth + 1));
       } else {
         f(path, current.m_depth + 1);
       }
@@ -7899,6 +7935,16 @@ void os_file_reset_umask() {
 
 #endif
 
+#ifdef XTRABACKUP
+std::tuple<bool, os_file_type_t> Dir_Walker::is_directory(const Path &path) {
+  os_file_type_t type;
+  bool exists;
+
+  os_file_status(path.c_str(), &exists, &type);
+
+  return {exists, type};
+}
+#else
 /** Check if the path is a directory. The file/directory must exist.
 @param[in]      path            The path to check
 @return true if it is a directory */
@@ -7918,6 +7964,7 @@ bool Dir_Walker::is_directory(const Path &path) {
 
   return (false);
 }
+#endif /* XTRABACKUP */
 
 dberr_t os_file_write_retry(IORequest &type, const char *name,
                             pfs_os_file_t file, const void *buf,

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -357,36 +357,63 @@ static dberr_t srv_undo_tablespace_read_encryption(pfs_os_file_t fh,
   offset = fsp_header_get_encryption_offset(space_page_size);
   ut_ad(offset);
 
-  /* Return if the encryption metadata is empty. */
-  if (!Encryption::is_encrypted_with_v3(first_page + offset)) {
-    ut::aligned_free(first_page);
-    return (DB_SUCCESS);
-  }
+  auto [found, recv_key] = recv_find_encryption_key(space->id);
 
-  if (!use_dumped_tablespace_keys || srv_backup_mode) {
+  bool is_enc = Encryption::is_encrypted_with_v3(first_page + offset);
+  lsn_t page_lsn = mach_read_from_8(first_page + FIL_PAGE_LSN);
+
+  // Function to set encryption using a given key and iv
+  auto set_encryption = [&](byte *key, byte *iv) -> bool {
+    fsp_flags_set_encryption(space->flags);
+    err = fil_set_encryption(space->id, Encryption::AES, key, iv);
+    ut_ad(err == DB_SUCCESS);
+    return err == DB_SUCCESS;
+  };
+
+  // Function to handle dumped encryption keys
+  auto load_key_from_dump = [&]() -> bool {
+    err = xb_set_encryption(space);
+    return err == DB_SUCCESS;
+  };
+
+  // Function to load encryption key from the page header
+  auto load_key_from_page = [&]() -> bool {
     byte key[Encryption::KEY_LEN];
     byte iv[Encryption::KEY_LEN];
     Encryption_key e_key{key, iv};
+
     if (fsp_header_get_encryption_key(space->flags, e_key, first_page)) {
-      fsp_flags_set_encryption(space->flags);
-      err = fil_set_encryption(space->id, Encryption::AES, key, iv);
-      ut_ad(err == DB_SUCCESS);
-    } else {
-      ut::aligned_free(first_page);
-      return (DB_FAIL);
+      return set_encryption(key, iv);
     }
+    return false;
+  };
+
+  bool encryption_success = false;
+
+  if (found && recv_key->lsn >= page_lsn) {
+    // Condition 1: Use key from redo if available and appropriate
+    encryption_success = use_dumped_tablespace_keys
+                             ? load_key_from_dump()
+                             : set_encryption(recv_key->ptr, recv_key->iv);
+  } else if (is_enc) {
+    // Condition 2: Page is encrypted
+    encryption_success = (use_dumped_tablespace_keys && !srv_backup_mode)
+                             ? load_key_from_dump()
+                             : load_key_from_page();
   } else {
-    err = xb_set_encryption(space);
-    if (err != DB_SUCCESS) {
-      ut::aligned_free(first_page);
-      return (DB_FAIL);
-    }
+    // Condition 3: If the page is not encrypted, we consider it successful
+    encryption_success = true;
   }
 
+  // Free the allocated memory and return the result
   ut::aligned_free(first_page);
-  ib::info(ER_IB_MSG_UNDO_ENCRYPTION_INFO_LOADED, space->name);
 
-  return (DB_SUCCESS);
+  if (encryption_success) {
+    ib::info(ER_IB_MSG_UNDO_ENCRYPTION_INFO_LOADED, space->name);
+    return (DB_SUCCESS);
+  } else {
+    return (DB_FAIL);
+  }
 }
 
 /** Fix up a v5.7 type undo tablespace that was being truncated.
@@ -435,18 +462,18 @@ static dberr_t srv_undo_tablespace_fixup_num(space_id_t space_num) {
   }
 #ifdef XTRABACKUP
   if (srv_backup_mode) {
-    if (opt_lock_ddl) {
-      xb::warn() << "Found _trunc.log in server dirctory. ";
-      return (DB_SUCCESS);
-    } else {
+    if (opt_lock_ddl == LOCK_DDL_OFF) {
       xb::error()
           << "Found _trunc.log file in server directory. Undo truncation might "
              "be concurrently running, Try backup after undo truncation is "
              "complete. These *_trunc.log could be left over from previous "
              "undo truncation, remove them safely to continue backup. You can "
-             "also run backup with --lock-ddl=true that blocks concurrent undo "
+             "also run backup with --lock-ddl=ON that blocks concurrent undo "
              "truncation";
       return (DB_ERROR);
+    } else {
+      xb::warn() << "Found _trunc.log in server directory. ";
+      return (DB_SUCCESS);
     }
   }
 #endif
@@ -617,13 +644,25 @@ dberr_t srv_undo_tablespace_open(undo::Tablespace &undo_space) {
     ut_a(size != (os_offset_t)-1);
     page_no_t n_pages = static_cast<page_no_t>(size / UNIV_PAGE_SIZE);
 
-    if (fil_node_create(file_name, n_pages, space, false, atomic_write) ==
-        nullptr) {
+#ifdef XTRABACKUP
+    DBUG_EXECUTE_IF(
+        "undo_create_node",
+        if (strncmp(file_name, "./undo_1.ibu", strlen("./undo_1.ibu")) == 0) {
+          *const_cast<const char **>(&xtrabackup_debug_sync) =
+              "undo_create_node";
+          debug_sync_point("undo_create_node");
+        });
+#endif /* XTRABACKUP */
+
+    err = fil_node_create(file_name, n_pages, space, false, atomic_write);
+    if (err != DB_SUCCESS) {
       os_file_close(fh);
 
-      ib::error(ER_IB_MSG_1082, undo_name);
+      fil_space_free(space_id, false);
+      if (opt_lock_ddl != LOCK_DDL_REDUCED)
+        ib::error(ER_IB_MSG_1082, undo_name);
 
-      return (DB_ERROR);
+      return (err);
     }
 
   } else {
@@ -642,9 +681,21 @@ dberr_t srv_undo_tablespace_open(undo::Tablespace &undo_space) {
   ut_ad(success);
 
   if (err != DB_SUCCESS) {
-    ib::error(ER_IB_MSG_1083, undo_name);
+    fil_space_free(space_id, false);
+    if (opt_lock_ddl != LOCK_DDL_REDUCED) ib::error(ER_IB_MSG_1083, undo_name);
     return (err);
   }
+
+#ifdef XTRABACKUP
+  DBUG_EXECUTE_IF(
+      "undo_space_open", if (!is_server_locked()) {
+        if (strncmp(file_name, "./undo_1.ibu", strlen("./undo_1.ibu")) == 0) {
+          *const_cast<const char **>(&xtrabackup_debug_sync) =
+              "undo_space_open";
+          debug_sync_point("undo_space_open");
+        }
+      });
+#endif /* XTRABACKUP */
 
   /* Now that space and node exist, make sure this undo tablespace
   is open so that it stays open until shutdown.
@@ -652,8 +703,20 @@ dberr_t srv_undo_tablespace_open(undo::Tablespace &undo_space) {
   header page has been written. */
   if (!undo::is_under_construction(space_id)) {
     bool success = fil_space_open(space_id);
-    ut_a(success);
+    if (!success) {
+      fil_space_free(space_id, false);
+      return DB_CANNOT_OPEN_FILE;
+    }
   }
+
+#ifdef XTRABACKUP
+  // Track undo tablespaces that are found after server is locked
+  // if lock_ddl is REDUCED, we will do one more undo scan via
+  // srv_undo_tablespaces_init()/open()
+  if (ddl_tracker && is_server_locked()) {
+    ddl_tracker->add_undo_tablespace(space_id, file_name);
+  }
+#endif /* XTRABACKUP */
 
   if (undo::is_reserved(space_id)) {
     undo::spaces->add(undo_space);
@@ -819,6 +882,7 @@ static dberr_t srv_undo_tablespaces_open(bool backup_mode) {
 
       case DB_SUCCESS:
 
+      case DB_NOT_FOUND:
       case DB_CANNOT_OPEN_FILE:
         /* Doesn't exist, keep looking */
         break;
@@ -1761,7 +1825,7 @@ dberr_t srv_start(bool create_new_db IF_XB(, lsn_t to_lsn)) {
     return (srv_init_abort(err));
   }
 
-  err = fil_scan_for_tablespaces(false);
+  err = fil_scan_for_tablespaces(false IF_XB(, false));
 
   if (err != DB_SUCCESS) {
     return (srv_init_abort(err));

--- a/storage/innobase/srv/srv0tmp.cc
+++ b/storage/innobase/srv/srv0tmp.cc
@@ -317,7 +317,8 @@ void Tablespace_pool::delete_old_pool(bool create_new_db) {
   Dir_Walker::walk(temp_tbsp_dir.c_str(), false, [&](const std::string &path) {
     /* If it is a file and the suffix matches ".ibt", then delete it */
 
-    if (!Dir_Walker::is_directory(path) && path.size() >= 4 &&
+    auto [exists, file_type] = Dir_Walker::is_directory(path);
+    if (exists && file_type == OS_FILE_TYPE_FILE && path.size() >= 4 &&
         (path.compare(path.length() - 4, 4, DOT_IBT) == 0)) {
       os_file_delete_if_exists(innodb_temp_file_key, path.c_str(), nullptr);
     }

--- a/storage/innobase/xtrabackup/src/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/CMakeLists.txt
@@ -18,6 +18,13 @@ INCLUDE(procps)
 
 OPTION(WITH_VERSION_CHECK "Build with version check" ON)
 
+OPTION(PROBUILD "Build Percona XtraBackup Pro variant" OFF)
+IF (PROBUILD)
+ SET(XTRABACKUP_SUFFIX "-pro")
+ ADD_DEFINITIONS(-DPROBUILD)
+ENDIF()
+
+
 INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/compile_flags.cmake)
 
 FIND_GCRYPT()
@@ -83,6 +90,7 @@ MYSQL_ADD_EXECUTABLE(xtrabackup
   xtrabackup.cc
   changed_page_tracking.cc
   datasink.cc
+  ddl_tracker.cc
   ds_buffer.cc
   ds_compress.cc
   ds_compress_lz4.cc

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1390,10 +1390,40 @@ static bool backup_rocksdb_checkpoint(Backup_context &context, bool final) {
 bool backup_start(Backup_context &context) {
   if (!opt_no_lock) {
     /* STOP SLAVE if lock-ddl=OFF */
-    if (!opt_lock_ddl && opt_safe_slave_backup) {
+    if (opt_lock_ddl != LOCK_DDL_ON && opt_safe_slave_backup) {
       if (!wait_for_safe_slave(mysql_connection)) {
         return (false);
       }
+    }
+    /* LTFB/LIFB has to be executed before copying MyISAM */
+    if (ddl_tracker != nullptr) {
+      debug_sync_point("ddl_tracker_before_lock_ddl");
+      if (!lock_tables_for_backup(mysql_connection, opt_backup_lock_timeout,
+                                  opt_backup_lock_retry_count)) {
+        return (false);
+      }
+      /**
+       * Gather log_status for ddl_tracker. We want to ensure that when we start
+       * processing DDL entries from ddl_tracker, no new DDL will happen in the
+       * server and we have parsed all DDL from before LTFB. We instruct InnoDB
+       * to flush the log ensuring the log_status query sees the most recent
+       * updates. We gather log_status here (even before copying MyISAM tables)
+       * so we allow the background redo thread to catchup later when we start
+       * to process the DDL's all we care is that redo has parsed at least up to
+       * the LSN where new DDL's are possible, as this will can change the
+       * in-memory structure of ddl_tracker. Ensuring no new DDL happens when we
+       * process handle_ddl_operations allows PXB to operate without a mutex
+       * here.
+       */
+      if (have_flush_engine_logs) {
+        xb::info() << "Executing FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS...";
+        xb_mysql_query(mysql_connection, "FLUSH NO_WRITE_TO_BINLOG ENGINE LOGS",
+                       false);
+      }
+      log_status_get(mysql_connection, true);
+      xb::info() << "DDL tracking :  log_status current checkpoint lsn is "
+                 << log_status.lsn_checkpoint << " and current lsn is "
+                 << log_status.lsn;
     }
 
     if (!backup_files(MySQL_datadir_path.path().c_str(), true, context)) {
@@ -1451,11 +1481,30 @@ bool backup_start(Backup_context &context) {
     context.myrocks_checkpoint.create(mysql_connection, true);
   }
 
+  if (ddl_tracker != nullptr) {
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(context.redo_mgr->get_copy_interval()));
+    while (context.redo_mgr->get_scanned_lsn() < log_status.lsn &&
+           !context.redo_mgr->has_parsed_lsn(log_status.lsn)) {
+      xb::info() << "Waiting for redo thread to catchup to LSN "
+                 << log_status.lsn << " (currently parsing at "
+                 << context.redo_mgr->get_parsed_lsn() << ")";
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(context.redo_mgr->get_copy_interval()));
+    }
+    dberr_t err = ddl_tracker->handle_ddl_operations();
+    if (err != DB_SUCCESS) {
+      xb::error() << "handle_ddl_operations failed with InnoDB DB_ error code: "
+                  << err;
+      return false;
+    }
+  }
+
   xb::info() << "Executing FLUSH NO_WRITE_TO_BINLOG BINARY LOGS";
   xb_mysql_query(mysql_connection, "FLUSH NO_WRITE_TO_BINLOG BINARY LOGS",
                  false);
 
-  log_status_get(mysql_connection);
+  log_status_get(mysql_connection, false);
 
   /* Wait until we have checkpoint LSN greater than the page tracking start LSN.
   Page tracking start LSN is system LSN (lets say 105) and Backup End LSN is
@@ -1485,7 +1534,7 @@ bool backup_start(Backup_context &context) {
                    << " to reach to page tracking start lsn "
                    << page_tracking_start_lsn;
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        log_status_get(mysql_connection);
+        log_status_get(mysql_connection, false);
       }
     }
   }
@@ -1705,7 +1754,9 @@ bool binlog_file_location::find_binlog(const std::string &dir,
   error = false;
 
   Dir_Walker::walk(dir, false, [&](const std::string &path) mutable {
-    if (ends_with(path.c_str(), ".index") && !Dir_Walker::is_directory(path)) {
+    auto [exists, file_type] = Dir_Walker::is_directory(path);
+    if (ends_with(path.c_str(), ".index") && exists &&
+        file_type == OS_FILE_TYPE_FILE) {
       std::ifstream f_index(path);
       if (f_index.fail()) {
         xb::error() << "cannot read " << SQUOTE(path.c_str());

--- a/storage/innobase/xtrabackup/src/backup_mysql.h
+++ b/storage/innobase/xtrabackup/src/backup_mysql.h
@@ -205,8 +205,9 @@ bool write_current_binlog_file(MYSQL *connection);
 
 /** Read binary log position, InnoDB LSN and other storage engine information
 from p_s.log_status and update global log_status variable.
-@param[in]   conn         mysql connection handle */
-void log_status_get(MYSQL *conn);
+@param[in]   conn                     mysql connection handle
+@param[in]   consumer_can_advance     bool to define if consumer can advance */
+void log_status_get(MYSQL *conn, bool consumer_can_advance);
 
 /*********************************************************************/ /**
  Retrieves MySQL binlog position and

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -1,0 +1,1235 @@
+/******************************************************
+Copyright (c) 2023 Percona LLC and/or its affiliates.
+
+DDL Tracker for XtraBackup.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+#include "ddl_tracker.h"
+#include <fil0fil.h>
+#include <os0thread-create.h>  // os_thread_create
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <univ.i>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include "backup_copy.h"
+#include "file_utils.h"
+#include "fsp0fsp.h"  // fsp_is_undo_tablespace
+#include "scope_guard.h"
+#include "sql_thd_internal_api.h"  // create_thd, destroy_thd
+#include "srv0start.h"
+#include "utils.h"
+#include "xb0xb.h"       // check_if_skip_table
+#include "xtrabackup.h"  // datafiles_iter_t
+
+static const int REN_FILE_VERSION = 1;
+
+extern bool xb_read_delta_metadata(const char *filepath, xb_delta_info_t *info);
+
+void ddl_tracker_t::backup_file_op(uint32_t space_id, mlog_id_t type,
+                                   const byte *buf, ulint len,
+                                   lsn_t record_lsn) {
+  ut_ad(!handle_ddl_ops);
+
+  byte *ptr = (byte *)buf;
+  switch (type) {
+    case MLOG_FILE_CREATE: {
+      assert(len > 6);
+      ptr += 4;  // flags
+      ptr += 2;  // len
+      const char *name = reinterpret_cast<char *>(ptr);
+      add_create_table_from_redo(space_id, record_lsn, name);
+    } break;
+    case MLOG_FILE_RENAME: {
+      ulint name_len = mach_read_from_2(ptr);
+      ptr += 2;  // from len
+      const char *old_name = reinterpret_cast<char *>(ptr);
+      ptr += name_len;  // from name
+      ptr += 2;         // to len
+      const char *new_name = reinterpret_cast<char *>(ptr);
+      add_rename_table_from_redo(space_id, record_lsn, old_name, new_name);
+    } break;
+    case MLOG_FILE_DELETE: {
+      ptr += 2;  // len
+      const char *name = reinterpret_cast<char *>(ptr);
+      add_drop_table_from_redo(space_id, record_lsn, name);
+    } break;
+    case MLOG_INDEX_LOAD:
+      add_to_recopy_tables(space_id, record_lsn, "add index");
+      break;
+    case MLOG_WRITE_STRING:
+      add_to_recopy_tables(space_id, record_lsn, "encryption");
+      break;
+    default:
+#ifdef UNIV_DEBUG
+      assert(0);
+#endif  // UNIV_DEBUG
+      break;
+  }
+}
+
+void ddl_tracker_t::add_table_from_ibd_scan(const space_id_t space_id,
+                                            std::string name,
+                                            ulint space_flags) {
+  // After lock is taken, the scans shouldn't modify the DDL tracker
+  // by the time, we are at handle_ddl_operations, we are consolidating
+  // and no more changes are allowed
+  ut_ad(!handle_ddl_ops);
+
+  Fil_path::normalize(name);
+  if (Fil_path::has_prefix(name, Fil_path::DOT_SLASH)) {
+    name.erase(0, strlen(Fil_path::DOT_SLASH));
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  tables_copied_no_lock[space_id] = {name, space_flags};
+}
+
+void ddl_tracker_t::add_undo_tablespace(const space_id_t space_id,
+                                        std::string name) {
+  ut_ad(fsp_is_undo_tablespace(space_id));
+
+  Fil_path::normalize(name);
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  if (is_server_locked()) {
+    after_lock_undo[name] = space_id;
+  } else {
+    before_lock_undo[name] = space_id;
+  }
+}
+
+void ddl_tracker_t::add_corrupted_tablespace(const space_id_t space_id,
+                                             const std::string &path,
+                                             ulint space_flags) {
+  ut_ad(!handle_ddl_ops);
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+
+  corrupted_tablespaces[space_id] = {path, space_flags};
+}
+
+void ddl_tracker_t::add_to_recopy_tables(space_id_t space_id, lsn_t record_lsn,
+                                         const std::string operation) {
+  // There should never be MLOG_INDEX_LOAD on undo tablespaces. However
+  // MLOG_WRITE_STRING on new undo tabelsapce creation is possible. But we
+  // ignore this as the UNDOs are tracked separately
+  if (fsp_is_undo_tablespace(space_id)) {
+    return;
+  }
+
+  ut_ad(!handle_ddl_ops);
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  recopy_tables.insert(space_id);
+  xb::info() << "DDL tracking : LSN: " << record_lsn << " " << operation
+             << " on space ID: " << space_id;
+}
+
+void ddl_tracker_t::add_missing_after_discovery(std::string path) {
+  ut_ad(!handle_ddl_ops);
+
+  Fil_path::normalize(path);
+  if (Fil_path::has_prefix(path, Fil_path::DOT_SLASH)) {
+    path.erase(0, strlen(Fil_path::DOT_SLASH));
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  missing_after_discovery.insert(path);
+}
+
+void ddl_tracker_t::add_create_table_from_redo(const space_id_t space_id,
+                                               lsn_t record_lsn,
+                                               const char *name) {
+  // undo tablespaces are tracked separately.
+  if (fsp_is_undo_tablespace(space_id)) {
+    return;
+  }
+
+  // tables in system tablespace need not be tracked. They can be
+  // created via redo log
+  if (fsp_is_system_tablespace(space_id)) {
+    return;
+  }
+
+  ut_ad(!handle_ddl_ops);
+
+  std::string new_space_name = name;
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, strlen(Fil_path::DOT_SLASH));
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  new_tables[space_id] = new_space_name;
+  xb::info() << "DDL tracking : LSN: " << record_lsn
+             << " create space ID: " << space_id << " Name: " << new_space_name;
+}
+
+void ddl_tracker_t::add_rename_table_from_redo(const space_id_t space_id,
+                                               lsn_t record_lsn,
+                                               const char *old_name,
+                                               const char *new_name) {
+  // Rename of tables in system tablespace is only rename in DD. this is
+  // tracked via redo log
+  if (fsp_is_system_tablespace(space_id)) {
+    return;
+  }
+
+  ut_ad(!handle_ddl_ops);
+
+  std::string old_space_name{old_name};
+  std::string new_space_name{new_name};
+
+  Fil_path::normalize(old_space_name);
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(old_space_name, Fil_path::DOT_SLASH)) {
+    old_space_name.erase(0, 2);
+  }
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, strlen(Fil_path::DOT_SLASH));
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  if (renames.find(space_id) != renames.end()) {
+    renames[space_id].second = new_space_name;
+  } else {
+    renames[space_id] = std::make_pair(old_space_name, new_space_name);
+  }
+  xb::info() << "DDL tracking : LSN: " << record_lsn
+             << " rename space ID: " << space_id << " From: " << old_space_name
+             << " To: " << new_space_name;
+}
+
+void ddl_tracker_t::add_drop_table_from_redo(const space_id_t space_id,
+                                             lsn_t record_lsn,
+                                             const char *name) {
+  // undo tablespaces are tracked separately.
+  if (fsp_is_undo_tablespace(space_id)) {
+    return;
+  }
+
+  // DROP table in system tablespace is drop indexes. There is no file removal
+  // this is also tracked/redone from redo
+  if (fsp_is_system_tablespace(space_id)) {
+    return;
+  }
+
+  ut_ad(!handle_ddl_ops);
+
+  std::string new_space_name{name};
+  Fil_path::normalize(new_space_name);
+  if (Fil_path::has_prefix(new_space_name, Fil_path::DOT_SLASH)) {
+    new_space_name.erase(0, strlen(Fil_path::DOT_SLASH));
+  }
+
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  drops[space_id] = new_space_name;
+
+  xb::info() << "DDL tracking : LSN: " << record_lsn
+             << " delete space ID: " << space_id << " Name: " << new_space_name;
+}
+
+bool ddl_tracker_t::is_missing_after_discovery(const std::string &name) {
+  return missing_after_discovery.count(name) != 0;
+}
+
+void ddl_tracker_t::add_rename_ibd_scan(const space_id_t &space_id,
+                                        std::string new_name) {
+  // undo tablespaces are tracked separately.
+  if (fsp_is_undo_tablespace(space_id)) {
+    // MLOG_FILE_RENAME is never done for undo tablespace
+    ut_ad(0);
+    return;
+  }
+
+  // rename tables in system tablespace is only rename in DD
+  // tracked via redo. Skip this
+  if (fsp_is_system_tablespace(space_id)) {
+    return;
+  }
+
+  ut_ad(!handle_ddl_ops);
+
+  Fil_path::normalize(new_name);
+  if (Fil_path::has_prefix(new_name, Fil_path::DOT_SLASH)) {
+    new_name.erase(0, 2);
+  }
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  renamed_during_scan[space_id] = new_name;
+}
+
+/* ======== Data copying thread context ======== */
+
+typedef struct {
+  datafiles_iter_t *it;
+  uint num;
+  uint *count;
+  ib_mutex_t *count_mutex;
+  bool *error;
+  std::thread::id id;
+  space_id_to_name_t *new_tables;
+} copy_thread_ctxt_t;
+
+/**
+ * This function extracts the database name and space name from the
+ * tablepsace path. If the space is not file-per-table tablespace, it
+ * returns only the space name with appended extension. For other cases,
+ * it constructs a path in the format "database_name/space_name"
+ * with an appended extension.
+ *
+ * If tablespace is general tablespace or undo tablespace, there is no
+ * database part, it would strip the leading path and just apend the extension
+ * Currently used only for EXT_NEW and EXT_CRPRT
+ *
+ * For example if path is /var/tmp/external/ts1.ibd and extension is EXT_NEW,
+ * result is ts1.ibd.new
+ *
+ * If tablespace is ./test/t1.ibd and extension is EXT_NEW, result is
+ * test/t1.ibd.new If tablespace is /var/tmp/test/t1.ibd and extension is
+ * EXT_NEW result is test/t1.ibd.new If tablespace is ./undo_001 result is
+ * undo_001.new if tablespace is /var/tmp/undo/undo_001.ibu, result is
+ * undo_001.ibu.new
+ *
+ * @param[in] space_id    tablespace id
+ * @param[in] path        the path the tablespace/undo file
+ * @param[in] space_flags tablespace flags
+ * @param[in] extension   EXT_NEW/EXT_DEL/EXT_CRPT/ etc
+ * @return A string representing the destination name
+ */
+static std::string get_dest_name(space_id_t space_id, const std::string &path,
+                                 ulint space_flags,
+                                 const std::string &extension) {
+  auto last_separator_pos = path.find_last_of(Fil_path::SEPARATOR);
+
+  std::string db_name = path.substr(0, last_separator_pos);
+  std::string space_name = path.substr(last_separator_pos + 1);
+
+  ut_ad(space_name.size() > 0);
+
+  if (!fsp_is_file_per_table(space_id, space_flags)) {
+    return space_name + extension;
+  }
+
+  // Extract the last part of db_name after the last separator
+  last_separator_pos = db_name.find_last_of(Fil_path::SEPARATOR);
+  if (last_separator_pos != std::string::npos) {
+    db_name = db_name.substr(last_separator_pos + 1);
+  }
+
+  ut_ad(db_name.size() > 0);
+
+  return db_name + '/' + space_name + extension;
+}
+
+static void copy_for_reduced(copy_thread_ctxt_t *ctxt) {
+  uint num = ctxt->num;
+  fil_node_t *node;
+
+  /*
+    Initialize mysys thread-specific memory so we can
+    use mysys functions in this thread.
+  */
+  my_thread_init();
+
+  /* create THD to get thread number in the error log */
+  THD *thd = create_thd(false, false, true, 0, 0);
+  debug_sync_point("copy_for_reduced");
+
+  while ((node = datafiles_iter_next(ctxt->it)) != NULL && !*(ctxt->error)) {
+    if (ctxt->new_tables->find(node->space->id) == ctxt->new_tables->end()) {
+      continue;
+    }
+    // Get destination name for the datafile
+    std::string dest_name =
+        get_dest_name(node->space->id, node->name, node->space->flags, EXT_NEW);
+
+    if (xtrabackup_copy_datafile_func(node, num, dest_name.c_str())) {
+      xb::error() << "failed to copy datafile " << node->name;
+      *(ctxt->error) = true;
+    }
+  }
+
+  mutex_enter(ctxt->count_mutex);
+  (*ctxt->count)--;
+  mutex_exit(ctxt->count_mutex);
+
+  destroy_thd(thd);
+  my_thread_end();
+}
+
+/**
+ * For both general tablespaces and undo tablespaces, the function transforms
+ * a filename from the `dir1/dir2/filename.ibd` format into the `spaceid.ext`
+ * format. For instance, if the path is `/var/tmp/external/ts1.ibd`, the space
+ * ID is 10, and the extension is EXT_DEL, the result will be `10.del`.
+ *
+ * In the case of file-per-table tablespaces, the function converts a filename
+ * from the `dir/schema/filename.ibd` format into the `schema/spaceid.ext`
+ * format. For example, if the path is `/var/tmp/test/t1.ibd`, the space ID is
+ * 10, and the extension is EXT_REN, the result will be `test/10.ren`.
+ *
+ * @param[in] space_id  The space ID of the current file.
+ * @param[in] file_path The full path of the file to be modified.
+ * @param[in] space_flags tablespace flags
+ * @param[in] ext       The extension to be appended to the new filename.
+ *
+ * @returns A modified filename
+ */
+static std::string convert_file_name(const space_id_t space_id,
+                                     const std::string &file_path,
+                                     ulint space_flags,
+                                     const std::string &ext) {
+  if (!fsp_is_file_per_table(space_id, space_flags)) {
+    return std::to_string(space_id) + ext;
+  }
+
+  char *space_name = fil_path_to_space_name(file_path.c_str());
+  auto free_guard = create_scope_guard([&]() {
+    if (space_name != nullptr) ut::free(space_name);
+  });
+
+  std::string file_name(space_name);
+  auto sep_pos = file_name.find_last_of(Fil_path::SEPARATOR);
+  return file_name.substr(0, sep_pos + 1) + std::to_string(space_id) + ext;
+}
+
+// Helper function to print the contents of a vector of pairs
+void printVector(const std::string &operation, const filevec &vec) {
+  for (const auto &element : vec) {
+    xb::info() << operation << element.first << " : " << element.second << " ";
+  }
+}
+
+// Function to find new, deleted, and changed files between two unordered_maps
+std::tuple<filevec, filevec> findChanges(const name_to_space_id_t &before,
+                                         const name_to_space_id_t &after) {
+  filevec newFiles;
+  filevec deletedOrChangedFiles;
+
+  // Iterate through the after map to find new, changed, and unchanged files
+  for (const auto &pair : after) {
+    auto itBefore = before.find(pair.first);
+    if (itBefore == before.end()) {
+      // Element is new
+      newFiles.emplace_back(pair.first, pair.second);
+    } else {
+      // Element exists in before map
+      if (itBefore->second != pair.second) {
+        // Element value has changed
+        deletedOrChangedFiles.emplace_back(
+            pair.first, itBefore->second);  // Use old value from before map
+        newFiles.emplace_back(pair.first, pair.second);
+      }
+    }
+  }
+
+  // Look for deleted
+  for (const auto &pair : before) {
+    auto itAfter = after.find(pair.first);
+
+    if (itAfter == after.end()) {
+      // Element is not present in the after map. This is deleted
+      deletedOrChangedFiles.emplace_back(pair.first, pair.second);
+    }
+  }
+
+  return {newFiles, deletedOrChangedFiles};
+}
+
+std::tuple<filevec, filevec> ddl_tracker_t::handle_undo_ddls() {
+  xb::info() << "DDL tracking: handling undo DDLs";
+
+  undo_spaces_deinit();
+  undo_spaces_init();
+  xb_scan_for_tablespaces(true);
+
+  // Generates the after_lock_undo list
+  srv_undo_tablespaces_init(false, true);
+
+  std::ostringstream str;
+  // xb::info() is not used intentionally, as there is a loss
+  // of newlines characters from the stream/string
+  str << "Before UNDO files" << xtrabackup::utils::to_string(before_lock_undo)
+      << "\n"
+      << "After UNDO files" << xtrabackup::utils::to_string(after_lock_undo)
+      << "\n";
+  fprintf(stderr, "%s\n", str.str().c_str());
+
+  auto [newfiles, deletedOrChangedFiles] =
+      findChanges(before_lock_undo, after_lock_undo);
+
+  // Print the results
+  xb::info() << "New UNDO files: ";
+  printVector("New undo file: ", newfiles);
+
+  xb::info() << "Deleted or truncated UNDO files: ";
+  printVector("Deleted undo file: ", deletedOrChangedFiles);
+
+  return {newfiles, deletedOrChangedFiles};
+}
+
+dberr_t ddl_tracker_t::handle_ddl_operations() {
+  fil_close_all_files();
+  fil_close();
+  fil_init(LONG_MAX);
+
+  auto [new_undo_files, deleted_undo_files] = handle_undo_ddls();
+
+  xb::info() << "DDL tracking : handling DDL operations";
+
+  if (new_tables.empty() && renames.empty() && drops.empty() &&
+      recopy_tables.empty() && corrupted_tablespaces.empty() &&
+      new_undo_files.empty() && deleted_undo_files.empty()) {
+    xb::info()
+        << "DDL tracking : Finished handling DDL operations - No changes";
+    return DB_SUCCESS;
+  }
+
+  ut_d(handle_ddl_ops = true;);
+
+  std::ostringstream str;
+  // xb::info() is not used intentionally, as there is a loss
+  // of newlines characters from the stream/string
+  str << "Tables_copied: "
+      << xtrabackup::utils::to_string(tables_copied_no_lock) << "\n"
+      << "New_tables: " << xtrabackup::utils::to_string(new_tables) << "\n"
+      << "Renames: " << xtrabackup::utils::to_string(renames) << "\n"
+      << "Drops: " << xtrabackup::utils::to_string(drops) << "\n"
+      << "Recopy_tables: " << xtrabackup::utils::to_string(recopy_tables)
+      << "\n"
+      << "Corrupted_tablespaces: "
+      << xtrabackup::utils::to_string(corrupted_tablespaces) << "\n"
+      << "Missing tables: "
+      << xtrabackup::utils::to_string(missing_after_discovery) << "\n"
+      << "Renamed_during_scan: "
+      << xtrabackup::utils::to_string(renamed_during_scan) << "\n";
+  fprintf(stderr, "%s\n", str.str().c_str());
+
+  dberr_t err;
+
+  for (auto &tablespace : corrupted_tablespaces) {
+    /* Create .crpt file extension with the filename. Prepare should delete
+    the corresponding .ibd, before doing *.ibd scan */
+    space_id_t space_id = tablespace.first;
+    const std::string &path = tablespace.second.first;
+    ulint flags = tablespace.second.second;
+
+    std::string dest_name = get_dest_name(space_id, path, flags, EXT_CRPT);
+    backup_file_printf(dest_name.c_str(), "%s", "");
+  }
+
+  /* Some tables might get to the new list if the DDL happen in between
+   * redo_mgr.start and xb_load_tablespaces. This causes we ending up with two
+   * tablespaces with the same spaceID. Remove them from new tables */
+  for (auto &table : tables_copied_no_lock) {
+    space_id_t space_id = table.first;
+    if (new_tables.find(space_id) != new_tables.end()) {
+      new_tables.erase(space_id);
+    }
+  }
+
+  /* recopy_tables will be handled as follow:
+    * not in the backup - nothign to do. This is a new table that was created
+     during the backup. It will be re-copied anyway as .new in the backup.
+    * in the backup - we add it to be recopied if renamed - we delete the old
+    file during prepare rename logic will then instruct adjust the proper file
+    name to be copied
+  */
+  for (auto &table : recopy_tables) {
+    if (tables_copied_no_lock.find(table) != tables_copied_no_lock.end()) {
+      if (renames.find(table) != renames.end()) {
+        // We never create .del for ibdata*
+        ut_ad(!fsp_is_system_tablespace(table));
+        std::string old_table_name = renames[table].first;
+        ulint flags = tables_copied_no_lock[table].second;
+        backup_file_printf(
+            convert_file_name(table, old_table_name, flags, EXT_DEL).c_str(),
+            "%s", "");
+      }
+      string name = tables_copied_no_lock[table].first;
+      new_tables[table] = name;
+    }
+  }
+
+  for (auto &table : drops) {
+    space_id_t space_id = table.first;
+    std::string table_name = table.second;
+    ulint flags = tables_copied_no_lock[space_id].second;
+
+    if (check_if_skip_table(table_name.c_str())) {
+      continue;
+    }
+    /* Remove from rename */
+    renames.erase(space_id);
+
+    /* Remove from new tables and skip drop*/
+    if (new_tables.find(space_id) != new_tables.end()) {
+      new_tables.erase(space_id);
+      continue;
+    }
+
+    /* Table not in the backup, nothing to drop, skip drop*/
+    if (tables_copied_no_lock.find(space_id) == tables_copied_no_lock.end()) {
+      continue;
+    }
+
+    // We never create .del for ibdata*
+    ut_ad(!fsp_is_system_tablespace(space_id));
+    backup_file_printf(
+        convert_file_name(space_id, table_name, flags, EXT_DEL).c_str(), "%s",
+        "");
+  }
+
+  for (auto &table : renames) {
+    space_id_t space_id = table.first;
+    std::string old_table_name = table.second.first;
+    std::string new_table_name = table.second.second;
+    ulint flags = tables_copied_no_lock[space_id].second;
+
+    if (check_if_skip_table(new_table_name.c_str())) {
+      continue;
+    }
+    if (check_if_skip_table(old_table_name.c_str())) {
+      continue;
+    }
+    /* renamed new table. update new table entry to renamed table name
+      or if table is missing and renamed, add the renamed table to the new_table
+      list. for example: 1. t1.ibd is discovered
+                   2. t1.ibd renamed to t2.ibd
+                   3. t2.ibd is opened and loaded to cache to copy
+                   4. t1.ibd is missing now
+      so we should add t2.ibd to new_tables and skip .ren file so that we don't
+      try to rename t1.ibd to t2.idb where t1.ibd is missing   */
+    if (new_tables.find(space_id) != new_tables.end() ||
+        is_missing_after_discovery(old_table_name)) {
+      new_tables[space_id] = new_table_name;
+      continue;
+    }
+
+    /* Table not in the backup, nothing to rename, skip rename*/
+    if (tables_copied_no_lock.find(space_id) == tables_copied_no_lock.end()) {
+      continue;
+    }
+
+    backup_file_printf(
+        convert_file_name(space_id, old_table_name, flags, EXT_REN).c_str(),
+        "%d\n%s", REN_FILE_VERSION, new_table_name.c_str());
+  }
+
+  for (auto table = new_tables.begin(); table != new_tables.end();) {
+    if (check_if_skip_table(table->second.c_str())) {
+      table = new_tables.erase(table);
+      continue;
+    }
+
+    if (fsp_is_system_tablespace(table->first)) {
+      // open system tablespace for recopying
+      srv_sys_space.shutdown();
+
+      srv_sys_space.set_space_id(TRX_SYS_SPACE);
+
+      /* Create the filespace flags. */
+      ulint fsp_flags =
+          fsp_flags_init(univ_page_size, false, false, false, false);
+      srv_sys_space.set_flags(fsp_flags);
+
+      srv_sys_space.set_name("innodb_system");
+      srv_sys_space.set_path(srv_data_home);
+
+      /* Supports raw devices */
+      if (!srv_sys_space.parse_params(innobase_data_file_path, true,
+                                      xtrabackup_prepare)) {
+        xb::error() << "Cannot parse system tablespace params";
+        ut_ad(0);
+        return DB_ERROR;
+      }
+      dberr_t err;
+      page_no_t sum_of_new_sizes;
+      lsn_t flush_lsn;
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+      err = srv_sys_space.check_file_spec(false, 0);
+
+      if (err != DB_SUCCESS) {
+        xb::error() << "In reduced mode, recopy could not find system "
+                       "tablespace files at the specified datadir";
+        ut_ad(0);
+        return DB_ERROR;
+      }
+
+      err = srv_sys_space.open_or_create(false, false, &sum_of_new_sizes,
+                                         &flush_lsn);
+
+      if (err != DB_SUCCESS) {
+        xb::error() << "could not reopen system tablespace";
+        ut_ad(0);
+        return DB_ERROR;
+      }
+
+    } else {
+      std::tie(err, std::ignore) = fil_open_for_xtrabackup(
+          table->second,
+          table->second.substr(0, table->second.length() - EXT_REN.length()));
+
+      // Under lock, we should be able to open tablespace
+      if (err != DB_SUCCESS) {
+        xb::error() << "Tablespace opening under reduced lock reopen failed: "
+                    << table->second << " err: " << err;
+
+        // Currently we are aware of ALTER INSTANCE ROTATE MASTER KEY can cause
+        // the failure.
+        ut_ad(err == DB_SUCCESS || err == DB_INVALID_ENCRYPTION_META);
+        return err;
+      }
+    }
+    table++;
+  }
+
+  // Create .del files for deleted undo tablespaces
+  for (auto &elem : deleted_undo_files) {
+    ulint flags = tables_copied_no_lock[elem.second].second;
+    backup_file_printf(
+        convert_file_name(elem.second, elem.first, flags, EXT_DEL).c_str(),
+        "%s", "");
+  }
+
+  // Add new undo files to be recopied
+  for (auto &elem : new_undo_files) {
+    new_tables[elem.second] = elem.first;
+  }
+
+  if (new_tables.empty()) {
+    xb::info() << "DDL tracking : no new files are being copied.";
+    return DB_SUCCESS;
+  }
+
+  /* Create data copying threads */
+  copy_thread_ctxt_t *data_threads = (copy_thread_ctxt_t *)ut::malloc_withkey(
+      UT_NEW_THIS_FILE_PSI_KEY,
+      sizeof(copy_thread_ctxt_t) * xtrabackup_parallel);
+  uint count = xtrabackup_parallel;
+  ib_mutex_t count_mutex;
+  mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &count_mutex);
+  bool data_copying_error = false;
+  datafiles_iter_t *it = datafiles_iter_new(nullptr);
+  for (uint i = 0; i < (uint)xtrabackup_parallel; i++) {
+    data_threads[i].it = it;
+    data_threads[i].num = i + 1;
+    data_threads[i].count = &count;
+    data_threads[i].count_mutex = &count_mutex;
+    data_threads[i].error = &data_copying_error;
+    data_threads[i].new_tables = &new_tables;
+    os_thread_create(PFS_NOT_INSTRUMENTED, i, copy_for_reduced,
+                     data_threads + i)
+        .start();
+  }
+
+  /* Wait for threads to exit */
+  while (1) {
+    xb::info() << "Sleeping for 1 second, waiting for the recopy of tables to"
+                  " be finished. Expecting count be 0, current count of"
+                  " tablespaces to be copied is "
+               << count;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    mutex_enter(&count_mutex);
+    if (count == 0) {
+      mutex_exit(&count_mutex);
+      break;
+    }
+    mutex_exit(&count_mutex);
+  }
+
+  if (data_copying_error) {
+    xb::error() << "DDL tracking : could not recopy tablespaces.";
+    return DB_ERROR;
+  }
+
+  mutex_free(&count_mutex);
+  ut::free(data_threads);
+  datafiles_iter_free(it);
+  xb::info() << "DDL tracking :  Finished handling DDL operations";
+  return DB_SUCCESS;
+}
+
+/** This map is required during incremental backup prepare becuase the
+tablename can change between full and incremental backups. For reduced
+lock, during prepare, we process the .del files based on space_id. So we
+delete the right tablespace but the delta files are not. For example, consider
+this scenario. backup has t1.ibd with space_id 10 <rename t1 to t2>
+incremental backup will have t2.ibd.delta and t2.ibd.meta
+and if there is drop table t2, with reduced lock we will have 10.ibd.del
+
+Later when processing incremental backup, we process the 10.ibd.del. this
+gives us the tablespace t1.ibd. We delete it. Additionally we look for
+t1.ibd.delta and t1.ibd.meta and delete them. But in the incremental backup,
+we have t2.ibd.delta and t2.ibd.meta.
+
+This map helps us to get the right meta and delta files for a given space id */
+meta_map_t meta_map;
+
+void insert_into_meta_map(space_id_t space_id, const std::string &meta_path) {
+  meta_map.insert({space_id, meta_path});
+}
+
+std::tuple<bool, std::string> is_in_meta_map(space_id_t space_id) {
+  auto it = meta_map.find(space_id);
+  bool exists = it != meta_map.end();
+  return {exists, exists ? it->second : ""};
+}
+
+static std::optional<std::pair<int, std::string>> parse_ren_file(
+    const std::string &file) {
+  try {
+    // Check if the file exists
+    if (!std::filesystem::exists(file)) {
+      xb::error() << "File '" << file << "' does not exist.";
+      return std::nullopt;
+    }
+
+    std::ifstream f(file);
+    if (!f) {
+      xb::error() << "Unable to open file '" << file << "'.";
+      return std::nullopt;
+    }
+
+    std::string line1, line2;
+
+    // Read the first line (version number)
+    if (!std::getline(f, line1)) {
+      xb::error() << "File '" << file
+                  << "' is empty or failed to read the first line.";
+      return std::nullopt;
+    }
+
+    // Try to convert the first line to an integer
+    std::istringstream iss(line1);
+    int version;
+    if (!(iss >> version)) {
+      xb::error() << "First line of file '" << file
+                  << "' is not a valid integer.";
+      return std::nullopt;
+    }
+
+    // Read the second line (file name)
+    if (!std::getline(f, line2)) {
+      xb::error() << "File '" << file << "' contains only one line.";
+      return std::nullopt;
+    }
+
+    // File has been read successfully with both a version and a file name
+    return std::make_pair(version, line2);
+
+  } catch (const std::filesystem::filesystem_error &e) {
+    xb::error() << "Filesystem error with file '" << file << "': " << e.what();
+    return std::nullopt;
+  } catch (const std::ifstream::failure &e) {
+    xb::error() << "File read error with file '" << file << "': " << e.what();
+    return std::nullopt;
+  } catch (const std::exception &e) {
+    xb::error() << "Generic exception with file '" << file << "': " << e.what();
+    return std::nullopt;
+  }
+}
+
+static void delete_force(const std::string &path) {
+  if (access(path.c_str(), R_OK) == 0) {
+    if (my_delete(path.c_str(), MYF(MY_WME))) {
+      xb::error() << "Can not delete file " << path << "; errno " << errno;
+      exit(EXIT_FAILURE);
+    }
+  }
+}
+
+static void rename_file(const std::string &from, const std::string &to) {
+  if (my_rename(from.c_str(), to.c_str(), MY_WME)) {
+    xb::error() << "Can't rename " << from << " to " << to << " errno "
+                << errno;
+    exit(EXIT_FAILURE);
+  }
+}
+
+static void rename_force(const std::string &from, const std::string &to) {
+  MY_STAT stat_info;
+  /* check if dest folder exists */
+  std::string dest_dir = to.substr(0, to.find_last_of("/"));
+  /* create target dir if not exist */
+  if (!my_stat(dest_dir.c_str(), &stat_info, MYF(0)) &&
+      (my_mkdir(dest_dir.c_str(), 0750, MYF(0)) < 0)) {
+    xb::error() << "cannot mkdir: " << my_errno() << " " << dest_dir;
+    exit(EXIT_FAILURE);
+  }
+  rename_file(from, to);
+}
+
+/** Check if the file has the the specified suffix and truncate
+  @param[in]            suffix     suffix to look for
+  @param[in,out]        path    Filename to check
+  @return true if the suffix is found and truncated. */
+static bool truncate_suffix(std::string suffix, std::string &path) {
+  size_t len = suffix.length();
+
+  if (path.size() < len || path.compare(path.size() - len, len, suffix) != 0) {
+    return (false);
+  }
+
+  path.resize(path.size() - len);
+  return (true);
+}
+
+/**
+ * Handles RENAME DDL that happened during the backup taken in reduced mode
+ * by processing the file with `.ren` extension.
+ * example input: `schema/10.ren` file with file content = `schema/new_name.ibd`
+ *        result: tablespace with space_id=10 will be renamed to
+ * `schema/new_name.ibd`.
+ * @param[in] entry		datadir entry
+ * @return true on success
+ */
+bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
+  if (entry.is_empty_dir) return true;
+
+  std::string ren_file_name = entry.file_name;
+  std::string ren_path = entry.path;
+
+  Fil_path::normalize(ren_path);
+  // trim .ren
+  truncate_suffix(EXT_REN, ren_file_name);
+  space_id_t source_space_id = std::stoi(ren_file_name);
+
+  auto result = parse_ren_file(ren_path);
+  if (!result) {
+    xb::error() << "Error handling prepare_handle_ren_files: " << ren_path;
+    return false;
+  }
+
+  int version = result->first;
+  std::string ren_file_content(result->second);
+
+  if (version != REN_FILE_VERSION) {
+    xb::error() << "Unexpected ren file version in " << ren_path
+                << ". Expected version " << REN_FILE_VERSION
+                << " Got version: " << version;
+    return false;
+  }
+
+  // trim .ibd
+  std::string dest_space_name = ren_file_content;
+  truncate_suffix(EXT_IBD, dest_space_name);
+
+  char *dest_path = Fil_path::make_ibd_from_table_name(dest_space_name);
+  auto dest_path_free_guard = create_scope_guard([&]() {
+    if (dest_path != nullptr) {
+      ut::free(dest_path);
+    }
+  });
+
+  fil_space_t *fil_space = fil_space_get(source_space_id);
+
+  if (fil_space != nullptr) {
+    char *source_path = nullptr, *source_space_name = nullptr;
+    bool res = fil_space_read_name_and_filepath(
+        fil_space->id, &source_space_name, &source_path);
+
+    auto source_path_free_guard = create_scope_guard([&]() {
+      if (source_space_name != nullptr) {
+        ut::free(source_space_name);
+      }
+      if (source_path != nullptr) {
+        ut::free(source_path);
+      }
+    });
+
+    if (!res || !os_file_exists(source_path)) {
+      xb::error() << "prepare_handle_ren_files: Tablespace " << fil_space->name
+                  << " not found.";
+      return false;
+    }
+
+    // space_id.ren is already with the desired name. Nothing to do.
+    if (source_path != nullptr && dest_path != nullptr &&
+        strcmp(source_path, dest_path) == 0) {
+      xb::info() << "prepare_handle_ren_files: ren_file: " << ren_path
+                 << " already has desired file name: " << dest_path
+                 << " source path is: " << source_path;
+      return true;
+    }
+
+    ut_ad(!os_file_exists(dest_path));
+
+    xb::info() << "prepare_handle_ren_files: renaming " << fil_space->name
+               << " to " << dest_space_name;
+
+    if (!fil_rename_tablespace(fil_space->id, source_path,
+                               dest_space_name.c_str(), NULL)) {
+      xb::error() << "prepare_handle_ren_files: Cannot rename "
+                  << fil_space->name << " to " << dest_space_name;
+      return false;
+    }
+  } else {
+    // In case source file doesn't exist we check if destination file is already
+    // there and if destination file DO NOT exist with desired name we throw
+    // error
+    // in case of incrementals, the original file might be present as .delta
+    // So ignore the debug check for incrementals.
+    if (!os_file_exists(dest_path) && !xtrabackup_incremental) {
+      xb::error() << "prepare_handle_ren_files: Tablespace with space_id "
+                  << source_space_id << " is not found."
+                  << " Destination path " << dest_path << " is also not found ";
+      xb::error() << "The incremental meta map is ";
+      fprintf(stderr, "%s", xtrabackup::utils::to_string(meta_map).c_str());
+      ut_ad(0);
+      return false;
+    }
+  }
+
+  // rename .delta .meta files as well
+  if (xtrabackup_incremental) {
+    auto [exists, meta_file] = is_in_meta_map(source_space_id);
+    if (exists) {
+      std::string to_path = entry.datadir + ren_file_content;
+
+      // create .delta path from .meta
+      std::string delta_file = meta_file;
+      truncate_suffix(EXT_META, delta_file);
+      delta_file.append(EXT_DELTA);
+
+      std::string to_delta(to_path + EXT_DELTA);
+      xb::info() << "Renaming incremental delta file from: " << delta_file
+                 << " to: " << to_delta;
+      rename_force(delta_file, to_delta);
+
+      std::string to_meta(to_path + EXT_META);
+      xb::info() << "Renaming incremental meta file from: " << meta_file
+                 << " to: " << to_meta;
+      rename_force(meta_file, to_meta);
+    } else if (fil_space == nullptr) {
+      // This means the tablespace is neither found in the fullbackup dir
+      // nor in the inc backup directory as .meta and .delta
+      xb::error() << "prepare_handle_ren_files(): failed to handle " << ren_path
+                  << " ren_file content: " << ren_file_content;
+      xb::error() << "The incremental meta map is ";
+      fprintf(stderr, "%s", xtrabackup::utils::to_string(meta_map).c_str());
+
+      ut_ad(0);
+      return false;
+    }
+  }
+
+  // delete the .ren file, we don't need it anymore
+  os_file_delete(0, ren_path.c_str());
+  return true;
+}
+
+/**
+ * Handles corrupted files during the backup taken in reduced mode
+ * by processing the file with `.crpt` extension.
+ * These files should be removed before we do *.ibd scan
+ * @param[in] entry		datadir entry
+ * @return true on success
+ * */
+bool prepare_handle_corrupt_files(const datadir_entry_t &entry, void *) {
+  if (entry.is_empty_dir) return true;
+
+  std::string corrupt_path = entry.path;
+  Fil_path::normalize(corrupt_path);
+  // trim .crpt
+  std::string source_path = corrupt_path;
+  truncate_suffix(EXT_CRPT, source_path);
+
+  if (xtrabackup_incremental) {
+    std::string delta_file = source_path + EXT_DELTA;
+    xb::info() << "prepare_handle_corrupt_files: deleting  " << delta_file;
+    if (!os_file_delete_if_exists_func(delta_file.c_str(), nullptr)) {
+      xb::error() << "prepare_handle_corrupt_files: Can not delete "
+                  << delta_file;
+      return false;
+    }
+
+    std::string meta_file = source_path + EXT_META;
+    xb::info() << "prepare_handle_corrupt_files: deleting  " << meta_file;
+    if (!os_file_delete_if_exists_func(meta_file.c_str(), nullptr)) {
+      xb::error() << "prepare_handle_corrupt_files: Can not delete "
+                  << meta_file;
+      return false;
+    }
+  } else {
+    xb::info() << "prepare_handle_corrupt_files: deleting  " << source_path;
+    if (!os_file_delete_if_exists_func(source_path.c_str(), nullptr)) {
+      xb::error() << "prepare_handle_corrupt_files: Can not delete "
+                  << source_path;
+      return false;
+    }
+  }
+
+  // delete the .crpt file, we don't need it anymore
+  if (!os_file_delete_if_exists_func(corrupt_path.c_str(), nullptr)) {
+    xb::error() << "prepare_handle_corrupt_files: Can not delete "
+                << corrupt_path;
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Handles DELETE DDL that happened during the backup taken in reduced mode
+ * by processing the file with `.del` extension.
+ * example input: `schema/10.del` file
+ *         result: tablespace with space_id=10 will be deleted.
+ * @param[in] entry		datadir entry
+ * @param[in] arg		unused
+ * @return true on success
+ */
+bool prepare_handle_del_files(const datadir_entry_t &entry,
+                              void *arg __attribute__((unused))) {
+  if (entry.is_empty_dir) return true;
+
+  std::string del_file_name = entry.file_name;
+  std::string del_file = entry.path;
+
+  // trim .del
+  truncate_suffix(EXT_DEL, del_file_name);
+  space_id_t space_id = atoi(del_file_name.c_str());
+
+  fil_space_t *fil_space = fil_space_get(space_id);
+  if (fil_space != nullptr) {
+    char *path = nullptr, *space_name = nullptr;
+    bool res =
+        fil_space_read_name_and_filepath(fil_space->id, &space_name, &path);
+
+    auto guard = create_scope_guard([&]() {
+      if (space_name != nullptr) {
+        ut::free(space_name);
+      }
+      if (path != nullptr) {
+        ut::free(path);
+      }
+    });
+
+    if (!res || !os_file_exists(path)) {
+      xb::error() << "prepare_handle_del_files: Tablespace " << fil_space->name
+                  << " not found.";
+      return false;
+    }
+
+    xb::info() << "prepare_handle_del_files: deleting " << fil_space->name;
+
+    dberr_t err = fil_delete_tablespace(fil_space->id, BUF_REMOVE_NONE);
+    if (err != DB_SUCCESS) {
+      xb::error() << "prepare_handle_del_files: Cannot delete "
+                  << fil_space->name;
+      return false;
+    }
+  }
+
+  if (xtrabackup_incremental) {
+    auto [exists, meta_file] = is_in_meta_map(space_id);
+    if (exists) {
+      // create .delta path from .meta
+      std::string delta_file = meta_file;
+      truncate_suffix(EXT_META, delta_file);
+      delta_file.append(EXT_DELTA);
+      xb::info() << "Deleting incremental meta file: " << meta_file;
+      delete_force(meta_file);
+      xb::info() << "Deleting incremental delta file: " << delta_file;
+      delete_force(delta_file);
+    }
+  }
+
+  xb::info() << "prepare_handle_del_files: deleting " << del_file.c_str();
+  os_file_delete(0, del_file.c_str());
+  return true;
+}
+
+// Function to check if a string ends with another string
+static bool ends_with(const string &full_string, const string &ext) {
+  // Check if the ending string is longer than the full
+  // string
+  if (ext.size() > full_string.size()) return false;
+
+  // Compare the ending of the full string with the target
+  // ending
+  return full_string.compare(full_string.size() - ext.size(), ext.size(),
+                             ext) == 0;
+}
+
+/************************************************************************
+ * Scan .meta files and build std::unordered_map<space_id, meta_path>.
+ * This map is later used to delete the .delta and .meta file for a dropped
+ * tablespace (ie. when processing the .del entries in reduced lock)
+ * @param[in] entry		datadir entry
+ * @return true on success
+ */
+bool xtrabackup_scan_meta(const datadir_entry_t &entry, void *) {
+  const std::string &meta_path = entry.path;
+  xb_delta_info_t info;
+
+  if (entry.is_empty_dir) {
+    return true;
+  }
+
+  IORequest read_request(IORequest::READ);
+  IORequest write_request(IORequest::WRITE | IORequest::PUNCH_HOLE);
+
+  ut_a(xtrabackup_incremental);
+
+  // We shouldn't add .new.meta to meta_map, as they are meant to be replaced
+  // with the old version of the file.
+  if (ends_with(entry.file_name, EXT_NEW_META)) {
+    return true;
+  }
+
+  if (!xb_read_delta_metadata(meta_path.c_str(), &info)) {
+    xb::error() << "xtrabackup_scan_meta(): failed to read .meta file "
+                << entry.path;
+    return false;
+  }
+
+  insert_into_meta_map(info.space_id, meta_path);
+
+  return true;
+}
+
+/** Handles CREATE DDL that happened during the backup taken in reduced mode
+by processing the file with `.new` extension.
+example input: `schema/filename.ibd.new` file
+result: file `schema/filename.ibd.new` will be renamed to `schema/filename.ibd`
+@param[in] entry  datadir entry
+@param[in] arg    unused
+@return true on success */
+bool prepare_handle_new_files(const datadir_entry_t &entry,
+                              void *arg __attribute__((unused))) {
+  if (entry.is_empty_dir) return true;
+  std::string src_path = entry.path;
+  std::string dest_path = src_path;
+  xb::info() << "prepare_handle_new_files: " << src_path;
+  size_t index = dest_path.find(EXT_NEW);
+#ifdef UNIV_DEBUG
+  assert(index != std::string::npos);
+#endif  // UNIV_DEBUG
+  dest_path.erase(index, 4);
+  rename_force(src_path, dest_path);
+
+  return true;
+}

--- a/storage/innobase/xtrabackup/src/ddl_tracker.h
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.h
@@ -1,0 +1,225 @@
+/******************************************************
+Copyright (c) 2023 Percona LLC and/or its affiliates.
+
+DDL Tracker for XtraBackup.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+
+*******************************************************/
+#ifndef DDL_TRACKER_H
+#define DDL_TRACKER_H
+#include <univ.i>
+#include "log0types.h"
+#include "mtr0types.h"
+typedef std::unordered_map<space_id_t, std::string> space_id_to_name_t;
+typedef std::unordered_map<std::string, space_id_t> name_to_space_id_t;
+typedef std::unordered_map<space_id_t, std::string> meta_map_t;
+using filevec = std::vector<std::pair<std::string, space_id_t>>;
+struct datadir_entry_t;
+extern meta_map_t meta_map;
+
+inline const std::string EXT_DEL = ".del";
+inline const std::string EXT_REN = ".ren";
+inline const std::string EXT_NEW = ".new";
+inline const std::string EXT_IBD = ".ibd";
+inline const std::string EXT_IBU = ".ibu";
+inline const std::string EXT_META = ".meta";
+inline const std::string EXT_NEW_META = ".new.meta";
+inline const std::string EXT_DELTA = ".delta";
+inline const std::string EXT_NEW_DELTA = ".new.delta";
+inline const std::string EXT_CRPT = ".crpt";
+
+class ddl_tracker_t {
+ private:
+  /** List of all tables copied without lock */
+  std::unordered_map<space_id_t, std::pair<std::string, ulint>>
+      tables_copied_no_lock;
+  /** Tablspaces with their ID and name, as they were copied to backup.*/
+  space_id_to_name_t new_tables;
+  name_to_space_id_t before_lock_undo;
+  name_to_space_id_t after_lock_undo;
+  /** Tablespaces involved in encryption or bulk index load.*/
+  std::unordered_set<space_id_t> recopy_tables;
+  /** Drop operations found in redo log. */
+  space_id_to_name_t drops;
+  /* For DDL operation found in redo log,  */
+  std::unordered_map<space_id_t, std::pair<std::string, std::string>> renames;
+  /** Tables that have been deleted between discovery and file open */
+  std::unordered_set<std::string> missing_after_discovery;
+  /** Tables that have been renamed during scan. Tablespace_id and new table
+   *  name */
+  space_id_to_name_t renamed_during_scan;
+
+  /** Tables that cannot be decrypted during backup because of encryption
+  changes. Copy threads that cannot decrypt page, considers them as corrupted
+  page. Can happen only on general tablespaces and mysql.ibd
+  key -> space_id
+  value -> {path, space_flags} */
+  std::unordered_map<space_id_t, std::pair<std::string, ulint>>
+      corrupted_tablespaces;
+  /** Multiple copy threads can add entries to corrupted_tablespaces and
+  recopy_tables concurrently */
+  std::mutex m_ddl_tracker_mutex;
+
+  std::tuple<filevec, filevec> handle_undo_ddls();
+
+#ifdef UNIV_DEBUG
+  /** Set to true when we do handle_ddl_operations. Used to assert that no
+  more ddls are allowed to change the different DDL handling structures */
+  bool handle_ddl_ops = false;
+#endif /* UNIV_DEBUG */
+
+  /** Check if table is in missing list
+  @param[in]  name  tablespace name */
+  bool is_missing_after_discovery(const std::string &name);
+
+ public:
+  /* Track undo tablespaces. This function is called twice. Once before lock,
+  at startup and then again after lock. The contents of two maps are used
+  to discover deleted, truncated and new undo tablespaces.
+  @param[in] space_id undo tablespace id
+  @param[in] name     undo tablespace name */
+  void add_undo_tablespace(const space_id_t space_id, std::string name);
+
+  /** Add a new table in the DDL tracker table list.
+   @param[in] space_id  tablespace identifier
+   @param[in] name      tablespace name
+   @param[in] space_flags      tablespace flags */
+  void add_table_from_ibd_scan(const space_id_t space_id, std::string name,
+                               ulint space_flags);
+
+  /** Track a new table from the MLOG_FILE_CREATE redo log record
+   @param[in] space_id        tablespace identifier
+   @param[in] record_lsn      LSN of redo record
+   @param[in] name            tablespace name */
+  void add_create_table_from_redo(const space_id_t space_id, lsn_t record_lsn,
+                                  const char *name);
+
+  /** Track tables from the MLOG_FILE_RENAME redo log record
+   @param[in]  space_id        tablespace identifier
+   @param[in]  record_lsn      LSN of redo record
+   @param[in]  old_name        RENAME from name
+   @param[in]  new_name        RENAME to name */
+  void add_rename_table_from_redo(const space_id_t space_id, lsn_t record_lsn,
+                                  const char *old_name, const char *new_name);
+
+  /** Track tables from the MLOG_FILE_DELTE redo log record
+   @param[in]  space_id        tablespace identifier
+   @param[in]  record_lsn      LSN of redo record
+   @param[in]  name            RENAME to name */
+  void add_drop_table_from_redo(const space_id_t space_id, lsn_t record_lsn,
+                                const char *name);
+
+  /** Add a table to the corrupted tablespace list. The list is later
+  converted to  tablespacename.ibd.crpt files on disk
+  @param[in] space_id    Tablespace id
+  @param[in] path        Tablespace path
+  @param[in] space_flags Tablespace flags */
+  void add_corrupted_tablespace(const space_id_t space_id,
+                                const std::string &path, ulint space_flags);
+
+  /** Add a table to the recopy list. These tables are
+  1. had ADD INDEX while the backup is in progress
+  2. tablespace encryption change from 'y' to 'n' or viceversa
+  @param[in]    space_id    Tablespace id
+  @param[in]    record_lsn  LSN of redo record
+  @param[in]    operation   Wheter is "add index" or "encryption" */
+  void add_to_recopy_tables(space_id_t space_id, lsn_t record_lsn,
+                            const std::string operation);
+
+  /** Report an operation to create, delete, or rename a file during backup.
+  @param[in] space_id   tablespace identifier
+  @param[in] type       redo log file operation type
+  @param[in] buf        redo log buffer
+  @param[in] len        length of redo entry, in bytes
+  @param[in] record_lsn lsn for REDO record */
+  void backup_file_op(uint32_t space_id, mlog_id_t type, const byte *buf,
+                      ulint len, lsn_t record_lsn);
+
+  /** Handle DDL operations that happenned in reduced lock mode
+  @return DB_SUCCESS for success, others for errors */
+  dberr_t handle_ddl_operations();
+
+  /** Note that a table has been deleted between disovery and file open
+  @param[in]  path  missing table name with path. */
+  void add_missing_after_discovery(std::string path);
+
+  /** Note that a table was renamed during scan.
+  @param[in]	space_id  tablespace identifier
+  @param[in]	new_name  tablespace new name */
+  void add_rename_ibd_scan(const space_id_t &space_id, std::string new_name);
+};
+
+/** Insert into meta files map. This map is later used to delete the right
+.meta and .delta files for a given space_id.del file
+@param[in] space_id Tablespace id
+@param[in] meta_path Meta file path in the incremental backup directory */
+void insert_into_meta_map(space_id_t space_id, const std::string &meta_path);
+
+/** Check if there is a meta (.meta file) for given tablespace id
+@param[in] space_id Tablespace id
+@return <true, path> if a meta file exists for a given space_id,
+else return <false, ""> if it doesnt exist */
+std::tuple<bool, std::string> is_in_meta_map(space_id_t space_id);
+
+/**
+ * Handle DDL for renamed files
+ * example input: test/10.ren file with content = test/new_name.ibd ;
+ *        result: tablespace with space_id=10 will be renamed to
+ * test/new_name.ibd
+ * @return true on success
+ */
+bool prepare_handle_ren_files(
+    const datadir_entry_t &entry, /*!<in: datadir entry */
+    void * /*data*/);
+
+/**
+ * Handle .crpt files. These files should be removed before we do *.ibd scan
+ * @return true on success
+ * */
+bool prepare_handle_corrupt_files(
+    const datadir_entry_t &entry, /*!<in: datadir entry */
+    void * /*data*/);
+
+/**
+ * Handle DDL for deleted files
+ * example input: test/10.del file
+ *        result: tablespace with space_id=10 will be deleted
+ * @return true on success
+ */
+bool prepare_handle_del_files(
+    const datadir_entry_t &entry, /*!<in: datadir entry */
+    void *arg __attribute__((unused)));
+
+/************************************************************************
+ * Scan .meta files and build std::unordered_map<space_id, meta_path>.
+ * This map is later used to delete the .delta and .meta file for a dropped
+ * tablespace (ie. when processing the .del entries in reduced lock)
+ * @return true on success
+ */
+bool xtrabackup_scan_meta(const datadir_entry_t &entry, /*!<in: datadir entry */
+                          void * /*data*/);
+
+/** Handles CREATE DDL that happened during the backup taken in reduced mode
+by processing the file with `.new` extension.
+example input: `schema/filename.ibd.new` file
+result: file `schema/filename.ibd.new` will be renamed to `schema/filename.ibd`
+@param[in] entry  datadir entry
+@param[in] arg    unused
+@return true on success */
+bool prepare_handle_new_files(
+    const datadir_entry_t &entry, /*!<in: datadir entry */
+    void *arg __attribute__((unused)));
+
+#endif  // DDL_TRACKER_H

--- a/storage/innobase/xtrabackup/src/fil_cur.cc
+++ b/storage/innobase/xtrabackup/src/fil_cur.cc
@@ -374,7 +374,7 @@ read_retry:
         if (retry_count == 0) {
           xb::error() << "failed to read page after 10 retries. File "
                       << cursor->abs_path << " seems to be corrupted.";
-          ret = XB_FIL_CUR_ERROR;
+          ret = XB_FIL_CUR_CORRUPTED;
           break;
         }
         xb::info() << "Database page corruption detected at page " << page_no

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -120,7 +120,8 @@ typedef enum {
   XB_FIL_CUR_SUCCESS,
   XB_FIL_CUR_SKIP,
   XB_FIL_CUR_ERROR,
-  XB_FIL_CUR_EOF
+  XB_FIL_CUR_EOF,
+  XB_FIL_CUR_CORRUPTED
 } xb_fil_cur_result_t;
 
 /* Holds the state needed to copy single data file. */

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -121,6 +121,13 @@ class Redo_Log_Parser {
   @param[in] start_lsn          start lsn
   @return false if error. */
   bool parse_log(const byte *buf, size_t len, lsn_t start_lsn);
+
+  /** Get last parsed LSN. */
+  lsn_t get_last_parsed_lsn() const;
+
+ private:
+  /** last parsed LSN */
+  std::atomic<lsn_t> last_parsed_lsn{0};
 };
 
 /** Redo log writer. */
@@ -302,11 +309,20 @@ class Redo_Log_Data_Manager {
   /** Get last scanned lsn. */
   lsn_t get_scanned_lsn() const;
 
+  /** Get last parsed lsn. */
+  lsn_t get_parsed_lsn() const;
+
+  /** Get copy interval. */
+  ulint get_copy_interval() const;
+
   /** Set copy interval. */
   void set_copy_interval(ulint interval);
 
   /** Whether there was an error. */
   bool is_error() const;
+
+  /** whether we have parsed up to LSN */
+  bool has_parsed_lsn(lsn_t lsn) const;
 
   ~Redo_Log_Data_Manager();
 

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -19,6 +19,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #ifndef XTRABACKUP_UTILS_H
 #define XTRABACKUP_UTILS_H
 #include <my_getopt.h>
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 namespace xtrabackup {
 namespace utils {
 
@@ -60,6 +66,68 @@ unsigned long host_free_memory();
 /** Generates uuid
 @return uuid string */
 std::string generate_uuid();
+
+using time = std::chrono::time_point<std::chrono::high_resolution_clock>;
+using HighResTimePoint =
+    std::chrono::time_point<std::chrono::high_resolution_clock>;
+constexpr HighResTimePoint INVALID_TIME = HighResTimePoint::min();
+
+std::string formatElapsedTime(std::chrono::nanoseconds elapsed);
+
+// Helper to convert single values to strings
+template <typename T>
+std::string to_string(const T &value) {
+  std::ostringstream oss;
+  oss << value;
+  return oss.str();
+}
+
+// Specialization for std::pair
+template <typename T1, typename T2>
+std::string to_string(const std::pair<T1, T2> &p) {
+  std::ostringstream oss;
+  oss << "{" << to_string(p.first) << ", " << to_string(p.second) << "}";
+  return oss.str();
+}
+
+// Specialization for std::unordered_map
+template <typename K, typename V>
+std::string to_string(const std::unordered_map<K, V> &umap) {
+  std::ostringstream oss;
+  oss << "{\n";
+  for (auto it = umap.begin(); it != umap.end(); ++it) {
+    oss << to_string(it->first) << ": " << to_string(it->second) << "\n";
+  }
+  oss << "}";
+  return oss.str();
+}
+
+// Specialization for std::vector
+template <typename T>
+std::string to_string(const std::vector<T> &vec) {
+  std::ostringstream oss;
+  oss << "[";
+  for (size_t i = 0; i < vec.size(); ++i) {
+    if (i > 0) {
+      oss << ", ";
+    }
+    oss << to_string(vec[i]);
+  }
+  oss << "]";
+  return oss.str();
+}
+
+// Specialization for std::unordered_set
+template <typename T>
+std::string to_string(const std::unordered_set<T> &uset) {
+  std::ostringstream oss;
+  oss << "{\n";
+  for (auto it = uset.begin(); it != uset.end(); ++it) {
+    oss << to_string(*it) << " ";
+  }
+  oss << "\n}";
+  return oss.str();
+}
 }  // namespace utils
 }  // namespace xtrabackup
 #endif  // XTRABACKUP_UTILS_H

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -467,8 +467,9 @@ static struct my_option my_long_options[] = {
     {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}};
 
 static void print_version() {
-  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname, XBCLOUD_VERSION, SYSTEM_TYPE,
-         MACHINE_TYPE, XBCLOUD_REVISION);
+  printf("%s  Ver %s%s for %s (%s) (revision id: %s)\n", my_progname,
+         XBCLOUD_VERSION, get_suffix_str().c_str(), SYSTEM_TYPE, MACHINE_TYPE,
+         XBCLOUD_REVISION);
 }
 
 static void usage() {

--- a/storage/innobase/xtrabackup/src/xbcrypt.cc
+++ b/storage/innobase/xtrabackup/src/xbcrypt.cc
@@ -336,8 +336,9 @@ static bool get_one_option(int optid,
 }
 
 static void print_version(void) {
-  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname,
-         XBCRYPT_VERSION, SYSTEM_TYPE, MACHINE_TYPE, XBCRYPT_REVISION);
+  printf("%s  Ver %s%s for %s (%s) (revision id: %s)\n", my_progname,
+         XBCRYPT_VERSION, get_suffix_str().c_str(), SYSTEM_TYPE, MACHINE_TYPE,
+         XBCRYPT_REVISION);
 }
 
 static void usage(void) {

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -256,8 +256,9 @@ static int get_options(int *argc, char ***argv) {
 }
 
 static void print_version(void) {
-  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname,
-         XBSTREAM_VERSION, SYSTEM_TYPE, MACHINE_TYPE, XBSTREAM_REVISION);
+  printf("%s  Ver %s%s for %s (%s) (revision id: %s)\n", my_progname,
+         XBSTREAM_VERSION, get_suffix_str().c_str(), SYSTEM_TYPE, MACHINE_TYPE,
+         XBSTREAM_REVISION);
 }
 
 static void usage(void) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -103,6 +103,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "backup_mysql.h"
 #include "changed_page_tracking.h"
 #include "crc_glue.h"
+#include "ddl_tracker.h"
 #include "ds_buffer.h"
 #include "ds_encrypt.h"
 #include "ds_tmpfile.h"
@@ -365,6 +366,10 @@ it every INNOBASE_WAKE_INTERVAL'th step. */
 ulong innobase_active_counter = 0;
 
 char *xtrabackup_debug_sync = NULL;
+#ifdef UNIV_DEBUG
+char *xtrabackup_debug_sync_thread = NULL;
+#endif /* UNIV_DEBUG */
+static std::string debug_sync_file_content;
 static const char *dbug_setting = nullptr;
 
 bool xtrabackup_incremental_force_scan = false;
@@ -466,7 +471,8 @@ bool opt_dump_innodb_buffer_pool = false;
 
 bool punch_hole_supported = false;
 
-bool opt_lock_ddl = false;
+const char *xtrabackup_lock_ddl_str = NULL;
+lock_ddl_type_t opt_lock_ddl = LOCK_DDL_ON;
 bool opt_lock_ddl_per_table = false;
 uint opt_lock_ddl_timeout = 0;
 uint opt_backup_lock_timeout = 0;
@@ -512,6 +518,7 @@ bool redo_catchup_completed = false;
 extern struct rand_struct sql_rand;
 extern mysql_mutex_t LOCK_sql_rand;
 bool xb_generated_redo = false;
+ddl_tracker_t *ddl_tracker = nullptr;
 
 static void check_all_privileges();
 static bool validate_options(const char *file, int argc, char **argv);
@@ -546,8 +553,8 @@ datafiles_iter_t *datafiles_iter_new(
   Fil_iterator::for_each_file([&](fil_node_t *file) {
     auto space_id = file->space->id;
 
-    ut_ad(dd_spaces == nullptr ||
-          (dd_spaces != nullptr && srv_backup_mode && opt_lock_ddl));
+    ut_ad(dd_spaces == nullptr || (dd_spaces != nullptr && srv_backup_mode &&
+                                   opt_lock_ddl == LOCK_DDL_ON));
 
     if (dd_spaces != nullptr && fsp_is_ibd_tablespace(space_id) &&
         !fsp_is_system_or_temp_tablespace(space_id) &&
@@ -684,6 +691,9 @@ enum options_xtrabackup {
   OPT_INNODB_REDO_LOG_ENCRYPT,
   OPT_INNODB_UNDO_LOG_ENCRYPT,
   OPT_XTRA_DEBUG_SYNC,
+#ifdef UNIV_DEBUG
+  OPT_XTRA_DEBUG_SYNC_THREAD,
+#endif /* UNIV_DEBUG */
   OPT_XTRA_COMPACT,
   OPT_XTRA_REBUILD_INDEXES,
   OPT_XTRA_REBUILD_THREADS,
@@ -1048,12 +1058,24 @@ struct my_option xb_client_options[] = {
      (uchar *)&opt_no_lock, (uchar *)&opt_no_lock, 0, GET_BOOL, NO_ARG, 0, 0, 0,
      0, 0, 0},
 
+    // clang-format off
     {"lock-ddl", OPT_LOCK_DDL,
      "Issue LOCK TABLES/LOCK INSTANCE FOR BACKUP if it is "
-     "supported by server at the beginning of the backup to block all DDL "
-     "operations.",
-     (uchar *)&opt_lock_ddl, (uchar *)&opt_lock_ddl, 0, GET_BOOL, NO_ARG, 1, 0,
-     0, 0, 0, 0},
+     "supported by server. Possible options are:                "
+     "ON      - LTFB/LIFB is executed at the beginning of the   "
+     "          backup to block all DDLs                        "
+     "OFF     - LTFB/LIFB is not executed                       "
+#ifdef PROBUILD
+     "REDUCED - PXB does a copy of InnoDB tables without taking "
+     "any lock, while keeping track of tables affected by DDL. Before starting "
+     "to copy Non-InnoDB tables, LTFB/LIFB is executed and all InnoDB tables "
+     "affected by DDL are handled(either recopied or a special file is placed "
+     "in backup dir to handle the DDL operation during --prepare) "
+#endif /* PROBUILD */
+     "Default is ON.",
+     (uchar *)&xtrabackup_lock_ddl_str, (uchar *)&xtrabackup_lock_ddl_str, 0,
+     GET_STR, OPT_ARG, 0, 0, 0, 0, 0, 0},
+    // clang-format on
 
     {"lock-ddl-timeout", OPT_LOCK_DDL_TIMEOUT,
      "If LOCK TABLES FOR BACKUP does not return within given timeout, abort "
@@ -1558,6 +1580,18 @@ Disable with --skip-innodb-checksums.",
      "Debug sync point. This is only used by the xtrabackup test suite",
      (G_PTR *)&xtrabackup_debug_sync, (G_PTR *)&xtrabackup_debug_sync, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+
+#ifndef NDEBUG
+    {"debug-sync-thread", OPT_XTRA_DEBUG_SYNC_THREAD,
+     "Thread sleeps at sync point and creates a filename with the "
+     "sync_point_name_<thread_number>. There can be multiple threads and so "
+     "multiple sync_point_name_ files can be present. Delete the files to "
+     "resume the thread. This is only used by the xtrabackup test suite",
+     (G_PTR *)&xtrabackup_debug_sync_thread,
+     (G_PTR *)&xtrabackup_debug_sync_thread, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
+     0, 0, 0},
+#endif /* !NDEBUG */
+
 #endif
 
 #ifndef NDEBUG
@@ -1655,8 +1689,43 @@ static int debug_sync_resumed;
 static void sigcont_handler(int sig);
 
 static void sigcont_handler(int sig __attribute__((unused))) {
+  *const_cast<const char **>(&xtrabackup_debug_sync) = "";
   debug_sync_resumed = 1;
 }
+
+#ifdef UNIV_DEBUG
+static void sigusr1_handler(int sig __attribute__((unused))) {
+  xb::info() << "SIGUSR1 received. Reading debug_sync_thread point from "
+             << "xb_debug_sync_thread file in backup directory "
+             << xtrabackup_target_dir;
+
+  std::string debug_sync_file =
+      std::string(xtrabackup_target_dir) + "/xb_debug_sync_thread";
+  std::ifstream ifs(debug_sync_file);
+
+  if (ifs.fail()) {
+    xb::warn() << "SIGUSR1 signal sent but the xb_debug_sync_thread file with"
+                  "a debug sync point name in it is not present at "
+               << xtrabackup_target_dir;
+    return;
+  }
+
+  debug_sync_file_content.assign((std::istreambuf_iterator<char>(ifs)),
+                                 (std::istreambuf_iterator<char>()));
+  debug_sync_file_content.erase(
+      std::remove(debug_sync_file_content.begin(),
+                  debug_sync_file_content.end(), '\n'),
+      debug_sync_file_content.end());
+  *const_cast<const char **>(&xtrabackup_debug_sync_thread) =
+      debug_sync_file_content.c_str();
+
+  xb::info() << "The debug sync point read from xb_debug_sync_thread files is "
+             << debug_sync_file_content;
+  xb::info() << "DEBUG_SYNC_THREAD: Deleting file" << debug_sync_file;
+  os_file_delete_if_exists_func(debug_sync_file.c_str(), nullptr);
+}
+#endif /* UNIV_DEBUG */
+
 #endif
 
 void debug_sync_point(const char *name) {
@@ -1700,6 +1769,50 @@ void debug_sync_point(const char *name) {
 #endif
 }
 
+#ifdef UNIV_DEBUG
+void debug_sync_thread(const char *name) {
+#ifndef __WIN__
+  FILE *fp;
+  char pid_path[FN_REFLEN];
+
+  if (xtrabackup_debug_sync_thread == nullptr) {
+    return;
+  }
+
+  if (strcmp(xtrabackup_debug_sync_thread, name)) {
+    return;
+  }
+
+  auto thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+
+  snprintf(pid_path, sizeof(pid_path), "%s/%s_%lu", xtrabackup_target_dir, name,
+           thread_id);
+
+  fp = fopen(pid_path, "w");
+  if (fp == NULL) {
+    xb::error() << "Cannot open " << pid_path;
+    exit(EXIT_FAILURE);
+  }
+
+  fclose(fp);
+
+  while (1) {
+    xb::info() << "DEBUG_SYNC_THREAD: Sleeping 1sec. Resume this thread by "
+               << "deleting file " << pid_path;
+    sleep(1);
+    bool exists = os_file_exists(pid_path);
+    if (!exists) break;
+  }
+
+  xb::info() << "DEBUG_SYNC_THREAD: Thread " << thread_id
+             << " resumed from sync point: " << name;
+
+  *const_cast<const char **>(&xtrabackup_debug_sync_thread) = nullptr;
+
+#endif
+}
+#endif /* UNIV_DEBUG */
+
 static const char *xb_client_default_groups[] = {"xtrabackup", "client", 0, 0,
                                                  0};
 
@@ -1707,10 +1820,11 @@ static const char *xb_server_default_groups[] = {"xtrabackup", "mysqld", 0, 0,
                                                  0};
 
 static void print_version(void) {
-  fprintf(stderr,
-          "%s version %s based on MySQL server %s %s (%s) (revision id: %s)\n",
-          my_progname, XTRABACKUP_VERSION, MYSQL_SERVER_VERSION, SYSTEM_TYPE,
-          MACHINE_TYPE, XTRABACKUP_REVISION);
+  fprintf(
+      stderr,
+      "%s version %s%s based on MySQL server %s %s (%s) (revision id: %s)\n",
+      my_progname, XTRABACKUP_VERSION, get_suffix_str().c_str(),
+      MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE, XTRABACKUP_REVISION);
 }
 
 static void usage(void) {
@@ -1927,6 +2041,23 @@ bool xb_get_one_option(int optid, const struct my_option *opt, char *argument) {
         opt_history = argument;
       } else {
         opt_history = "";
+      }
+      break;
+    case OPT_LOCK_DDL:
+      if (argument == NULL || strcasecmp(argument, "on") == 0 ||
+          strcasecmp(argument, "1") == 0 || strcasecmp(argument, "true") == 0) {
+        opt_lock_ddl = LOCK_DDL_ON;
+      } else if (strcasecmp(argument, "off") == 0 ||
+                 strcasecmp(argument, "0") == 0 ||
+                 strcasecmp(argument, "false") == 0) {
+        opt_lock_ddl = LOCK_DDL_OFF;
+#ifdef PROBUILD
+      } else if (strcasecmp(argument, "reduced") == 0) {
+        opt_lock_ddl = LOCK_DDL_REDUCED;
+#endif /* PROBUILD */
+      } else {
+        xb::error() << "Invalid --lock-ddl argument: " << argument;
+        return 1;
       }
       break;
     case 'p':
@@ -2346,7 +2477,7 @@ error:
   return (true);
 }
 
-static void xb_scan_for_tablespaces() {
+void xb_scan_for_tablespaces(bool only_undo) {
   /* This is the default directory for IBD and IBU files. Put it first
   in the list of known directories. */
   fil_set_scan_dir(MySQL_datadir_path.path());
@@ -2365,7 +2496,7 @@ static void xb_scan_for_tablespaces() {
   --innodb-undo-directory also. */
   fil_set_scan_dir(Fil_path::remove_quotes(MySQL_undo_path), true);
 
-  if (fil_scan_for_tablespaces(true) != DB_SUCCESS) {
+  if (fil_scan_for_tablespaces(true, only_undo) != DB_SUCCESS) {
     exit(EXIT_FAILURE);
   }
 }
@@ -2514,6 +2645,22 @@ static bool xtrabackup_read_info(char *filename) {
   } else if (xb_server_version < 80029) {
     cfg_version = IB_EXPORT_CFG_VERSION_V6;
   }
+  /* skip start_time, end_time, lock_time, binlog_pos, innodb_from_lsn,
+   * innodb_to_lsn, partial, incremental, format, compressed, encrypt */
+  for (int i = 0; i < 12; i++) {
+    char c;
+    do {
+      c = fgetc(fp);
+    } while (c != '\n');
+  }
+
+  char lock[8];
+  if (fscanf(fp, "lock_ddl_type = %7s\n", lock) != 1) {
+    r = false;
+    goto end;
+  }
+  /* used at log0recv.cc to apply or not file operations */
+  opt_lock_ddl = ddl_lock_type_from_str(string(lock));
 end:
   fclose(fp);
   return (r);
@@ -2586,7 +2733,8 @@ static void xtrabackup_print_metadata(char *buf, size_t buf_len) {
            "redo_memory = %ld\n"
            "redo_frames = %ld\n",
            metadata_type_str, metadata_from_lsn, metadata_to_lsn,
-           metadata_last_lsn, opt_lock_ddl ? backup_redo_log_flushed_lsn : 0,
+           metadata_last_lsn,
+           opt_lock_ddl == LOCK_DDL_ON ? backup_redo_log_flushed_lsn : 0,
            redo_memory, redo_frames);
 }
 
@@ -2654,8 +2802,7 @@ static bool xtrabackup_write_metadata(const char *filepath) {
 /***********************************************************************
 Read meta info for an incremental delta.
 @return true on success, false on failure. */
-static bool xb_read_delta_metadata(const char *filepath,
-                                   xb_delta_info_t *info) {
+bool xb_read_delta_metadata(const char *filepath, xb_delta_info_t *info) {
   FILE *fp;
   char key[51];
   char value[51];
@@ -2752,6 +2899,30 @@ static bool xtrabackup_write_info(const char *filepath) {
   return result;
 }
 
+std::string ddl_lock_type_to_str(lock_ddl_type_t type) {
+  switch (type) {
+    case LOCK_DDL_ON:
+      return "ON";
+    case LOCK_DDL_OFF:
+      return "OFF";
+    case LOCK_DDL_REDUCED:
+      return "REDUCED";
+    default:
+      ut_error;
+  }
+}
+
+lock_ddl_type_t ddl_lock_type_from_str(std::string type) {
+  if (type == "ON" || type == "TRUE") {
+    return LOCK_DDL_ON;
+  } else if (type == "OFF" || type == "FALSE") {
+    return LOCK_DDL_OFF;
+  } else if (type == "REDUCED") {
+    return LOCK_DDL_REDUCED;
+  } else {
+    ut_error;
+  }
+}
 /* ================= backup ================= */
 void xtrabackup_io_throttling(void) {
   if (xtrabackup_throttle && (--io_ticket) < 0) {
@@ -2998,6 +3169,11 @@ const char *xb_get_copy_action(const char *dflt) {
 /* TODO: We may tune the behavior (e.g. by fil_aio)*/
 
 static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
+  return xtrabackup_copy_datafile_func(node, thread_n, nullptr);
+}
+
+bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
+                                   const char *dest_name) {
   char dst_name[FN_REFLEN];
   ds_file_t *dstfile = NULL;
   xb_fil_cur_t cursor;
@@ -3039,7 +3215,9 @@ static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
     goto error;
   }
 
-  strcpy(dst_name, cursor.rel_path);
+  strncpy(dst_name, dest_name ? dest_name : cursor.rel_path,
+          sizeof dst_name - 1);
+  dst_name[sizeof(dst_name) - 1] = '\0';
 
   /* Setup the page write filter */
   if (xtrabackup_incremental) {
@@ -3083,7 +3261,9 @@ static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
     }
   }
 
-  if (res == XB_FIL_CUR_ERROR) {
+  if (res == XB_FIL_CUR_ERROR ||
+      (res == XB_FIL_CUR_CORRUPTED &&
+       (ddl_tracker == nullptr || opt_lock_ddl != LOCK_DDL_REDUCED))) {
     goto error;
   }
 
@@ -3107,6 +3287,14 @@ static bool xtrabackup_copy_datafile(fil_node_t *node, uint thread_n) {
   if (write_filter && write_filter->deinit) {
     write_filter->deinit(&write_filt_ctxt);
   }
+
+  if (res == XB_FIL_CUR_CORRUPTED) {
+    if (ddl_tracker != nullptr) {
+      ddl_tracker->add_corrupted_tablespace(cursor.space_id, cursor.node->name,
+                                            cursor.space_flags);
+    }
+  }
+
   return (rc);
 
 error:
@@ -3118,7 +3306,7 @@ error:
     write_filter->deinit(&write_filt_ctxt);
     ;
   }
-  xb::error() << "xtrabackup_copy_datafile() failed";
+  xb::error() << "xtrabackup_copy_datafile_func() failed";
   return (true); /*ERROR*/
 
 skip:
@@ -3130,7 +3318,7 @@ skip:
     write_filter->deinit(&write_filt_ctxt);
   }
 
-  if (!opt_lock_ddl) {
+  if (opt_lock_ddl != LOCK_DDL_ON) {
     xb::warn() << "We assume the "
                << "table was dropped during xtrabackup execution "
                << "and ignore the file.";
@@ -3182,6 +3370,13 @@ static void data_copy_thread_func(data_thread_ctxt_t *ctxt) {
     if (xtrabackup_copy_datafile(node, num)) {
       xb::error() << "failed to copy datafile " << node->name;
       *(ctxt->error) = true;
+    } else {
+      /* With reduced lock mode, instead of tracking undo from the startup scan,
+      we track undo tablespaces after we copy them */
+      if (ddl_tracker && fsp_is_undo_tablespace(node->space->id)) {
+        ddl_tracker->add_undo_tablespace(node->space->id,
+                                         node->space->files.front().name);
+      }
     }
   }
 
@@ -3396,7 +3591,7 @@ static bool xb_fil_io_init(void)
 /****************************************************************************
 Populates the tablespace memory cache by scanning for and opening data files.
 @returns DB_SUCCESS or error code.*/
-static dberr_t xb_load_tablespaces(void)
+static dberr_t xb_load_tablespaces()
 /*=====================*/
 {
   dberr_t err;
@@ -3435,7 +3630,7 @@ static dberr_t xb_load_tablespaces(void)
   }
 
   xb::info() << "Generating a list of tablespaces";
-  xb_scan_for_tablespaces();
+  xb_scan_for_tablespaces(false);
 
   /* Add separate undo tablespaces to fil_system */
 
@@ -3446,7 +3641,11 @@ static dberr_t xb_load_tablespaces(void)
 
   for (auto tablespace : Tablespace_map::instance().external_files()) {
     if (tablespace.type != Tablespace_map::TABLESPACE) continue;
-    fil_open_for_xtrabackup(tablespace.file_name, tablespace.name);
+    /* when LOCK_DDL_REDUCED while processing ddl files on prepare phase
+    we should not load external files */
+    if (!xtrabackup_prepare) {
+      fil_open_for_xtrabackup(tablespace.file_name, tablespace.name);
+    }
   }
 
   debug_sync_point("xtrabackup_load_tablespaces_pause");
@@ -3458,7 +3657,7 @@ static dberr_t xb_load_tablespaces(void)
 Initialize the tablespace memory cache and populate it by scanning for and
 opening data files.
 @returns DB_SUCCESS or error code.*/
-ulint xb_data_files_init(void)
+ulint xb_data_files_init()
 /*====================*/
 {
   os_create_block_cache();
@@ -3885,6 +4084,80 @@ end:
 #endif
 }
 
+/* true on success, false on failure */
+bool xb_check_and_set_open_files_limit(size_t num_files) {
+  if (opt_lock_ddl != LOCK_DDL_REDUCED) {
+    return true;
+  }
+
+#if defined(RLIMIT_NOFILE)
+  xb::info() << "xb_check_and_set_open_files_limit is verifying the open_files "
+                "limit for --lock-ddl=reduced";
+
+  struct rlimit rlimit;
+  uint old_cur;
+
+  if (getrlimit(RLIMIT_NOFILE, &rlimit)) {
+    xb::info() << "getrlimit() failed with error: " << strerror(errno);
+    return true;
+  }
+
+  old_cur = (uint)rlimit.rlim_cur;
+
+  xb::info() << "Current open file limits:";
+  xb::info() << "Desired file_handles: " << num_files;
+  xb::info() << "ulimit -Sn: " << rlimit.rlim_cur;
+  xb::info() << "ulimit -Hn: " << rlimit.rlim_max;
+  xb::info() << "--open-files-limit: " << xb_open_files_limit;
+
+  if (rlimit.rlim_cur == RLIM_INFINITY) {
+    // current open files limit is inifinity. All good. nothing do
+    return true;
+  }
+
+  if (num_files < old_cur) {
+    // all good nothing to do. Num of files we have is less than
+    // the open files limit.
+    return true;
+  }
+
+  if (xb_open_files_limit != 0) {
+    if (num_files > xb_open_files_limit) {
+      xb::error() << "Reduced lock mode needs open file handles: " << num_files
+                  << " but --open-files-limit parameter is set to "
+                  << xb_open_files_limit;
+      xb::error() << "Please retry with --open-files-limit=" << num_files;
+      return false;  // ERROR
+    }
+  }
+
+  if (num_files <= rlimit.rlim_max) {
+    // We are allowed to go up to rlimit.rlim_max. Lets try.
+    ulint result_files = xb_set_max_open_files(num_files);
+    if (result_files < num_files) {
+      xb::error() << "Reduced lock mode requested open file handles: "
+                  << num_files << " but only got " << result_files
+                  << " open file handles";
+      return false;  // ERROR
+    } else {
+      xb::info() << "Reduced lock mode successfully raised open files limit to "
+                 << result_files;
+    }
+  } else {
+    // we are below xb_open_limit but above the max allowed open files
+    xb::error() << "Reduced lock mode requires open file handles " << num_files
+                << " but the max limit (ulimit -Hn) is " << rlimit.rlim_max;
+    return false;
+  }
+
+#else
+  xb::info() << "setrlimit() is not available on this platform";
+  return true;
+#endif
+
+  return true;
+}
+
 /**************************************************************************
 Prints a warning for every table that uses unsupported engine and
 hence will not be backed up. */
@@ -4006,14 +4279,16 @@ void xtrabackup_backup_func(void) {
 
   srv_backup_mode = true;
 
-  if (opt_lock_ddl) {
+  if (opt_lock_ddl == LOCK_DDL_ON) {
     xb_dd_spaces = xb::backup::build_space_id_set(mysql_connection);
     ut_ad(xb_dd_spaces->size());
+  } else if (opt_lock_ddl == LOCK_DDL_REDUCED) {
+    ddl_tracker = new ddl_tracker_t;
   }
 
   /* We can safely close files if we don't allow DDL during the
   backup */
-  srv_close_files = xb_close_files || opt_lock_ddl;
+  srv_close_files = xb_close_files || opt_lock_ddl == LOCK_DDL_ON;
 
   if (xb_close_files)
     xb::warn()
@@ -4220,6 +4495,8 @@ void xtrabackup_backup_func(void) {
     exit(EXIT_FAILURE);
   }
 
+  debug_sync_thread("before_file_copy");
+
   /* Create data copying threads */
   data_threads = (data_thread_ctxt_t *)ut::malloc_withkey(
       UT_NEW_THIS_FILE_PSI_KEY,
@@ -4396,6 +4673,8 @@ void xtrabackup_backup_func(void) {
   xb_keyring_shutdown();
 
   cleanup_mysql_environment();
+
+  delete ddl_tracker;
 }
 
 /* ================= prepare ================= */
@@ -4676,11 +4955,12 @@ static bool get_meta_path(
 {
   size_t len = strlen(delta_path);
 
-  if (len <= 6 || strcmp(delta_path + len - 6, ".delta")) {
+  if (len <= 6 ||
+      strcmp(delta_path + len - EXT_DELTA.length(), EXT_DELTA.c_str())) {
     return false;
   }
-  memcpy(meta_path, delta_path, len - 6);
-  strcpy(meta_path + len - 6, XB_DELTA_INFO_SUFFIX);
+  memcpy(meta_path, delta_path, len - EXT_DELTA.length());
+  strcpy(meta_path + len - EXT_DELTA.length(), XB_DELTA_INFO_SUFFIX);
 
   return true;
 }
@@ -4851,7 +5131,7 @@ static bool xb_space_create_file(
     return (false);
   }
 
-  if (fil_node_create(path, size, space, false, false) == nullptr) {
+  if (fil_node_create(path, size, space, false, false) != DB_SUCCESS) {
     ib::fatal(UT_LOCATION_HERE) << "Unable to add tablespace node '" << path
                                 << "' to the tablespace cache.";
   }
@@ -4943,7 +5223,7 @@ static pfs_os_file_t xb_delta_open_matching_space(
   }
   Fil_path::normalize(real_name);
   /* Truncate ".ibd" */
-  dest_space_name[strlen(dest_space_name) - 4] = '\0';
+  dest_space_name[strlen(dest_space_name) - EXT_IBD.length()] = '\0';
 
   /* Create the database directory if it doesn't exist yet */
   if (!os_file_create_directory(dest_dir, false)) {
@@ -4994,7 +5274,7 @@ static pfs_os_file_t xb_delta_open_matching_space(
             fil_space_read_name_and_filepath(f_space_id, &space_name, &oldpath);
         ut_a(res);
         xb::info() << "Renaming " << dest_space_name << " to " << tmpname
-                   << ".ibu";
+                   << EXT_IBU;
 
         ut_a(os_file_status(oldpath, &exists, &type));
 
@@ -5049,7 +5329,7 @@ static pfs_os_file_t xb_delta_open_matching_space(
       ut_a(res);
 
       xb::info() << "Renaming " << dest_space_name << " to " << tmpname
-                 << ".ibd";
+                 << EXT_IBD;
 
       ut_a(os_file_status(oldpath, &exists, &type));
 
@@ -5144,8 +5424,9 @@ exit:
 }
 
 /************************************************************************
-Applies a given .delta file to the corresponding data file.
-@return true on success */
+ * Applies a given .delta file to the corresponding data file.
+ * @return true on success
+ */
 static bool xtrabackup_apply_delta(
     const datadir_entry_t &entry, /*!<in: datadir entry */
     void * /*data*/) {
@@ -5190,10 +5471,10 @@ static bool xtrabackup_apply_delta(
     snprintf(dst_path, sizeof(dst_path), "%s/%s", xtrabackup_real_target_dir,
              entry.file_name.c_str());
   }
-  dst_path[strlen(dst_path) - 6] = '\0';
+  dst_path[strlen(dst_path) - EXT_DELTA.length()] = '\0';
 
   strncpy(space_name, entry.file_name.c_str(), FN_REFLEN - 1);
-  space_name[strlen(space_name) - 6] = 0;
+  space_name[strlen(space_name) - EXT_DELTA.length()] = 0;
 
   if (!get_meta_path(src_path, meta_path)) {
     goto error;
@@ -5345,9 +5626,9 @@ error:
 }
 
 /************************************************************************
-Callback to handle datadir entry. Deletes entry if it has no matching
-fil_space in fil_system directory.
-@return false if delete attempt was unsuccessful */
+ * Callback to handle datadir entry. Deletes entry if it has no matching
+ * fil_space in fil_system directory.
+ * @return false if delete attempt was unsuccessful */
 static bool rm_if_not_found(
     const datadir_entry_t &entry, /*!<in: datadir entry */
     void *arg __attribute__((unused))) {
@@ -5366,7 +5647,7 @@ static bool rm_if_not_found(
   }
 
   /* Truncate ".ibd" */
-  name[strlen(name) - 4] = '\0';
+  name[strlen(name) - EXT_IBD.length()] = '\0';
 
   HASH_SEARCH(name_hash, inc_dir_tables_hash, ut::hash_string(name),
               xb_filter_entry_t *, table, (void)0, !strcmp(table->name, name));
@@ -5386,8 +5667,8 @@ static bool rm_if_not_found(
 }
 
 /** Make sure that we have a read access to the given datadir entry
-@param[in]	statinfo	entry stat info
-@param[out]	name		entry name */
+ * @param[in]	statinfo	entry stat info
+ * @param[out]	name		entry name */
 static void check_datadir_enctry_access(const char *name,
                                         const struct stat *statinfo) {
   const char *entry_type = S_ISDIR(statinfo->st_mode) ? "directory" : "file";
@@ -5502,7 +5783,7 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
 Applies all .delta files from incremental_dir to the full backup.
 @return true on success. */
 static bool xtrabackup_apply_deltas() {
-  return xb_process_datadir(xtrabackup_incremental_dir, ".delta",
+  return xb_process_datadir(xtrabackup_incremental_dir, EXT_DELTA.c_str(),
                             xtrabackup_apply_delta, NULL);
 }
 
@@ -6163,9 +6444,10 @@ static bool xb_export_cfg_write(
   char file_path[FN_REFLEN];
   FILE *file;
   bool success;
+  std::string EXT_CFG = ".cfg";
 
   strcpy(file_path, node->name);
-  strcpy(file_path + strlen(file_path) - 4, ".cfg");
+  strcpy(file_path + strlen(file_path) - EXT_CFG.length(), EXT_CFG.c_str());
 
   file = fopen(file_path, "w+b");
 
@@ -6498,6 +6780,78 @@ skip_check:
 
   Tablespace_map::instance().deserialize("./");
 
+  if (opt_lock_ddl == LOCK_DDL_REDUCED) {
+    if (!xb_process_datadir(
+            xtrabackup_incremental_dir ? xtrabackup_incremental_dir : ".",
+            EXT_CRPT.c_str(), prepare_handle_corrupt_files, NULL)) {
+      xb_data_files_close();
+      goto error_cleanup;
+    }
+
+    /* Handle `RENAME/DELETE` DDL files produced by DDL tracking during backup
+     */
+    err = xb_data_files_init();
+    if (err != DB_SUCCESS) {
+      xb::error() << "xb_data_files_init() failed "
+                  << "with error code " << err;
+      goto error_cleanup;
+    }
+
+    // This should be done before handling .del files. Because we have to delete
+    // the correct delta files for the corresponding .del files.
+    if (xtrabackup_incremental_dir) {
+      // Build meta map
+      if (!xb_process_datadir(
+              xtrabackup_incremental_dir ? xtrabackup_incremental_dir : ".",
+              EXT_META.c_str(), xtrabackup_scan_meta, NULL)) {
+        xb_data_files_close();
+        goto error_cleanup;
+      }
+    }
+
+    // This should be done before rename because .del files are created after
+    // consolidating or skipping intermediate operations (renames etc). So they
+    // should be processed before renames.
+    if (!xb_process_datadir(
+            xtrabackup_incremental_dir ? xtrabackup_incremental_dir : ".",
+            EXT_DEL.c_str(), prepare_handle_del_files, NULL)) {
+      xb_data_files_close();
+      goto error_cleanup;
+    }
+
+    // This should be done after processing .meta and .del
+    if (!xb_process_datadir(
+            xtrabackup_incremental_dir ? xtrabackup_incremental_dir : ".",
+            EXT_REN.c_str(), prepare_handle_ren_files, NULL)) {
+      xb_data_files_close();
+      goto error_cleanup;
+    }
+
+    xb_data_files_close();
+    fil_close();
+    innodb_free_param();
+    undo_spaces_deinit();
+
+    /* Handle `CREATE` DDL files produced by DDL tracking during backup */
+    if (xtrabackup_incremental_dir) {
+      /** This is the new file, this might be less than the original .ibd
+       * because we are copying the file while there are still dirty pages in
+       * the BP. Those changes will later be conciliated via redo log*/
+      xb_process_datadir(xtrabackup_incremental_dir, EXT_NEW_META.c_str(),
+                         prepare_handle_new_files, NULL);
+      xb_process_datadir(xtrabackup_incremental_dir, EXT_NEW_DELTA.c_str(),
+                         prepare_handle_new_files, NULL);
+      xb_process_datadir(xtrabackup_incremental_dir, EXT_NEW.c_str(),
+                         prepare_handle_new_files, NULL);
+    } else {
+      xb_process_datadir(".", EXT_NEW.c_str(), prepare_handle_new_files, NULL);
+    }
+
+    if (innodb_init_param()) {
+      goto error_cleanup;
+    }
+  }
+
   if (xtrabackup_incremental) {
     Tablespace_map::instance().deserialize(xtrabackup_incremental_dir);
     err = xb_data_files_init();
@@ -6519,8 +6873,8 @@ skip_check:
     /* Cleanup datadir from tablespaces deleted between full and
     incremental backups */
 
-    xb_process_datadir("./", ".ibd", rm_if_not_found, NULL);
-    xb_process_datadir("./", ".ibu", rm_if_not_found, NULL);
+    xb_process_datadir("./", EXT_IBD.c_str(), rm_if_not_found, NULL);
+    xb_process_datadir("./", EXT_IBU.c_str(), rm_if_not_found, NULL);
 
     xb_filter_hash_free(inc_dir_tables_hash);
   }
@@ -6805,13 +7159,13 @@ bool xb_init() {
   const char *mixed_options[4] = {NULL, NULL, NULL, NULL};
   int n_mixed_options;
 
-  if (opt_no_lock || opt_no_backup_locks) opt_lock_ddl = false;
+  if (opt_no_lock || opt_no_backup_locks) opt_lock_ddl = LOCK_DDL_OFF;
 
   /* sanity checks */
-  if (opt_lock_ddl && opt_lock_ddl_per_table) {
+  if (opt_lock_ddl != LOCK_DDL_OFF && opt_lock_ddl_per_table) {
     xb::error()
         << "--lock-ddl and --lock-ddl-per-table are mutually exclusive. "
-           "Please specify --lock-ddl=false to use --lock-ddl-per-table.";
+           "Please specify --lock-ddl=OFF to use --lock-ddl-per-table.";
     return (false);
   }
 
@@ -6895,13 +7249,13 @@ bool xb_init() {
     history_start_time = time(NULL);
 
     /* stop slave before taking backup up locks if lock-ddl=ON*/
-    if (!opt_no_lock && opt_lock_ddl && opt_safe_slave_backup) {
+    if (!opt_no_lock && opt_lock_ddl == LOCK_DDL_ON && opt_safe_slave_backup) {
       if (!wait_for_safe_slave(mysql_connection)) {
         return (false);
       }
     }
 
-    if (opt_lock_ddl &&
+    if (opt_lock_ddl == LOCK_DDL_ON &&
         !lock_tables_for_backup(mysql_connection, opt_lock_ddl_timeout, 0)) {
       return (false);
     }
@@ -7445,6 +7799,12 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
+  if (opt_page_tracking && opt_lock_ddl == LOCK_DDL_REDUCED) {
+    xb::error() << "--page-tracking and --lock-ddl=REDUCED cannot be enabled"
+                << " together.";
+    exit(EXIT_FAILURE);
+  }
+
   /* Expand target-dir, incremental-basedir, etc. */
 
   my_getwd(cwd, sizeof(cwd), MYF(0));
@@ -7604,6 +7964,9 @@ int main(int argc, char **argv) {
 
 #ifndef __WIN__
   signal(SIGCONT, sigcont_handler);
+#ifdef UNIV_DEBUG
+  signal(SIGUSR1, sigusr1_handler);
+#endif /* UNIV_DEBUG */
 #endif
 
   /* --backup */

--- a/storage/innobase/xtrabackup/src/xtrabackup_version.h.in
+++ b/storage/innobase/xtrabackup/src/xtrabackup_version.h.in
@@ -20,8 +20,45 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #ifndef XB_VERSION_H
 #define XB_VERSION_H
+#include <string>
 
 #define XTRABACKUP_VERSION		"@XB_VERSION@"
 #define XTRABACKUP_REVISION		"@XB_REVISION@"
+#define XTRABACKUP_SUFFIX_DEF           "@XTRABACKUP_SUFFIX@"
+
+#ifdef XTRABACKUP_SUFFIX
+#define XTRABACKUP_SUFFIX_STR STRINGIFY_ARG(XTRABACKUP_SUFFIX)
+#else
+#define XTRABACKUP_SUFFIX_STR XTRABACKUP_SUFFIX_DEF
+#endif
+
+inline std::string get_suffix_str() {
+  std::string str(XTRABACKUP_SUFFIX_STR);
+
+#ifdef UNIV_DEBUG
+  str.append("-debug");
+#endif
+
+#ifdef HAVE_VALGRIND
+  str.append("-valgrind");
+#endif
+
+#ifdef HAVE_ASAN
+  str.append("-asan");
+#endif
+
+#ifdef HAVE_LSAN
+  str.append("-lsan");
+#endif
+
+#ifdef HAVE_UBSAN
+  str.append("-ubsan");
+#endif
+
+#ifdef HAVE_TSAN
+  str.append("-tsan");
+#endif
+  return str;
+}
 
 #endif /* XB_VERSION_H */

--- a/storage/innobase/xtrabackup/test/bootstrap.sh
+++ b/storage/innobase/xtrabackup/test/bootstrap.sh
@@ -111,12 +111,16 @@ main () {
 
     case "${TYPE}" in
         innodb80)
-            url="https://dev.mysql.com/get/Downloads/MySQL-8.1"
+            url="https://dev.mysql.com/get/Downloads/MySQL-8.4"
             fallback_url="https://downloads.mysql.com/archives/get/p/23/file"
+	    # Strip '-<number>' where <number> is 1-100
+            clean_version="${VERSION%-[0-9][0-9]}"
+            clean_version="${clean_version%-[0-9]}"
+
 	    if [ "${OS}" == "deb" ]; then
-                tarball="mysql-${VERSION}-linux-glibc2.28-${arch}.tar.xz"
+                tarball="mysql-${clean_version}-linux-glibc2.28-${arch}.tar.xz"
             else
-                tarball="mysql-${VERSION}-linux-glibc2.17-${arch}.tar.xz"
+                tarball="mysql-${clean_version}-linux-glibc2.17-${arch}.tar.xz"
             fi
             if ! check_url "${url}" "${tarball}"; then
                     unset url
@@ -124,20 +128,14 @@ main () {
             fi
             ;;
         xtradb80)
-            url="https://www.percona.com/downloads/Percona-Server-8.0/Percona-Server-${VERSION}/binary/tarball"
-            short_version=$(echo ${VERSION} | awk -F "." '{ print $3 }' | cut -d '-' -f1)
+            url="https://www.percona.com/downloads/Percona-Server-8.4/Percona-Server-${VERSION}/binary/tarball"
             if [[ ${PXB_TYPE} == "Debug" ]] || [[ ${PXB_TYPE} == "debug" ]]; then
                 SUFFIX="-debug"
               else
                 SUFFIX="-minimal"
             fi
-            if [[ ${short_version} -lt "20" ]]; then
-                tarball="Percona-Server-${VERSION}-Linux.${arch}.ssl$(ssl_version).tar.gz"
-            elif [[ ${short_version} -ge "20" && ${short_version} -lt "22" ]]; then
-                tarball="Percona-Server-${VERSION}-Linux.${arch}.glibc2.12${SUFFIX}.tar.gz"
-            elif [[ ${short_version} -ge "22" ]]; then
-                tarball="Percona-Server-${VERSION}-Linux.${arch}.glibc$(glibc_version)${SUFFIX}.tar.gz"
-            fi
+            tarball="Percona-Server-${VERSION}-Linux.${arch}.glibc$(glibc_version)${SUFFIX}.tar.gz"
+
             ;;
         *) 
             echo "Err: Specified unsupported ${TYPE}."
@@ -181,7 +179,7 @@ main () {
 
 TYPE="xtradb80"
 PXB_TYPE="release"
-VERSION="8.0.35-27"
+VERSION="8.4.0-1"
 DESTDIR="./server"
 parse_arguments PICK-ARGS-FROM-ARGV "$@"
 main

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -28,6 +28,30 @@ function xtrabackup()
   fi
 }
 
+function xtrabackup_background() {
+  # Check if XB_ERROR_LOG is set
+  if [ -z "${XB_ERROR_LOG+x}" ]; then
+    echo "Error: XB_ERROR_LOG variable is not set. Please set XB_ERROR_LOG to the desired error log file path." >&2
+    return 1
+  fi
+
+  # Check if the number of arguments passed is correct
+  if [ $# -lt 1 ]; then
+    echo "Usage: xtrabackup_background [args...]" >&2
+    return 1
+  fi
+
+  local args="$@"  # Combine all arguments to form the xtrabackup command
+
+  # Execute xtrabackup in the background using the run_cmd_background function and store the PID in XB_PID
+  run_cmd_background $XB_BIN $XB_ARGS $args
+  XB_PID=$!
+
+  # Optionally, return the PID of the background process
+  echo $XB_PID
+}
+
+
 function rr_xtrabackup()
 {
   run_cmd rr $XB_BIN $XB_ARGS "$@"
@@ -133,6 +157,32 @@ function run_cmd_expect_failure()
   then
       die "===> `basename $1` succeeded when it was expected to fail"
   fi
+}
+
+function run_cmd_background() {
+  # Check if XB_ERROR_LOG is set
+  if [ -z "${XB_ERROR_LOG+x}" ]; then
+    echo "Error: XB_ERROR_LOG variable is not set. Please set XB_ERROR_LOG to the desired error log file path." >&2
+    return 1
+  fi
+
+  # Check if the number of arguments passed is correct
+  if [ $# -lt 1 ]; then
+    echo "Usage: run_cmd_background <command> [args...]" >&2
+    return 1
+  fi
+
+  local cmd="$@"  # Combine all arguments to form the command
+
+  # Execute the command in the background, piping stdout to tee to duplicate the output to both the error log file and stdout
+  # Dont use PIPE here as the PID will be pid of pipe
+  $cmd > >(tee -a "$XB_ERROR_LOG") 2>&1 &
+
+  # Capture the PID of the background process and store it in JOB_ID
+  CMD_PID=$!
+
+  # Optionally, return the PID of the command
+  echo $CMD_PID
 }
 
 function load_sakila()
@@ -1005,6 +1055,16 @@ function require_debug_pxb_version()
     fi
 }
 
+#########################################################################
+# Requires pro pxb version
+########################################################################
+function require_pro_pxb_version()
+{
+    if ! $XB_BIN --version 2>&1 | grep -q '\-pro'; then
+        skip_test "Requires pro build"
+    fi
+}
+
 ########################################################################
 # Return 0 if the server version is lower than the first argument
 #########################################################################
@@ -1187,6 +1247,13 @@ function require_debug_sync()
 {
     if ! $XB_BIN --help 2>&1 | grep -q debug-sync; then
         skip_test "Requires --debug-sync support"
+    fi
+}
+
+function require_debug_sync_thread()
+{
+    if ! $XB_BIN --help 2>&1 | grep -q debug-sync-thread; then
+        skip_test "Requires --debug-sync-thread support"
     fi
 }
 
@@ -1467,6 +1534,54 @@ function wait_for_file_to_generated() {
     i=$((i+1))
     echo "Waited $i seconds for $file to be created"
   done
+}
+
+function wait_for_debug_sync_thread()
+{
+   # Check if the number of arguments passed is correct
+  if [ $# -lt 1 ]; then
+    echo "Usage: wait_for_debug_sync_thread <debug_sync_point_name>"
+    return 1
+  fi
+
+  local sync_point=$1
+  if [ -z "${XB_ERROR_LOG+x}" ]; then
+    echo "Error: XB_ERROR_LOG variable is not set. Please set XB_ERROR_LOG to the desired error log file path." >&2
+    return 1
+  fi
+
+  while ! egrep -q "DEBUG_SYNC_THREAD: Sleeping 1sec. Resume this thread by deleting file.*$sync_point.*" ${XB_ERROR_LOG} ; do
+    sleep 1
+    vlog "waiting for debug_sync_thread $sync_point in $XB_ERROR_LOG"
+  done
+}
+
+function resume_debug_sync_thread()
+{
+   # Check if the number of arguments passed is correct
+  if [ $# -lt 2 ]; then
+    echo "Usage: resume_debug_sync_thread <debug_sync_point_name> <backup_dir>"
+    return 1
+  fi
+
+  local sync_point=$1
+  local backup_dir=$2
+
+  if [ -z "${XB_ERROR_LOG+x}" ]; then
+    echo "Error: XB_ERROR_LOG variable is not set. Please set XB_ERROR_LOG to the desired error log file path." >&2
+    return 1
+  fi
+
+  echo "Resume from sync point: $sync_point"
+  rm  $backup_dir/"$sync_point"_*
+
+  echo "wait for resumed signal of $sync_point"
+
+  while ! egrep -q "DEBUG_SYNC_THREAD: Thread .* resumed from sync point: $sync_point" ${XB_ERROR_LOG} ; do
+   sleep 1
+   vlog "waiting for debug_sync_thread point resume $sync_point in pxb $XB_ERROR_LOG"
+  done
+
 }
 
 # To avoid unbound variable error when no server have been started

--- a/storage/innobase/xtrabackup/test/run.sh
+++ b/storage/innobase/xtrabackup/test/run.sh
@@ -45,8 +45,8 @@ Usage: $0 [-f] [-g] [-h] [-s suite] [-t test_name] [-d mysql_basedir] [-c build_
 -k          Make a copy of failed var directory
 -t path     Run only a single named test. This option can be passed multiple times.
 -h          Print this help message
--s suite    Select a test suite to run. Possible values: binlog, experimental, gr, keyring, rocksdb, pagetracking,  main, compression and xbcloud.
-            Default is 'binlog, main, gr, pagetracking, rocksdb, keyring, compression and xbcloud'.
+-s suite    Select a test suite to run. Possible values: binlog, experimental, gr, keyring, rocksdb, pagetracking,  main, compression, reducedlock and xbcloud.
+            Default is 'binlog, main, gr, pagetracking, rocksdb, keyring, compression, reducedlock and xbcloud'.
 -j N        Run tests in N parallel processes.
 -T seconds  Test timeout (default is $TEST_TIMEOUT seconds).
 -x options  Extra options to pass to xtrabackup
@@ -939,8 +939,8 @@ if [ -n "$tname" ]
 then
    tests="$tname"
 else
-   tests="suites/binlog/* suites/pagetracking/* suites/gr/*.sh suites/keyring/*.sh suites/xbcloud/*.sh suites/compression/*.sh suites/rocksdb/*.sh t/*.sh"
-   suites=" pagetracking binlog gr keyring compression rocksdb main xbcloud"
+   tests="suites/binlog/* suites/pagetracking/* suites/gr/*.sh suites/keyring/*.sh suites/xbcloud/*.sh suites/compression/*.sh suites/reducedlock/*.sh suites/rocksdb/*.sh t/*.sh"
+   suites=" pagetracking binlog gr keyring compression reducedlock rocksdb main xbcloud"
 fi
 
 export OUTFILE="$PWD/results/setup"

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_mix_plugins.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_mix_plugins.sh
@@ -7,9 +7,10 @@ require_server_version_higher_than 5.7.10
 is_xtradb || skip_test "Keyring vault requires Percona Server"
 
 vlog setup keyring_file
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
 . inc/keyring_file.sh
-
-start_server
+configure_server_with_component
 
 run_cmd $MYSQL $MYSQL_ARGS test <<EOF
 CREATE TABLE t1 (c1 VARCHAR(100)) ENCRYPTION='y';

--- a/storage/innobase/xtrabackup/test/suites/keyring/keyring_pxb_2275.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/keyring_pxb_2275.sh
@@ -22,7 +22,7 @@ mkdir $topdir/backup
 
 # Test 1 - should fail since we don't have any entry on keyring file yet
 vlog "Test 1 - Should fail as keyring file does not have encryption information"
-run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=80M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=false --backup \
+run_cmd_expect_failure $XB_BIN $XB_ARGS --innodb-log-file-size=80M --xtrabackup-plugin-dir=${plugin_dir} --lock-ddl=OFF --backup \
 --target-dir=$topdir/backup --debug-sync="xtrabackup_pause_after_redo_catchup" 2> >(tee $topdir/backup.log)&
 
 job_pid=$!
@@ -84,7 +84,7 @@ $MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE tmp1" sakila
 innodb_wait_for_flush_all
 
 
-run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=80M --lock-ddl=false --backup \
+run_cmd $XB_BIN $XB_ARGS --innodb-log-file-size=80M --lock-ddl=OFF --backup \
 --target-dir=$topdir/backup --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} --debug-sync="xtrabackup_pause_after_redo_catchup" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/suites/keyring/pxb-1793.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/pxb-1793.sh
@@ -15,9 +15,10 @@ innodb_temp_tablespace_encrypt=ON
 encrypt-tmp-files
 "
 
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
 . inc/keyring_file.sh
-
-start_server
+configure_server_with_component
 
 # backup fails if bug is present
 xtrabackup --backup --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/suites/keyring/pxb-1954.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/pxb-1954.sh
@@ -31,7 +31,7 @@ mysql -e "INSERT INTO t SELECT * FROM t" test
       mysql -e "ALTER TABLE t ROW_FORMAT=REDUNDANT;" test
   done ) >/dev/null 2>/dev/null &
 
-xtrabackup --lock-ddl --backup --target-dir=$topdir/backup \
+xtrabackup --backup --target-dir=$topdir/backup \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 xtrabackup --prepare --target-dir=$topdir/backup \

--- a/storage/innobase/xtrabackup/test/suites/keyring/rollback.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/rollback.sh
@@ -38,7 +38,7 @@ trap "kill_bg_trx $uncommitted_trx" EXIT
 wait_for_bg_trx
 
 vlog "Backup"
-xtrabackup --lock-ddl --backup --target-dir=$topdir/backup \
+xtrabackup --backup --target-dir=$topdir/backup \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 kill_bg_trx $uncommitted_trx
@@ -77,7 +77,7 @@ vlog "Test 2: No rollback on encrypted table. Lack of keyring shouldn't fail the
 
 vlog "Backup"
 rm -rf $topdir/backup
-xtrabackup --lock-ddl --backup --target-dir=$topdir/backup \
+xtrabackup --backup --target-dir=$topdir/backup \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 vlog "Record db state"

--- a/storage/innobase/xtrabackup/test/suites/keyring/shared_tablespace_encryption.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/shared_tablespace_encryption.sh
@@ -10,9 +10,10 @@ innodb-sys-tablespace-encrypt
 loose-innodb-default-encryption=on
 "
 
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
 . inc/keyring_file.sh
-
-start_server
+configure_server_with_component
 
 mysql -e "CREATE TABLE t (a INT PRIMARY KEY, b TEXT)" test
 mysql -e "INSERT INTO t (a, b) VALUES (1, 'a')" test
@@ -26,7 +27,11 @@ stop_server
 
 rm -rf $mysql_datadir
 
-xtrabackup --copy-back --transition-key=1234 --generate-new-master-key --target-dir=$topdir/backup
+xtrabackup --copy-back --transition-key=1234 --generate-new-master-key --target-dir=$topdir/backup \
+               --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+cp ${instance_local_manifest}  $mysql_datadir
+cp ${keyring_component_cnf} $mysql_datadir
 
 start_server
 
@@ -43,7 +48,10 @@ stop_server
 
 rm -rf $mysql_datadir
 
-xtrabackup --copy-back --target-dir=$topdir/backup
+xtrabackup --copy-back --target-dir=$topdir/backup --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+cp ${instance_local_manifest}  $mysql_datadir
+cp ${keyring_component_cnf} $mysql_datadir
 
 start_server
 

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_add_column.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_add_column.sh
@@ -1,0 +1,117 @@
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_server
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+  INSTANT=$2
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP and INSTANT=$INSTANT"
+
+  start_server
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.keep (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.keep VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.rename (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.rename VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.drop VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.default_val (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.default_val VALUES(1, 'a'), (2, 'b');" test
+
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    innodb_wait_for_flush_all
+  fi
+
+
+  xtrabackup --backup --target-dir=$topdir/backup_add_column \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_add_column.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_add_column/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # change default value and generate redo
+  QUERY="ALTER TABLE test.default_val ALTER COLUMN name SET DEFAULT 'no-name', ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.default_val VALUES (3, 'c'), (4, 'd');" test
+
+  # Add new column to table and generate redo
+  QUERY="ALTER TABLE test.keep ADD COLUMN new_col VARCHAR(50) AFTER id, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.keep VALUES (3, 'col', 'c'), (4, 'col', 'd');" test
+
+  # Add new column to table,  generate redo, rename the table and generate redo
+  QUERY="ALTER TABLE test.rename ADD COLUMN new_col VARCHAR(50) AFTER id, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.rename VALUES (3, 'col', 'c'), (4, 'col', 'd');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.rename TO test.after_rename; INSERT INTO test.after_rename VALUES (5, 'col', 'e'), (6, 'col', 'f');" test
+
+  # Add new column to table,  generate redo, drop the table
+  QUERY="ALTER TABLE test.drop ADD COLUMN new_col VARCHAR(50) AFTER id, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+    else
+    QUERY+="INPLACE"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.drop VALUES (3, 'col', 'c'), (4, 'col', 'd'); DROP TABLE test.drop;" test
+
+  # Create table, generate redo and add column
+  QUERY="CREATE TABLE test.new (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.new VALUES(1, 'a'), (2, 'b'); ALTER TABLE test.new ADD COLUMN new_col VARCHAR(50) AFTER id, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.new VALUES (3, 'col', 'c'), (4, 'col', 'd');" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  xtrabackup --prepare --target-dir=$topdir/backup_add_column
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_add_column
+  start_server
+  verify_db_state test
+
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_add_column.log $topdir/backup_add_column
+}
+
+
+# Run test with all tables in backup and algortihm inplace
+run_test true false
+
+# Run test with all tables in backup and algortihm instant
+run_test true true
+
+# Run test with all tables in redo and algortihm inplace
+run_test false false
+
+# Run test with all tables in redo and algortihm instant
+run_test false true
+

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_add_index.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_add_index.sh
@@ -1,0 +1,80 @@
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_server
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  start_server
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_keep (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.secondary_idx_keep VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_rename (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.secondary_idx_rename VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_drop (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.secondary_idx_drop VALUES(1, 'a'), (2, 'b');" test
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    innodb_wait_for_flush_all
+  fi
+
+
+  xtrabackup --backup --target-dir=$topdir/backup_optimized_ddl \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_optimized_ddl.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_optimized_ddl/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # Add secondary index
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_keep ADD INDEX(name);" test
+
+  # Add secondary index and rename table
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_rename ADD INDEX(name); RENAME TABLE test.secondary_idx_rename TO test.secondary_idx_after_rename" test
+
+  # Add secondary index and drop table
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_drop ADD INDEX(name); DROP TABLE test.secondary_idx_drop;" test
+
+  # Create table and generate redo
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_new (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.secondary_idx_new VALUES(1, 'a'), (2, 'b'); ALTER TABLE test.secondary_idx_new ADD INDEX(name);" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  original_keep_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_keep FORCE INDEX(name);" | awk {'print $1'}`
+  original_rename_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_after_rename FORCE INDEX(name);" | awk {'print $1'}`
+  xtrabackup --prepare --target-dir=$topdir/backup_optimized_ddl
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_optimized_ddl
+  start_server
+  verify_db_state test
+  restored_keep_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_keep FORCE INDEX(name);" | awk {'print $1'}`
+  restored_rename_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_after_rename FORCE INDEX(name);" | awk {'print $1'}`
+
+  if [ "$original_keep_table_row_count" != "$restored_keep_table_row_count" ]; then
+    die "rows in table secondary_idx_keep is $restored_keep_table_row_count when it should be $original_keep_table_row_count"
+  fi
+
+  if [ "$original_rename_table_row_count" != "$restored_rename_table_row_count" ]; then
+    die "rows in table secondary_idx_after_rename is $restored_rename_table_row_count when it should be $original_rename_table_row_count"
+  fi
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_optimized_ddl.log $topdir/backup_optimized_ddl
+}
+
+
+# Run test with all tables in backup
+run_test true
+
+# Run test ensure DDL for create tables are part of redo log entries
+run_test false

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_drop_column.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_drop_column.sh
@@ -1,0 +1,106 @@
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_server
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+  INSTANT=$2
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP and INSTANT=$INSTANT"
+
+  start_server
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.keep (id INT PRIMARY KEY AUTO_INCREMENT, new_col VARCHAR(50), name VARCHAR(50)); INSERT INTO test.keep VALUES(1, 'a', 'a'), (2, 'b', 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.rename (id INT PRIMARY KEY AUTO_INCREMENT, new_col VARCHAR(50), name VARCHAR(50)); INSERT INTO test.rename VALUES(1, 'a', 'a'), (2, 'b', 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop (id INT PRIMARY KEY AUTO_INCREMENT, new_col VARCHAR(50), name VARCHAR(50)); INSERT INTO test.drop VALUES(1, 'a', 'a'), (2, 'b', 'b');" test
+
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    innodb_wait_for_flush_all
+  fi
+
+
+  xtrabackup --backup --target-dir=$topdir/backup_drop_column \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_drop_column.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_drop_column/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # Drop column from the table and generate redo
+  QUERY="ALTER TABLE test.keep DROP COLUMN new_col, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.keep VALUES (3, 'c'), (4, 'd');" test
+
+  # Drop column from the table, generate redo, rename the table and generate redo
+  QUERY="ALTER TABLE test.rename DROP COLUMN new_col, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.rename VALUES (3, 'c'), (4, 'd');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.rename TO test.after_rename; INSERT INTO test.after_rename VALUES (5, 'e'), (6, 'f');" test
+
+  # Drop column from the table, generate redo and drop the table
+  QUERY="ALTER TABLE test.drop DROP COLUMN new_col, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+    else
+    QUERY+="INPLACE"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.drop VALUES (3, 'c'), (4, 'd'); DROP TABLE test.drop;" test
+
+  # Create table, generate redo and drop column
+  QUERY="CREATE TABLE test.new (id INT PRIMARY KEY AUTO_INCREMENT, new_col VARCHAR(50), name VARCHAR(50)); INSERT INTO test.new VALUES(1, 'a', 'a'), (2, 'b', 'b'); ALTER TABLE test.new DROP COLUMN new_col, ALGORITHM="
+  if [ "$INSTANT" = "true" ]; then
+    QUERY+="INSTANT"
+  else
+    QUERY+="INPLACE"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "${QUERY} ; INSERT INTO test.new VALUES (3, 'c'), (4, 'd');" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  xtrabackup --prepare --target-dir=$topdir/backup_drop_column
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_drop_column
+  start_server
+  verify_db_state test
+
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_drop_column.log $topdir/backup_drop_column
+}
+
+
+# Run test with all tables in backup and algortihm inplace
+run_test true false
+
+# Run test with all tables in backup and algortihm instant
+run_test true true
+
+# Run test with all tables in redo and algortihm inplace
+run_test false false
+
+# Run test with all tables in redo and algortihm instant
+run_test false true
+

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_drop_index.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/alter_table_drop_index.sh
@@ -1,0 +1,80 @@
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_server
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  start_server
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_keep (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50), KEY(name)); INSERT INTO test.secondary_idx_keep VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_rename (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50), KEY(name)); INSERT INTO test.secondary_idx_rename VALUES(1, 'a'), (2, 'b');" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_drop (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50), KEY(name)); INSERT INTO test.secondary_idx_drop VALUES(1, 'a'), (2, 'b');" test
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    innodb_wait_for_flush_all
+  fi
+
+
+  xtrabackup --backup --target-dir=$topdir/backup_optimized_ddl \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_optimized_ddl.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_optimized_ddl/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # Add secondary index
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_keep DROP INDEX name;" test
+
+  # Add secondary index and rename table
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_rename DROP INDEX name; RENAME TABLE test.secondary_idx_rename TO test.secondary_idx_after_rename" test
+
+  # Add secondary index and drop table
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.secondary_idx_drop DROP INDEX name; DROP TABLE test.secondary_idx_drop;" test
+
+  # Create table and generate redo
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.secondary_idx_new (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50), KEY(name)); INSERT INTO test.secondary_idx_new VALUES(1, 'a'), (2, 'b'); ALTER TABLE test.secondary_idx_new DROP INDEX name;" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  original_keep_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_keep FORCE INDEX(name);" | awk {'print $1'}`
+  original_rename_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_after_rename FORCE INDEX(name);" | awk {'print $1'}`
+  xtrabackup --prepare --target-dir=$topdir/backup_optimized_ddl
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_optimized_ddl
+  start_server
+  verify_db_state test
+  restored_keep_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_keep FORCE INDEX(name);" | awk {'print $1'}`
+  restored_rename_table_row_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.secondary_idx_after_rename FORCE INDEX(name);" | awk {'print $1'}`
+
+  if [ "$original_keep_table_row_count" != "$restored_keep_table_row_count" ]; then
+    die "rows in table secondary_idx_keep is $restored_keep_table_row_count when it should be $original_keep_table_row_count"
+  fi
+
+  if [ "$original_rename_table_row_count" != "$restored_rename_table_row_count" ]; then
+    die "rows in table secondary_idx_after_rename is $restored_rename_table_row_count when it should be $original_rename_table_row_count"
+  fi
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_optimized_ddl.log $topdir/backup_optimized_ddl
+}
+
+
+# Run test with all tables in backup
+run_test true
+
+# Run test ensure DDL for create tables are part of redo log entries
+run_test false

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/basic_operation.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/basic_operation.sh
@@ -1,0 +1,97 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+
+function run_test() {
+  local TEST_TYPE=$1
+
+  start_server
+  vlog "Running test with ${TEST_TYPE}"
+  if [[ $TEST_TYPE = "special_char" ]]; then
+    DELETE_TABLE="delete_Ѭtable"
+    ORIGINAL_TABLE="original_Ѭtable"
+    RENAMED_TABLE="renamed_Ѭtable"
+    OP_DDL_TABLE="op_Ѭddl"
+    NEW_TABLE="new_Ѭtable"
+    DELETE_TABLE_IN_DISK="delete_@U2table"
+    ORIGINAL_TABLE_IN_DISK="original_@U2table"
+    RENAMED_TABLE_IN_DISK="renamed_@U2table"
+    NEW_TABLE_IN_DISK="new_@U2table"
+  elif [[ $TEST_TYPE = "normal" ]]; then
+    DELETE_TABLE="delete_table"
+    ORIGINAL_TABLE="original_table"
+    RENAMED_TABLE="renamed_table"
+    OP_DDL_TABLE="op_ddl"
+    NEW_TABLE="new_table"
+    DELETE_TABLE_IN_DISK="delete_table"
+    ORIGINAL_TABLE_IN_DISK="original_table"
+    RENAMED_TABLE_IN_DISK="renamed_table"
+    NEW_TABLE_IN_DISK="new_table"
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.${DELETE_TABLE} (id INT PRIMARY KEY AUTO_INCREMENT);" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.${ORIGINAL_TABLE} (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.${ORIGINAL_TABLE} VALUES(1)" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.${OP_DDL_TABLE} (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.${OP_DDL_TABLE} VALUES(1, 'test')" test
+
+  innodb_wait_for_flush_all
+
+  xtrabackup --backup --target-dir=$topdir/backup_new_table \
+    --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_new_table.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # Generate redo on table than delete it
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.${DELETE_TABLE} VALUES (1); DROP TABLE test.${DELETE_TABLE};" test
+
+  # Create table and generate redo
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.${NEW_TABLE} (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.${NEW_TABLE} VALUES (), ();" test
+
+  # Rename table and generate redo
+  $MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.${ORIGINAL_TABLE} TO test.${RENAMED_TABLE}; INSERT INTO test.${RENAMED_TABLE} VALUES (2);" test
+
+  # Bulk Index Load and generate redo
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.${OP_DDL_TABLE} ADD INDEX(name); INSERT INTO test.${OP_DDL_TABLE} VALUES (2, 'test2');" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/${DELETE_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+     die "xtrabackup did not handle delete table DDL"
+  fi
+
+  if ! egrep -q "DDL tracking : LSN: [0-9]* create space ID: [0-9]* Name: test/${NEW_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+     die "xtrabackup did not handle new table DDL"
+  fi
+
+  if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/${ORIGINAL_TABLE_IN_DISK}.ibd To: test/${RENAMED_TABLE_IN_DISK}.ibd" $topdir/backup_with_new_table.log ; then
+     die "xtrabackup did not handle rename table DDL"
+  fi
+
+  if ! egrep -q "DDL tracking : LSN: [0-9]* add index on space ID: [0-9]*" $topdir/backup_with_new_table.log ; then
+     die "xtrabackup did not handle Bulk Index Load DDL"
+  fi
+
+  xtrabackup --prepare --target-dir=$topdir/backup_new_table
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_new_table
+  start_server
+  verify_db_state test
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_new_table
+}
+
+run_test normal
+run_test special_char

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/create_user.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/create_user.sh
@@ -1,0 +1,44 @@
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.table VALUES (), (), (), ();" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_new_user \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_user/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# CREATE USER
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE USER u1@localhost IDENTIFIED BY 'SomeStr0ngPWD!';"
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_user
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_user
+start_server
+
+ROWS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM mysql.user WHERE User = 'u1'"`
+if [ "$ROWS" != "1" ]; then
+  vlog "User u1 not found in mysql.user"
+  exit 1
+fi
+
+USER=`${MYSQL} ${MYSQL_ARGS} -u u1 -p'SomeStr0ngPWD!' -Ns -e "SELECT CURRENT_USER()"`
+if [ "$USER" != "u1@localhost" ]; then
+  vlog "not able to login with new user u1"
+  exit 1
+fi

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/ddl_between_discovery_and_file_open.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/ddl_between_discovery_and_file_open.sh
@@ -1,0 +1,180 @@
+###############################################################################
+# PXB-3220: Tolerate file deletion/rename between discovery and file open
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.drop_table VALUES(1);" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.rename_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.rename_table VALUES(1);" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.alter_rename_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.alter_rename_table VALUES(1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.alter_drop_column_table (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.alter_drop_column_table VALUES(1, 'test')" test
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="xtrabackup_suspend_between_file_discovery_and_open" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Delete table
+run_cmd $MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.drop_table;" test
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.rename_table TO test.new_rename_table; INSERT INTO test.new_rename_table VALUES(2);" test
+# Alter table rename and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.alter_rename_table RENAME test.new_alter_rename_table; INSERT INTO test.new_alter_rename_table VALUES(2);" test
+# Alter table drop column and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.alter_drop_column_table DROP COLUMN name; INSERT INTO test.alter_drop_column_table VALUES(2);" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/rename_table.ibd To: test/new_rename_table.ibd" $topdir/backup.log ; then
+    die "xtrabackup did not handle rename table DDL"
+fi
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/alter_rename_table.ibd To: test/new_alter_rename_table.ibd" $topdir/backup.log ; then
+    die "xtrabackup did not handle alter table rename DDL"
+fi
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test
+
+echo
+echo PXB-3253 : [ERROR] [MY-012592] [InnoDB] Operating system error number 2 in a file operation
+echo
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.drop_table VALUES(1);" test
+
+innodb_wait_for_flush_all
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup_background --backup --target-dir=$BACKUP_DIR --debug="d,before_file_open_dbug" --lock-ddl=REDUCED
+
+XB_PID=$!
+pid_file=$BACKUP_DIR/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+# Delete table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.drop_table;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $XB_PID
+run_cmd wait $XB_PID
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+record_db_state test
+
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+verify_db_state test
+
+echo
+echo PXB-3120 : Assertion failure: Dir_Walker::is_directory
+echo
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.drop_table VALUES(1);" test
+
+innodb_wait_for_flush_all
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup_background --backup --target-dir=$BACKUP_DIR --debug="d,dir_walker_dbug" --lock-ddl=REDUCED
+
+XB_PID=$!
+pid_file=$BACKUP_DIR/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+# Delete table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.drop_table;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $XB_PID
+run_cmd wait $XB_PID
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+record_db_state test
+
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+verify_db_state test
+
+echo
+echo PXB-3245: Assertion failure: fil0fil.cc:2545:err == DB_SUCCESS found during incremental backup with lock-ddl=REDUCED
+echo
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.drop_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.drop_table VALUES(1);" test
+
+innodb_wait_for_flush_all
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup_background --backup --target-dir=$BACKUP_DIR --debug="d,shard_create_node" --lock-ddl=REDUCED
+
+XB_PID=$!
+pid_file=$BACKUP_DIR/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+# Delete table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.drop_table;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $XB_PID
+run_cmd wait $XB_PID
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: test/drop_table.ibd" $XB_ERROR_LOG ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+record_db_state test
+
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+verify_db_state test
+
+stop_server
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_alter_MK.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_alter_MK.sh
@@ -1,0 +1,34 @@
+## This test will be changed once https://jira.percona.com/browse/PXB-3197 is implemented
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+configure_server_with_component
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT) ENCRYPTION='Y'; INSERT INTO test.enc_table VALUES (), (), (), ();" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_alter_MK \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_alter_MK.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_alter_MK/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER INSTANCE ROTATE INNODB MASTER KEY;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.enc_table VALUES ();" test
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd_expect_failure wait $job_pid
+
+if ! egrep -q "Encryption information in datafile: test/enc_table.ibd can't be decrypted, please confirm that keyring is loaded" $topdir/backup_alter_MK.log ; then
+    die "xtrabackup did not failed due to missing encryption information"
+fi
+

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_force.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_force.sh
@@ -1,0 +1,40 @@
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+configure_server_with_component
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.enc_table VALUES (), (), (), ();" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_new_table \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Encrypt table
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='Y';" test
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='N';" test
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='Y';" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_table --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_table --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+cp ${instance_local_manifest}  $mysql_datadir
+cp ${keyring_component_cnf} $mysql_datadir
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace.sh
@@ -1,0 +1,66 @@
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  configure_server_with_component
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLESPACE ts1 Engine=InnoDB ENCRYPTION = 'Y';CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT) TABLESPACE ts1 ENCRYPTION='Y'; INSERT INTO test.enc_table VALUES (), (), (), ();" test
+    innodb_wait_for_flush_all
+  fi
+
+  xtrabackup --backup --target-dir=$topdir/backup_enc_general_tablespace \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_enc_general_tablespace.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_enc_general_tablespace/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  # Encrypt table
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLESPACE ts1 Engine=InnoDB ENCRYPTION = 'Y';CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT) TABLESPACE ts1 ENCRYPTION='Y'; INSERT INTO test.enc_table VALUES (), (), (), ();" test
+    innodb_wait_for_flush_all
+  fi
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION = 'N';" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION = 'Y';" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION = 'N';" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION = 'Y';" test
+
+  # Insert some more data
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.enc_table VALUES (), (), (), ();" test
+
+
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  cp ${instance_local_manifest}  $mysql_datadir
+  cp ${keyring_component_cnf} $mysql_datadir
+  start_server
+  verify_db_state test
+
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_enc_general_tablespace.log $topdir/backup_enc_general_tablespace
+}
+
+run_test true
+
+run_test false

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
@@ -1,0 +1,106 @@
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_sync_thread
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  configure_server_with_component
+
+  XB_ERROR_LOG=$topdir/backup_with_enc_general_tablespace.log
+
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd' Engine=InnoDB ENCRYPTION = 'Y';CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT) TABLESPACE ts1 ENCRYPTION='Y'; INSERT INTO test.enc_table VALUES (), (), (), ();" test
+  innodb_wait_for_flush_all
+
+	xtrabackup_background --backup --target-dir=$topdir/backup_enc_general_tablespace --debug-sync-thread="before_file_copy" --lock-ddl=REDUCED
+
+  job_pid=$XB_PID
+
+	wait_for_debug_sync_thread "before_file_copy"
+
+	echo "Now pause redo thread"
+	echo "xtrabackup_copy_logfile_pause" > $topdir/backup_enc_general_tablespace/xb_debug_sync_thread
+	kill -SIGUSR1 $job_pid
+
+	wait_for_debug_sync_thread "xtrabackup_copy_logfile_pause"
+
+  echo "Now re-encrypt the tablespace Y->N-Y"
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION='N';ALTER TABLESPACE ts1 ENCRYPTION='Y';" test
+
+  echo "Now resume copying thread"
+	resume_debug_sync_thread  "before_file_copy" $topdir/backup_enc_general_tablespace
+
+  echo "Now resume redo copy thread"
+	resume_debug_sync_thread "xtrabackup_copy_logfile_pause" $topdir/backup_enc_general_tablespace
+
+	wait $XB_PID
+	exit_status=$?
+
+  # Check the exit status and take appropriate action
+  if [ $exit_status -eq 0 ]; then
+      echo "xtrabackup_background exited successfully."
+  else
+      echo "xtrabackup_background exited with an error (exit status: $exit_status)."
+			exit 1
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.enc_table VALUES (), (), (), ();" test
+	$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t2(a INT); INSERT INTO t2 VALUES (1),(2),(3),(4),(5);" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE mysql ENCRYPTION='Y';" test
+
+  XB_ERROR_LOG=$topdir/backup_inc.log
+	BACKUP_DIR=$topdir/backup_inc
+	xtrabackup_background --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_enc_general_tablespace --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
+
+	wait_for_debug_sync_thread "before_file_copy"
+
+	echo "Now pause redo thread"
+	echo "xtrabackup_copy_logfile_pause" > $BACKUP_DIR/xb_debug_sync_thread
+	kill -SIGUSR1 $XB_PID
+
+	wait_for_debug_sync_thread "xtrabackup_copy_logfile_pause"
+
+  echo "Now re-encrypt the tablespace Y->N-Y"
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE mysql ENCRYPTION='N';ALTER TABLESPACE mysql ENCRYPTION='Y';" test
+
+  echo "Now resume copying thread"
+	resume_debug_sync_thread  "before_file_copy" $BACKUP_DIR
+
+  echo "Now resume redo copy thread"
+	resume_debug_sync_thread "xtrabackup_copy_logfile_pause" $BACKUP_DIR
+
+	echo "################reached waitpid#######################"
+	wait $XB_PID
+	exit_status=$?
+
+  # Check the exit status and take appropriate action
+  if [ $exit_status -eq 0 ]; then
+      echo "xtrabackup_background exited successfully."
+  else
+      echo "xtrabackup_background exited with an error (exit status: $exit_status)."
+			exit 1
+  fi
+
+  record_db_state test
+  stop_server
+  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace --incremental-dir=$topdir/backup_inc --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  cp ${instance_local_manifest}  $mysql_datadir
+  cp ${keyring_component_cnf} $mysql_datadir
+
+  start_server
+  verify_db_state test
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_enc_general_tablespace.log $topdir/backup_enc_general_tablespace $topdir/backup_inc
+}
+
+run_test true

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
@@ -1,0 +1,112 @@
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_sync_thread
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  configure_server_with_component
+  mkdir $topdir/external
+
+  stop_server
+  start_server --innodb_directories=$topdir/external/
+
+  XB_ERROR_LOG=$topdir/backup_with_enc_general_tablespace_external.log
+
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLESPACE ts1 ADD DATAFILE '$topdir/external/ts1.ibd' Engine=InnoDB ENCRYPTION = 'Y';CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT) TABLESPACE ts1 ENCRYPTION='Y'; INSERT INTO test.enc_table VALUES (), (), (), ();" test
+  innodb_wait_for_flush_all
+
+	xtrabackup_background --backup --target-dir=$topdir/backup_enc_general_tablespace_external --debug-sync-thread="before_file_copy" --lock-ddl=REDUCED
+
+  job_pid=$XB_PID
+
+	wait_for_debug_sync_thread "before_file_copy"
+
+	echo "Now pause redo thread"
+	echo "xtrabackup_copy_logfile_pause" > $topdir/backup_enc_general_tablespace_external/xb_debug_sync_thread
+	kill -SIGUSR1 $job_pid
+
+	wait_for_debug_sync_thread "xtrabackup_copy_logfile_pause"
+
+  echo "Now re-encrypt the tablespace Y->N-Y"
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 ENCRYPTION='N';ALTER TABLESPACE ts1 ENCRYPTION='Y';" test
+
+  echo "Now resume copying thread"
+	resume_debug_sync_thread  "before_file_copy" $topdir/backup_enc_general_tablespace_external
+
+  echo "Now resume redo copy thread"
+	resume_debug_sync_thread "xtrabackup_copy_logfile_pause" $topdir/backup_enc_general_tablespace_external
+
+	wait $XB_PID
+	exit_status=$?
+
+  # Check the exit status and take appropriate action
+  if [ $exit_status -eq 0 ]; then
+      echo "xtrabackup_background exited successfully."
+  else
+      echo "xtrabackup_background exited with an error (exit status: $exit_status)."
+			exit 1
+  fi
+
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.enc_table VALUES (), (), (), ();" test
+  $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t2(a INT); INSERT INTO t2 VALUES (1),(2),(3),(4),(5);" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE mysql ENCRYPTION='Y';" test
+
+  XB_ERROR_LOG=$topdir/backup_inc.log
+	BACKUP_DIR=$topdir/backup_inc_external
+	xtrabackup_background --backup --target-dir=$topdir/backup_inc_external --incremental-basedir=$topdir/backup_enc_general_tablespace_external --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
+
+	wait_for_debug_sync_thread "before_file_copy"
+
+	echo "Now pause redo thread"
+	echo "xtrabackup_copy_logfile_pause" > $BACKUP_DIR/xb_debug_sync_thread
+	kill -SIGUSR1 $XB_PID
+
+	wait_for_debug_sync_thread "xtrabackup_copy_logfile_pause"
+
+  echo "Now re-encrypt the tablespace Y->N-Y"
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE mysql ENCRYPTION='N';ALTER TABLESPACE mysql ENCRYPTION='Y';" test
+
+  echo "Now resume copying thread"
+	resume_debug_sync_thread  "before_file_copy" $BACKUP_DIR
+
+  echo "Now resume redo copy thread"
+	resume_debug_sync_thread "xtrabackup_copy_logfile_pause" $BACKUP_DIR
+
+	echo "################reached waitpid#######################"
+	wait $XB_PID
+	exit_status=$?
+
+  # Check the exit status and take appropriate action
+  if [ $exit_status -eq 0 ]; then
+      echo "xtrabackup_background exited successfully."
+  else
+      echo "xtrabackup_background exited with an error (exit status: $exit_status)."
+			exit 1
+  fi
+
+  record_db_state test
+  stop_server
+
+  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_enc_general_tablespace_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace_external --incremental-dir=$topdir/backup_inc_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+  rm -rf $mysql_datadir/*
+  rm -rf $topdir/external/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_enc_general_tablespace_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  cp ${instance_local_manifest}  $mysql_datadir
+  cp ${keyring_component_cnf} $mysql_datadir
+
+  start_server
+  verify_db_state test
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_enc_general_tablespace_external.log $topdir/backup_enc_general_tablespace_external $topdir/external $topdir/backup_inc_external
+}
+
+run_test true

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_single_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_single_tablespace.sh
@@ -1,0 +1,60 @@
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+
+function run_test() {
+  ALL_TABLES_IN_BACKUP=$1
+
+  vlog "Running test with ALL_TABLES_IN_BACKUP=$ALL_TABLES_IN_BACKUP"
+
+  configure_server_with_component
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "true" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.enc_table VALUES (), (), (), ();" test
+    innodb_wait_for_flush_all
+  fi
+
+  xtrabackup --backup --target-dir=$topdir/backup_new_table \
+    --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+    2> >( tee $topdir/backup_with_new_table.log)&
+
+  job_pid=$!
+  pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+  wait_for_xb_to_suspend $pid_file
+  xb_pid=`cat $pid_file`
+  echo "backup pid is $job_pid"
+
+  if [ "$ALL_TABLES_IN_BACKUP" = "false" ]; then
+    $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.enc_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.enc_table VALUES (), (), (), ();" test
+    innodb_wait_for_flush_all
+  fi
+
+  # Encrypt table
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='Y';" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='N';" test
+  $MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.enc_table ENCRYPTION='Y';" test
+
+  # Resume the xtrabackup process
+  vlog "Resuming xtrabackup"
+  kill -SIGCONT $xb_pid
+  run_cmd wait $job_pid
+
+  xtrabackup --prepare --target-dir=$topdir/backup_new_table --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  record_db_state test
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup_new_table --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  cp ${instance_local_manifest}  $mysql_datadir
+  cp ${keyring_component_cnf} $mysql_datadir
+  start_server
+  verify_db_state test
+  stop_server
+  rm -rf $mysql_datadir $topdir/backup_with_new_table.log $topdir/backup_new_table
+}
+
+run_test true
+
+run_test false

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/external_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/external_tablespaces.sh
@@ -1,0 +1,184 @@
+########################################################################
+# Test support for external tablespaces
+########################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+vlog "case #1: ensure external undo tablespaces are copied"
+
+undo_directory_ext=$TEST_VAR_ROOT/var1/undo_dir_ext
+mkdir -p $undo_directory_ext
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_undo_directory=$undo_directory_ext
+"
+
+start_server
+$MYSQL $MYSQL_ARGS -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+$MYSQL $MYSQL_ARGS -e "INSERT INTO t1 VALUES (1)" test
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_003 ADD DATAFILE 'undo_003.ibu'"
+
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$topdir/backup \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $topdir/backup.log)&
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_1 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE UNDO_003 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_001 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 3s
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q "Deleted undo file: $undo_directory_ext/undo_1.ibu : [0-9]*" $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL for undo_1.ibu"
+fi
+
+if ! egrep -q "Deleted undo file: $undo_directory_ext/undo_003.ibu : [0-9]*" $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL for undo_003.ibu"
+fi
+
+if ! egrep -q "Deleted undo file: $undo_directory_ext/undo_001 : [0-9]*" $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL for undo_001"
+fi
+
+del_count=$(egrep -o "Done: Writing file $topdir/backup/[0-9]*.del" $topdir/backup.log | wc -l)
+
+if ["$del_count" -ne 3]; then
+    die "xtrabackup did not create .del file"
+fi 
+
+if ! egrep -q "New undo file: $undo_directory_ext/undo_1.ibu : [0-9]*" $topdir/backup.log ; then
+    die "xtrabackup did not handle new table DDL"
+fi
+
+if ! egrep -q "Done: Copying $undo_directory_ext/undo_1.ibu to $topdir/backup/undo_1.ibu.new" $topdir/backup.log ; then
+    die "xtrabackup did not create undo_1.ibu.new file"
+fi
+
+if ! egrep -q "Done: Copying $undo_directory_ext/undo_003.ibu to $topdir/backup/undo_003.ibu.new" $topdir/backup.log ; then
+    die "xtrabackup did not create undo_003.ibu.new file"
+fi
+
+if ! egrep -q "Done: Copying $undo_directory_ext/undo_001 to $topdir/backup/undo_001.new" $topdir/backup.log ; then
+    die "xtrabackup did not create undo_001.new file"
+fi
+
+
+
+
+
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=default"
+xtrabackup --prepare --target-dir=$topdir/backup
+stop_server
+rm -rf $MYSQLD_DATADIR/*
+rm -rf $undo_directory_ext/*
+xtrabackup --copy-back --target-dir=$topdir/backup --innodb_undo_directory=$undo_directory_ext
+start_server
+
+stop_server
+rm -rf $MYSQLD_DATADIR
+rm -rf $undo_directory_ext
+
+
+
+vlog "case #2: ensure external file-per-table and general tablespaces are handled"
+
+data_directory_ext=$TEST_VAR_ROOT/var1/data_dir_ext
+mkdir -p $data_directory_ext
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_directories=$data_directory_ext
+"
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.DELETE_TABLE (id INT PRIMARY KEY AUTO_INCREMENT) DATA DIRECTORY = '$data_directory_ext';" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.ORIGINAL_TABLE (id INT PRIMARY KEY AUTO_INCREMENT) DATA DIRECTORY = '$data_directory_ext'; INSERT INTO test.ORIGINAL_TABLE VALUES(1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.OP_DDL_TABLE (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)) DATA DIRECTORY = '$data_directory_ext'; INSERT INTO test.OP_DDL_TABLE VALUES(1, 'test')" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLESPACE ts1 ADD DATAFILE '$data_directory_ext/ts1.ibd'  Engine=InnoDB; CREATE TABLE test.TS1_TABLE (id INT PRIMARY KEY AUTO_INCREMENT) TABLESPACE ts1; INSERT INTO test.TS1_TABLE VALUES (), (), (), ();" test
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_new_table \
+--debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Generate redo on table than delete it
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.DELETE_TABLE VALUES (1); DROP TABLE test.DELETE_TABLE;" test
+
+# Create table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.NEW_TABLE (id INT PRIMARY KEY AUTO_INCREMENT) DATA DIRECTORY = '$data_directory_ext'; INSERT INTO test.NEW_TABLE VALUES (), ();" test
+
+# Bulk Index Load and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.OP_DDL_TABLE ADD INDEX(name); INSERT INTO test.OP_DDL_TABLE VALUES (2, 'test2');" test
+
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLESPACE ts1 RENAME TO ts2;" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE TS1_TABLE;" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLESPACE ts2;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: $data_directory_ext/test/DELETE_TABLE.ibd" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+if ! egrep -q "Done: Writing file $topdir/backup_new_table/test/[0-9]*.del" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not create .del file"
+fi
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* delete space ID: [0-9]* Name: $data_directory_ext/ts1.ibd" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not handle delete tablespace DDL"
+fi
+
+if ! egrep -q "Done: Writing file $topdir/backup_new_table/[0-9]*.del" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not create .del file for tablespace"
+fi
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* create space ID: [0-9]* Name: $data_directory_ext/test/NEW_TABLE.ibd" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not handle new table DDL"
+fi
+
+if ! egrep -q "Done: Copying $data_directory_ext/test/OP_DDL_TABLE.ibd to $topdir/backup_new_table/test/OP_DDL_TABLE.ibd.new" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not create OP_DDL_TABLE.ibd.new file"
+fi
+
+if ! egrep -q "DDL tracking : LSN: [0-9]* add index on space ID: [0-9]*" $topdir/backup_with_new_table.log ; then
+    die "xtrabackup did not handle Bulk Index Load DDL"
+fi
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_table
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+rm -rf $data_directory_ext/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_table
+
+if [ ! -f $mysql_datadir/ibdata1 ] ; then
+	die "Data files were not copied to correct place!"
+fi
+
+start_server
+verify_db_state test
+stop_server
+rm -rf $mysql_datadir $topdir/backup_new_table $data_directory_ext
+

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
@@ -1,0 +1,60 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.delete_table (id INT PRIMARY KEY AUTO_INCREMENT);" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table VALUES(1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.op_ddl (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50)); INSERT INTO test.op_ddl VALUES(1, 'test')" test
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.original_table VALUES (2);" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+
+# Generate redo on table than delete it
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.delete_table VALUES (1); DROP TABLE test.delete_table;" test
+
+# Create table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table VALUES (), ();" test
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.original_table TO test.renamed_table; INSERT INTO test.renamed_table VALUES (3);" test
+
+# Bulk Index Load and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.op_ddl ADD INDEX(name); INSERT INTO test.op_ddl VALUES (2, 'test2');" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
@@ -1,0 +1,53 @@
+###############################################################################
+# PXB-3320: prepare_handle_del_files() fails to delete the .meta and .delta files
+#           for deleted tablespaces in incremental backup directory
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+
+innodb_wait_for_flush_all
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t2(a INT)" test
+
+xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Generate redo on table than delete it
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t2 VALUES (1); DROP TABLE test.t2;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+# Ensure that t2.ibd shouldn't be present
+FILE=$topdir/backup_base/test/t2.ibd
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server has dropped the table during incremental"
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test
+rm -rf $topdir/backup_base
+rm -rf $topdir/backup_inc
+rm $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
@@ -1,0 +1,58 @@
+###############################################################################
+# PXB-3246: Assertion failure: log0recv.cc:2141:!page || fil_page_type_is_index(page_type)
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY AUTO_INCREMENT);" test
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+
+innodb_wait_for_flush_all
+
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE t1 to t2" test
+
+xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Generate redo on table than delete it
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t2 VALUES (1); DROP TABLE test.t2;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+# Ensure two things. t1.ibd and t2.ibd shouldn't be present
+FILE=$topdir/backup_base/test/t1.ibd
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server has dropped the table during incremental"
+
+FILE=$topdir/backup_base/test/t2.ibd
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server has dropped the table during incremental"
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test
+rm -rf $topdir/backup_base
+rm -rf $topdir/backup_inc
+rm $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
@@ -1,0 +1,57 @@
+###############################################################################
+# PXB-3318 : prepare_handle_ren_files(): failed to handle .ren files
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+
+innodb_wait_for_flush_all
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t1(a INT);" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 VALUES (1),(2),(3),(4)" test
+
+xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Generate redo on table t
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE t1 to t2" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+# Ensure two things. t1.ibd shouldn't be present
+FILE=$topdir/backup_base/test/t1.ibd
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server has renamed the table to t2 during incremental"
+
+# t2.ibd should be present
+FILE=$topdir/backup_base/test/t2.ibd
+[ -f $FILE ] || die "$FILE doesn't exists. It should have been present after rename from t1 to t2"
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test
+rm -rf $topdir/backup_base
+rm -rf $topdir/backup_inc
+rm $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/optimize_table.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/optimize_table.sh
@@ -1,0 +1,34 @@
+. inc/common.sh
+
+require_pro_pxb_version
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.table VALUES (), (), (), ();" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_new_table \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Encrypt table
+$MYSQL $MYSQL_ARGS -Ns -e "OPTIMIZE TABLE test.table ;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_table
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_table
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/page_tracking_disallowed.test
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/page_tracking_disallowed.test
@@ -1,0 +1,12 @@
+###############################################################################
+# PXB-3246: Assertion failure: log0recv.cc:2141:!page || fil_page_type_is_index(page_type)
+###############################################################################
+
+. inc/common.sh
+require_pro_pxb_version
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED  --page-tracking 2> >(tee $topdir/backup_error.log)
+
+if ! egrep -q "\--page-tracking and --lock-ddl=REDUCED cannot be enabled together" $topdir/backup_error.log ; then
+    die "xtrabackup didn't handle page-tracking and lock-ddl=REDUCED"
+fi

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/parallel_copy.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/parallel_copy.sh
@@ -1,0 +1,44 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="ddl_tracker_before_lock_ddl" --parallel=10 --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+for i in {1..100} ; do
+    $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.tb_${i} (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.tb_${i} VALUES (1)" test
+done;
+
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+# xtrabackup uses an ever incremental thread ID. Second phase copy will start from 20+
+if ! egrep -q '[1-3][0-9] \[Note\] \[MY-[0-9]*\] \[Xtrabackup\] Copying test/tb_[0-9]*\.ibd to .*/test/tb_[0-9]*.ibd.new' $topdir/backup.log ; then
+    die "xtrabackup did not copied tables in parallel"
+fi
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/partial_backup.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/partial_backup.sh
@@ -1,0 +1,56 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="ddl_tracker_before_lock_ddl" --tables=test.to_backup --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.to_backup (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.to_backup VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.to_skip (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.to_skip VALUES (1)" test
+
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ls $topdir/backup/test/to_skip* 2>/dev/null; then
+    die "xtrabackup did not skip table"
+fi
+
+if ! ls $topdir/backup/test/to_backup* 2>/dev/null; then
+    die "xtrabackup did not backup table"
+fi
+
+xtrabackup --prepare --export --target-dir=$topdir/backup
+
+$MYSQL $MYSQL_ARGS -Ns -e "TRUNCATE TABLE test.to_backup" test
+
+ROWS=`${MYSQL} ${MYSQL_ARGS}  -Ns -e "SELECT COUNT(*) FROM test.to_backup" test`
+if [ "$ROWS" != "0" ]; then
+    die "xtrabackup did not truncate table"
+fi
+
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.to_backup DISCARD TABLESPACE" test
+cp -R $topdir/backup/test/to_backup* $mysql_datadir/test/
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.to_backup IMPORT TABLESPACE" test
+
+ROWS=`${MYSQL} ${MYSQL_ARGS}  -Ns -e "SELECT COUNT(*) FROM test.to_backup" test`
+if [ "$ROWS" != "1" ]; then
+    die "xtrabackup did not import tablespace"
+fi

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/reduced_lock_same_table.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/reduced_lock_same_table.sh
@@ -1,0 +1,51 @@
+###############################################################################
+# PXB-XXXX: Reduce the time the instance remain under lock
+# Test PXB-2683
+# This tests the same scenario with two variants
+# 1. The table is created before the backup starts - copy thread will copy its .ibd
+# 2. The table is created after the backup starts - DDL Tracker will copy its .ibd after the backup completes
+###############################################################################
+
+. inc/common.sh
+
+require_pro_pxb_version
+require_debug_pxb_version
+require_debug_server
+start_server
+
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table_in_backup (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table_in_backup VALUES (),(),(),(),()" test
+innodb_wait_for_flush_all
+
+$MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+
+xtrabackup --backup --target-dir=$topdir/backup_new_table \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE original_table_in_backup TO original_table_in_backup_renamed;" test
+$MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_page_cleaner_disabled_debug=true;"
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table_in_backup (id INT PRIMARY KEY AUTO_INCREMENT) KEY_BLOCK_SIZE=4;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.original_table_in_backup VALUES (),();" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE original_table_in_backup_renamed;" test
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE original_table_in_backup TO original_table_in_backup_renamed;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_table
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_table
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_different_database.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_different_database.sh
@@ -1,0 +1,44 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table VALUES(1); CREATE DATABASE test2;" test
+innodb_wait_for_flush_all
+
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.original_table TO test2.renamed_table; INSERT INTO test2.renamed_table VALUES (2);" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+# Ensure we have DDL tracking in the log renaming the table
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/original_table.ibd To: test2/renamed_table.ibd' $topdir/backup.log ; then
+    die "xtrabackup did not handle rename table DDL"
+fi
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_multiple_times.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_multiple_times.sh
@@ -1,0 +1,41 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table VALUES(1);" test
+innodb_wait_for_flush_all
+
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.original_table TO test.renamed_table; INSERT INTO test.renamed_table VALUES (2);" test
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.renamed_table TO test.renamed_table2; INSERT INTO test.renamed_table2 VALUES (3);" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_within_checkpoint_age.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_within_checkpoint_age.sh
@@ -1,0 +1,44 @@
+###############################################################################
+# PXB-3034: Reduce the time the instance remain under lock
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+require_debug_server
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_checkpoint_disabled=true;"
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table VALUES(1)" test
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.original_table TO test.renamed_table; INSERT INTO test.renamed_table VALUES (2);" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+# Ensure we have DDL tracking in the log renaming the table
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/original_table.ibd To: test/renamed_table.ibd' $topdir/backup.log ; then
+    die "xtrabackup did not handle rename table DDL"
+fi
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/rename_then_drop_table.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/rename_then_drop_table.sh
@@ -1,0 +1,96 @@
+#########################################################################################
+# PXB-3227: Rename table and then drop table, make sure that original table was deleted 
+#########################################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.original_table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.original_table VALUES(1);" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="xtrabackup_suspend_at_start" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.original_table TO test.renamed_table; INSERT INTO test.renamed_table VALUES (2);" test
+# Drop table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.renamed_table;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test
+
+if [ -f $mysql_datadir/test/original_table.ibd ] ; then
+    die 'dropped original_table.ibd file has been copied to the datadir'
+fi
+
+stop_server
+rm -rf $topdir/backup
+
+#########################################################################################################
+# PXB-3229: Make sure backup does not fail with `File exists` error trying to create .del file twice 
+#########################################################################################################
+
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.t1 VALUES(1);" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t2 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.t2 VALUES(1);" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="xtrabackup_suspend_at_start" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.t1 TO test.t3; INSERT INTO test.t3 VALUES (2);" test
+# Drop table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.t3;" test
+# Rename table and generate redo
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.t2 TO test.t3; INSERT INTO test.t3 VALUES (2);" test
+# Drop table
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.t3;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test
+stop_server
+rm -rf $mysql_datadir $topdir/backup
+
+
+
+
+

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/system_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/system_tablespace.sh
@@ -1,0 +1,58 @@
+# PXB-3221 : Assertion failure: page0cur.cc:1177:ib::fatal triggered during prepare
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t1(a INT, KEY k1(a)) TABLESPACE=innodb_system;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 VALUES (1),(2),(3),(4)" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+
+innodb_wait_for_flush_all
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$BACKUP_DIR \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $XB_ERROR_LOG)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+mysql -e "ALTER TABLE t1 ADD INDEX k2(a)" test
+mysql -e "ALTER TABLE t1 DROP INDEX k1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+stop_server
+
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+#mysql -e "ALTER TABLE t1 DROP INDEX k1" test
+mysql -e "DELETE FROM t1 WHERE a = 2" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 SELECT * FROM t1" test
+mysql -e "DELETE FROM t1 WHERE a = 2" test
+
+stop_server
+
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/truncate.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/truncate.sh
@@ -1,0 +1,34 @@
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.table (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.table VALUES (), (), (), ();" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_new_table \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_with_new_table.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_new_table/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Encrypt table
+$MYSQL $MYSQL_ARGS -Ns -e "TRUNCATE TABLE test.table ;" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup_new_table
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_new_table
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/undo.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/undo.sh
@@ -1,0 +1,143 @@
+########################################################################
+# Test support for separate UNDO tablespace
+########################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+
+vlog "case #1: ensure truncated  undo tablespace is recopied"
+
+start_server
+$MYSQL $MYSQL_ARGS -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+$MYSQL $MYSQL_ARGS -e "INSERT INTO t1 VALUES (1)" test
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$topdir/backup \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $topdir/backup.log)&
+job_pid=$!
+
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_1 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE innodb_undo_001 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 3s
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q 'Deleted undo file: ./undo_1.ibu : [0-9]*' $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL"
+fi
+
+if ! egrep -q "Deleted undo file: ./undo_001 : [0-9]*" $topdir/backup.log ; then
+    die "xtrabackup did not handle delete table DDL for undo_001"
+fi
+
+if ! egrep -q 'New undo file: ./undo_1.ibu : [0-9]*' $topdir/backup.log ; then
+    die "xtrabackup did not handle new table DDL for undo_1.ibu"
+fi
+
+if ! egrep -q 'New undo file: ./undo_001 : [0-9]*' $topdir/backup.log ; then
+    die "xtrabackup did not handle new table DDL for undo_001"
+fi
+
+
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=default"
+xtrabackup --prepare --target-dir=$topdir/backup
+stop_server
+rm -rf $MYSQLD_DATADIR/*
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+
+stop_server
+rm -rf $MYSQLD_DATADIR
+start_server
+
+echo
+echo PXB-3280 : undo log truncation causes assertion failure with reduced lock
+echo
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup_background --backup --target-dir=$BACKUP_DIR --debug="d,undo_create_node" --lock-ddl=REDUCED
+
+XB_PID=$!
+pid_file=$BACKUP_DIR/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_1 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE UNDO_2 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 1
+
+mysql -e "DROP UNDO TABLESPACE UNDO_1"
+mysql -e "DROP UNDO TABLESPACE UNDO_2"
+
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=default"
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $XB_PID
+run_cmd wait $XB_PID
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+record_db_state test
+
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+verify_db_state test
+
+echo
+echo PXB-3280 : CASE2: undo log truncation causes assertion failure with reduced lock
+echo
+
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup_background --backup --target-dir=$BACKUP_DIR --debug="d,undo_space_open" --lock-ddl=REDUCED
+
+XB_PID=$!
+pid_file=$BACKUP_DIR/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_1 SET INACTIVE"
+mysql -e "ALTER UNDO TABLESPACE UNDO_2 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 1
+
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=default"
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $XB_PID
+run_cmd wait $XB_PID
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+record_db_state test
+
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+verify_db_state test
+
+stop_server
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/undo_2.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/undo_2.sh
@@ -1,0 +1,117 @@
+########################################################################
+# PXB-3295 : Undo tablespaces are not tracked properly with lock-ddl=REDUCED
+########################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+require_pro_pxb_version
+start_server
+
+echo
+echo PXB-3295 : Undo tablespaces are not tracked properly
+echo
+mysql -e "CREATE UNDO TABLESPACE UNDO_1 ADD DATAFILE 'undo_1.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_2 ADD DATAFILE 'undo_2.ibu'"
+mysql -e "CREATE UNDO TABLESPACE UNDO_3 ADD DATAFILE 'undo_3.ibu'"
+XB_ERROR_LOG=$topdir/backup.log
+BACKUP_DIR=$topdir/backup
+rm -rf $BACKUP_DIR
+xtrabackup --backup --lock-ddl=REDUCED --target-dir=$BACKUP_DIR \
+--debug-sync="ddl_tracker_before_lock_ddl" 2> >( tee $XB_ERROR_LOG)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+UNDO_2_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "ALTER UNDO TABLESPACE UNDO_2 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 2
+UNDO_2_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "DROP UNDO TABLESPACE UNDO_2"
+
+# before inactive
+UNDO_3_BI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+
+mysql -e "ALTER UNDO TABLESPACE UNDO_3 SET INACTIVE"
+mysql -e "SET GLOBAL innodb_purge_rseg_truncate_frequency=1"
+sleep 2
+
+# after inactive
+UNDO_3_AI_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+mysql -e "CREATE UNDO TABLESPACE UNDO_4 ADD DATAFILE 'undo_4.ibu'"
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+UNDO_1_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_1'")
+UNDO_4_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_4'")
+
+xtrabackup --prepare --target-dir=$BACKUP_DIR
+stop_server
+
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$BACKUP_DIR
+start_server
+
+UNDO_BACKUP_1_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_1'")
+UNDO_BACKUP_2_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_2'")
+UNDO_BACKUP_3_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space  from information_schema.innodb_tablespaces where name = 'UNDO_3'")
+UNDO_BACKUP_4_SPACE_ID=$($MYSQL $MYSQL_ARGS -BN -e "select space from information_schema.innodb_tablespaces where name = 'UNDO_4'")
+
+echo "UNDO_1 space_id is $UNDO_BACKUP_1_SPACE_ID"
+echo "UNDO_2 space_id is $UNDO_BACKUP_2_SPACE_ID"
+echo "UNDO_3 space_id is $UNDO_BACKUP_3_SPACE_ID"
+echo "UNDO_4 space_id is $UNDO_BACKUP_4_SPACE_ID"
+
+# UNDO_1 no space_id change
+if [ $UNDO_1_SPACE_ID != $UNDO_BACKUP_1_SPACE_ID ]; then
+ echo "space_id of undo_01 shouldn't have changed. Before backup: undo_1 space_id $UNDO_1_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_1_SPACE_ID"
+ exit 1
+fi
+
+## UNDO_4 no space_id change. If we get this it means undo_04 is copied.
+#FILE=$BACKUP_DIR/undo_4.ibu
+#[ -f $FILE ] || die "$FILE did NOT exist. It should have been backuped. It is created before end of backup. Server did CREATE UNDO TABLESPACE undo_04, right before DDL lock is taken"
+#
+#if [ -z ${UNDO_BACKUP_4_SPACE_ID+x} ]; then
+# echo "UNDO TABLESPACE 4 should have been present in backup. But it is not found."
+# exit 1
+#if
+#
+#if [ $UNDO_4_SPACE_ID != $UNDO_BACKUP_4_SPACE_ID ]; then
+# echo "space_id of undo_04 shouldn't have changed. Before backup: undo_4 space_id $UNDO_4_SPACE_ID. After backup and restore undo_4 space_id is $UNDO_BACKUP_4_SPACE_ID"
+# exit 1
+#fi
+
+# UND0_3 should have AI space_id and not BI space_id
+if [ $UNDO_3_AI_SPACE_ID != $UNDO_BACKUP_3_SPACE_ID ]; then
+ echo "space_id of undo_03 should have space_id after truncation. space_id at time of the backup: undo_3 space_id $UNDO_3_AF_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_3_SPACE_ID"
+ exit 1
+fi
+
+# UNDO_3 shouldn't have space_id before truncation
+if [ $UNDO_3_BI_SPACE_ID == $UNDO_BACKUP_3_SPACE_ID ]; then
+ echo "space_id of undo_03 should NOT have space_id before truncation. space_id  before_truncation undo_3 space_id $UNDO_3_BI_SPACE_ID. After backup and restore undo_1 space_id is $UNDO_BACKUP_3_SPACE_ID"
+ exit 1
+fi
+
+FILE=$BACKUP_DIR/undo_2.ibu
+[ ! -f $FILE ] || die "$FILE exists. It should have been deleted by prepare. Server did DROP UNDO TABLESPACE undo_02"
+
+# UNDO_2 should be empty because it was dropped. We should also check physical presence of undo_02.ibu file
+if [ ! -z "${UNDO_BACKUP_2_SPACE_ID}" ]; then
+ echo "UNDO TABLESPACE 2 should have been dropped in backup. Found UNDO_2 with space_id: $UNDO_BACKUP_2_SPACE_ID"
+ exit 1
+fi
+
+
+stop_server
+
+rm -rf $mysql_datadir $BACKUP_DIR
+rm $XB_ERROR_LOG

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
@@ -1,0 +1,102 @@
+. inc/xbcloud_common.sh
+. inc/common.sh
+
+require_pro_pxb_version
+require_debug_pxb_version
+is_xbcloud_credentials_set
+
+start_server
+
+write_credentials
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table1 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table1 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table2 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table2 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table3 (id INT PRIMARY KEY AUTO_INCREMENT, name varchar(10)); INSERT INTO test.new_table3 VALUES (1, 'a')" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table4 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table4 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table5 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table5 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table6 (id INT PRIMARY KEY AUTO_INCREMENT, name varchar(10)); INSERT INTO test.new_table6 VALUES (1, 'a')" test
+
+innodb_wait_for_flush_all
+
+
+vlog "take full backup"
+
+(xtrabackup --backup --target-dir=$topdir/full --stream --extra-lsndir=$topdir/full\
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+| run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+	    --parallel=4 \
+	    ${full_backup_name}) &
+
+job_pid=$!
+pid_file=$topdir/full/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table7 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table7 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.new_table1 TO renamed_table; INSERT INTO test.renamed_table VALUES (2)" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.new_table2" test
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.new_table3 ADD INDEX(name); INSERT INTO test.new_table3 VALUES (2, 'test2');" test
+
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+innodb_wait_for_flush_all
+
+vlog "take incremental backup"
+
+
+
+(xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --stream \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+| run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
+            --parallel=4 \
+      ${inc_backup_name}) &
+job_pid=$!
+pid_file=$topdir/inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.new_table8 (id INT PRIMARY KEY AUTO_INCREMENT); INSERT INTO test.new_table8 VALUES (1)" test
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.new_table4 TO renamed_table2; INSERT INTO test.renamed_table2 VALUES (2)" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.new_table5" test
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.new_table6 ADD INDEX(name); INSERT INTO test.new_table6 VALUES (2, 'test2');" test
+
+# Resume the xtrabackup process
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+innodb_wait_for_flush_all
+record_db_state test
+
+vlog "download and prepare"
+mkdir $topdir/downloaded_full
+mkdir $topdir/downloaded_inc
+
+run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
+        --parallel=4 \
+	${full_backup_name} | \
+    xbstream -xv -C $topdir/downloaded_full --parallel=4
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/downloaded_full
+
+run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
+        --parallel=4 \
+        ${inc_backup_name} | \
+    xbstream -xv -C $topdir/downloaded_inc
+
+xtrabackup --prepare \
+	   --target-dir=$topdir/downloaded_full \
+	   --incremental-dir=$topdir/downloaded_inc
+
+stop_server
+rm -rf $MYSQLD_DATADIR/*
+
+xtrabackup --copy-back --target-dir=$topdir/downloaded_full
+start_server
+verify_db_state test

--- a/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
+++ b/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
@@ -41,7 +41,7 @@ mysql -e "alter instance enable innodb redo_log"
 
 vlog "### case #3 check when redo log is disabled after backup is started ###"
 run_cmd_expect_failure xtrabackup  --backup \
-        --target-dir=$topdir/full --lock-ddl=false   \
+        --target-dir=$topdir/full --lock-ddl=OFF   \
 	--debug-sync="data_copy_thread_func" 2>&1 \
         | tee $topdir/full.log &
 job_pid=$!
@@ -66,7 +66,7 @@ mysql -e "alter instance enable innodb redo_log"
 
 vlog "### case #4 check redo log is disabled during incremental backup ###"
 run_cmd xtrabackup --backup --target-dir=$topdir/full
-run_cmd_expect_failure xtrabackup --backup --lock-ddl=false --target-dir=$topdir/inc \
+run_cmd_expect_failure xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/inc \
 	--incremental-basedir=$topdir/full \
 	--debug-sync="data_copy_thread_func" 2>&1 \
 	| tee $topdir/inc.log &

--- a/storage/innobase/xtrabackup/test/t/bug1277403.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1277403.sh
@@ -12,7 +12,7 @@ has_backup_locks && skip_test "Requires server without backup locks support"
 
 mysql -e 'CREATE TABLE t1 (a INT) engine=MyISAM' test
 
-xtrabackup --backup --lock-ddl=false --target-dir=$topdir/full_backup
+xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/full_backup
 
 grep_general_log > $topdir/log1
 

--- a/storage/innobase/xtrabackup/test/t/bug1291299.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1291299.sh
@@ -10,7 +10,7 @@ remote_dir=$TEST_VAR_ROOT/var1/remote_dir
 mkdir -p $remote_dir
 start_server --innodb_directories=$remote_dir
 
-xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup \
+xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/backup \
            --debug-sync="data_copy_thread_func" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/bug1461735.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1461735.sh
@@ -13,7 +13,7 @@ debug-sync=xtrabackup_load_tablespaces_pause
 start_server
 
 function backup_local() {
-	xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup
+	xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/backup
 }
 
 function prepare_local() {
@@ -21,7 +21,7 @@ function prepare_local() {
 }
 
 function backup_xbstream() {
-	xtrabackup --backup --lock-ddl=false --stream=xbstream --target-dir=$topdir/backup > $topdir/backup.xbs
+	xtrabackup --backup --lock-ddl=OFF --stream=xbstream --target-dir=$topdir/backup > $topdir/backup.xbs
 }
 
 function prepare_xbstream() {
@@ -30,7 +30,7 @@ function prepare_xbstream() {
 }
 
 function backup_rsync() {
-	xtrabackup --backup --lock-ddl=false --rsync --target-dir=$topdir/backup
+	xtrabackup --backup --lock-ddl=OFF --rsync --target-dir=$topdir/backup
 }
 
 function prepare_rsync() {

--- a/storage/innobase/xtrabackup/test/t/bug1706582.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1706582.sh
@@ -6,7 +6,7 @@ start_server
 
 vlog "Full backup"
 
-run_cmd_expect_failure xtrabackup --backup --lock-ddl --lock-ddl-per-table \
+run_cmd_expect_failure xtrabackup --backup --lock-ddl=ON --lock-ddl-per-table \
     --target-dir=$topdir/data/full  2>&1 | \
         grep "\-\-lock-ddl and --lock-ddl-per-table are mutually exclusive"
 

--- a/storage/innobase/xtrabackup/test/t/create_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/t/create_tablespace.sh
@@ -46,7 +46,7 @@ INSERT INTO test.t2_3 VALUES (1100), (1200), (1300);
 EOF
 
 xtrabackup --backup --target-dir=$topdir/inc \
-	   --incremental-basedir=$topdir/full --lock-ddl=false \
+	   --incremental-basedir=$topdir/full --lock-ddl=OFF \
 	   --debug-sync="data_copy_thread_func" &
 
 job_pid=$!

--- a/storage/innobase/xtrabackup/test/t/ddl.sh
+++ b/storage/innobase/xtrabackup/test/t/ddl.sh
@@ -45,7 +45,7 @@ start_server
 mkdir -p $topdir/backup
 
 # Backup
-xtrabackup --datadir=$mysql_datadir --lock-ddl=false --backup \
+xtrabackup --datadir=$mysql_datadir --lock-ddl=OFF --backup \
     --target-dir=$topdir/backup \
     --debug-sync="data_copy_thread_func" &
 

--- a/storage/innobase/xtrabackup/test/t/mdl_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/mdl_locks.sh
@@ -53,7 +53,7 @@ function alter_table() {
 		-e "ALTER TABLE sakila.payment ADD COLUMN col1 INT"
 }
 
-xtrabackup --backup --lock-ddl \
+xtrabackup --backup --lock-ddl=ON \
 	--lock-ddl-timeout=2 --target-dir=$topdir/backup1
 
 start_transaction &
@@ -72,7 +72,7 @@ done
 
 # SELECT blocks ALTER TABLE, ALTER TABLE blocks LOCK TABLES FOR BACKUP
 run_cmd_expect_failure \
-	$XB_BIN $XB_ARGS --backup --lock-ddl --lock-ddl-timeout=2 \
+	$XB_BIN $XB_ARGS --backup --lock-ddl=ON --lock-ddl-timeout=2 \
 			 --target-dir=$topdir/backup2
 
 mysql -Ne "SELECT CONCAT('KILL ', id, ';') FROM \
@@ -82,7 +82,7 @@ OR info LIKE 'ALTER TABLE%'" | mysql
 wait $tr_job_id
 wait $ddl_job_id
 
-xtrabackup --backup --lock-ddl \
+xtrabackup --backup --lock-ddl=ON \
 	--lock-ddl-timeout=2 --target-dir=$topdir/backup3
 
 mysql -e "CREATE TABLE rcount (val INT)" test
@@ -108,7 +108,7 @@ done
 
 if has_backup_locks ;
 then
-	xtrabackup --backup --lock-ddl --target-dir=$topdir/backup6
+	xtrabackup --backup --lock-ddl=ON --target-dir=$topdir/backup6
 	xtrabackup --prepare --target-dir=$topdir/backup6
 fi
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1679.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1679.sh
@@ -27,7 +27,7 @@ CREATE TABLE test02 (id int auto_increment primary key, a TEXT, b TEXT);
 INSERT INTO test02 SELECT * FROM test01;
 EOF
 
-xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup 2>&1 | tee /dev/stderr | \
+xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/backup 2>&1 | tee /dev/stderr | \
     while read line ; do
         echo $line
         if [ $( echo $line | grep -i -c './test/test01#p#p3.ibd') -eq 1 ]; then

--- a/storage/innobase/xtrabackup/test/t/pxb-1824.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1824.sh
@@ -45,10 +45,10 @@ while true ; do
       mysql -e "TRUNCATE test.sbtest1"
 done >/dev/null 2>/dev/null &
 
-xtrabackup --lock-ddl --backup --target-dir=$topdir/backup --parallel=8
-xtrabackup --lock-ddl --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --target-dir=$topdir/backup --parallel=8
+xtrabackup --backup --incremental-basedir=$topdir/backup \
 	   --target-dir=$topdir/inc --parallel=8
-xtrabackup --lock-ddl --backup --incremental-basedir=$topdir/inc \
+xtrabackup --backup --incremental-basedir=$topdir/inc \
 	   --target-dir=$topdir/inc1 --parallel=8
 
 if ! grep -q flushed_lsn $topdir/backup/xtrabackup_checkpoints ; then

--- a/storage/innobase/xtrabackup/test/t/pxb-1914.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1914.sh
@@ -15,12 +15,12 @@ xtrabackup --backup --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1
 
-xtrabackup --backup --lock-ddl=false --backup-lock-retry-count=5 --backup-lock-timeout=3 \
+xtrabackup --backup --lock-ddl=OFF --backup-lock-retry-count=5 --backup-lock-timeout=3 \
 	   --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1
 
-xtrabackup --backup --lock-ddl=false --backup-lock-timeout=2 --backup-lock-retry-count=4 \
+xtrabackup --backup --lock-ddl=OFF --backup-lock-timeout=2 --backup-lock-retry-count=4 \
 	   --no-backup-locks --target-dir=$topdir/bak1
 
 rm -rf $topdir/bak1

--- a/storage/innobase/xtrabackup/test/t/pxb-2357.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-2357.sh
@@ -12,7 +12,7 @@ start_server --innodb-redo-log-archive-dirs=":$TEST_VAR_ROOT/b"
 
 mkdir $topdir/backup
 
-xtrabackup --backup --lock-ddl=false --target-dir=$topdir/backup \
+xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/backup \
            --debug-sync="stop_before_redo_archive" \
            2> >(tee $topdir/backup.log)&
 

--- a/storage/innobase/xtrabackup/test/t/skip_orphan_table.sh
+++ b/storage/innobase/xtrabackup/test/t/skip_orphan_table.sh
@@ -65,10 +65,10 @@ if [ $(grep 'Warning.*space.*does not exist' $topdir/pxb.log | wc -l) -eq 1 ]
        die "not exactly 1 tablespace missing "
 fi
 
-vlog "Case#2 backup should copy FTS in backup with lock-ddl=false"
+vlog "Case#2 backup should copy FTS in backup with lock-ddl=OFF"
 
 rm -rf ${topdir}/backup
-run_cmd xtrabackup --backup --lock-ddl=false  --target-dir=${topdir}/backup
+run_cmd xtrabackup --backup --lock-ddl=OFF  --target-dir=${topdir}/backup
 
 vlog "Case#2 prepare should work with orphan ibd copied"
 

--- a/storage/innobase/xtrabackup/test/t/undo_truncation.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_truncation.sh
@@ -18,5 +18,5 @@ for i in {1..100} ; do
 done &
 
 sleep 1s
-run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --lock-ddl=false --target-dir=$topdir/backup
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --lock-ddl=OFF --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_log_overwrap.sh
@@ -14,7 +14,7 @@ mkdir $topdir/backup
 #avoid log wrap before we do the first scan
 innodb_wait_for_flush_all
 run_cmd_expect_failure $XB_BIN $XB_ARGS --datadir=$mysql_datadir --backup \
-    --lock-ddl=false --innodb_log_file_size=4M --target-dir=$topdir/backup \
+    --lock-ddl=OFF --innodb_log_file_size=4M --target-dir=$topdir/backup \
     --debug-sync="xtrabackup_copy_logfile_pause" &
 
 job_pid=$!


### PR DESCRIPTION
Problem:
--------
    Currently, xtrabackup, with lock-ddl=ON(the default), locks the
    server using backup locks (Executes LOCK INSTANCE FOR BACKUP/ LOCK
    TABLES FOR BACKUP). This is done at the very start of backup.

    After this, a redo thread that copies redo and data copying threads
    copy all the datafiles (IBD files, .sdi files, myisam files etc).

    Backup lock is released only at the end. This means DDLs are not
    possible on Server for the duration of backup.

Solution/Goal:
-------------

   The goal of this feature is to reduce the time server is locked by
xtrabackup. The new design during backup is as follows:

 1. Copy all redo logs from checkpoint up to the current LSN and start following new entries.
   2. Start the redo log thread.
   3. Track file operations from the redo log.(ie parse MLOG_FILE_*
      records from redolog)
   4. Copy of all .ibd without taking any lock.
   5. Acquire Backup lock (Lock Instance for Backup/ Lock Tables for Backup).
      This step ensures no new DDL operations, such as creating or altering tables, will occur.
   6. Query log_status to discover the LSN from after LTFB/LIFB
   7. Copy all non-innodb files
   8. Ensure the redo log has catch up to LSN from https://github.com/percona/percona-xtrabackup/pull/6
   9. Check the file operations that were tracked and recopying the tablespaces.
  10. Create additional `meta` files to perform the required actions (deletions or renames) on the already copied files. This approach ensures that the backup remains consistent and accurate without disrupting the streaming process. This step is required for taking streaming backups. The meta files are
       a. .new -> for files that have to recopied due to encryption or
           ADD INDEX (Add index skips redo log, so reocpy is a must)
       b. .del -> file is deleted. If we have copied it, create a
          space_id.del file
       c. .ren -> file is renamed after we copied with a different name.
          Create a space_id.ren file
       d. .crpt -> file cannot be copied fully because of encryption
          changes. This will be recopied and for existing file, we have to create
          .crpt file
       e. .new.meta: Same as .new, this is for incremental backups
       d. .new.delta: Same as .new, this is for incremental backups,
          incremental backups, create t1.ibd.meta and t1.ibd.delta
          (instead of t1.ibd)
   11. Gather a sync point from all engines (InnoDB LSN, binlog, GTID, etc.) by querying the `log_status`.
   12. Stop the redo follow thread once it copies at least up to sync point at step 11.
   13. Release LTFB/LIFB.

   Prepare phase changes to handle reduced lock:
   ---------------------------------------------
   Process the new metadata files during `--prepare` phase before crash recovery starts.
   1. .crpt: These files are removed matching the name after stripping the extension. It is important to do this before the IBD scan because these are incompelte files (could be zero size too)
   2. Do a scan to create space_id to file_name mapping
   3. space_id.del -> delete the file matching the space_id. Incase of incremental, we delete the corresponding .new.meta and .new.delta files
   4. space_id.ren -> For the file matching the space_id, rename it to the name contained in the file
   5. .new extension -> replace the file that matches the name without the .new extension
   6. .new.meta/.delta -> Replace the  meta and delta files matching the name without the ".new" in the name.

   then regular recovery starts.

Limitations:
------------
1. ALTER INSTANCE ROTATE MASTER KEY is not handled. So applications should block this
2. Number of open file handles required is the same as number of files in datadir

Other changes fixed as part of this feature:

    PXB-3399 : PXB 84 Creating Backup on replica fails

    During the 8.4 merge, we mistakenly assumed all master/slave are
    replaced/removed in 8.4. there are still few places where server uses
    this terminology

    relay_master_log_file
    exec_master_log_position

    We mistakenly used relay_source_log_file and exec_source_log_position instead of the above names.

    Revert to the actual names (i.e master in the names)

    PXB-3113 : Improve debug sync framework to allow PXB to pause and resume threads

    https://perconadev.atlassian.net/browse/PXB-3113

    The current debug-sync option in PXB completely suspends PXB process and user can resume by sending SIGCONT signal
    This is useful for scenarios where PXB is paused and do certain operations on server and then resume PXB to complete.

    But many bugs we found during testing, involves multiple threads in PXB. The goal of this work is to be able to
    pause and resume the thread.

    Since many tests use the existing debug-sync option, I dont want to disturb these tests. We can convert them to
    the new mechanism later.

    How to use?
    -----------
    The new mechanism is used with option --debug-sync-thread="sync_point_name"

    In the code place a debug_sync_thread(“debug_point_1”) to stop thread at this place.

    You can pass the debug_sync point via commandline --debug-sync-thread=”debug_sync_point1”

    PXB will create a file of the debug_sync point name in the backup directory. It is suffixed with a threadnumber.
    Please ensure that no two debug_sync points use same name (it doesn’t make sense to have two sync points with same name)

    ```
    2024-03-28T15:58:23.310386-00:00 0 [Note] [MY-011825] [Xtrabackup] DEBUG_SYNC_THREAD: sleeping 1sec.  Resume this thread by deleting file /home/satya/WORK/pxb/bld/backup//xb_before_file_copy_4860396430306702017
    ```
    In the test, after activating syncpoint, you can use wait_for_debug_sync_thread_point <syncpoint_name>

    Do some stuff now. This thread is sleeping.

    Once you are done, and if you want the thread to resume, you can do so by deleting the file 'rm backup_dir/sync_point_name_*`
    Please use resume_debug_sync_thread_point <syncpoint_name> <backup_dir>. It dletes the syncpoint file and additionally checks that syncpoint is
    indeed resumed.

    More common/complicated scenario:
    ----------------------------------
    The scenario is to signal another thread to stop after reaching the first sync point. To achieve this. Do steps 1 to 3 (above)

    Echo the debug_sync point name into a file named “xb_debug_sync_thread”. Example:

    4. echo "xtrabackup_copy_logfile_pause" > backup/xb_debug_sync_thread

    5. send SIGUSR1 signal to PXB process. kill -SIGUSR1 496102

    6. Wait for syncpoint to be reached. wait_for_debug_sync_thread <syncpoint_name>

    PXB acknowledges it
    2024-03-28T16:05:07.849926-00:00 0 [Note] [MY-011825] [Xtrabackup] SIGUSR1 received. Reading debug_sync point from xb_debug_sync_thread file in backup directory
    2024-03-28T16:05:07.850004-00:00 0 [Note] [MY-011825] [Xtrabackup] DEBUG_SYNC_THREAD: Deleting  file/home/satya/WORK/pxb/bld/backup//xb_debug_sync_thread

    and then prints this once the sync point is reached.
    2024-03-28T16:05:08.508830-00:00 1 [Note] [MY-011825] [Xtrabackup] DEBUG_SYNC_THREAD: sleeping 1sec.  Resume this thread by deleting file /home/satya/WORK/pxb/bld/backup//xb_xtrabackup_copy_logfile_pause_10389933572825668634

    At this point, we have two threads sleeping at two sync points. Either of them can be resumed by deleting the filenames mentioned in the error log.
    (Or use resume_debug_sync_thread())

Contributions:
--------------
Because of squash, some of the commits by other team members are not visible. The other developers are
1. Aibek Bukabayev
2. Marcelo Altmann