### PR TITLE
(8.0) PXB-3427 : Parallelize incremental delta apply in incremental backup …

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -428,8 +428,8 @@ bool backup_file_printf(const char *filename, const char *fmt, ...) {
 }
 
 template <typename F>
-static bool run_data_threads(const char *dir, F func, uint n,
-                             const char *thread_description) {
+bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
+                      const char *thread_description) {
   datadir_thread_ctxt_t *data_threads;
   uint i, count;
   ib_mutex_t count_mutex;
@@ -453,7 +453,7 @@ static bool run_data_threads(const char *dir, F func, uint n,
   }
 
   xb_process_datadir(
-      dir, "",
+      dir, suffix,
       [&](const datadir_entry_t &entry, void *arg) mutable -> bool {
         queue.push(entry);
         return true;
@@ -487,6 +487,18 @@ static bool run_data_threads(const char *dir, F func, uint n,
 
   return (ret);
 }
+
+// Explicit instantiation for function pointer type:
+// void(*)(datadir_thread_ctxt_t*)
+template bool run_data_threads<void (*)(datadir_thread_ctxt_t *)>(
+    const char *, const char *, void (*)(datadir_thread_ctxt_t *), uint,
+    const char *);
+
+// Explicit instantiation for std::function<void(datadir_thread_ctxt_t*)> (used
+// when std::bind is applied)
+template bool run_data_threads<std::function<void(datadir_thread_ctxt_t *)>>(
+    const char *, const char *, std::function<void(datadir_thread_ctxt_t *)>,
+    uint, const char *);
 
 /************************************************************************
 Write buffer into .ibd file and preserve it's sparsiness. */
@@ -1044,7 +1056,7 @@ bool backup_files(const char *from, bool prep_mode, Backup_context &context) {
   xb::info() << "Starting " << (prep_mode ? "prep copy of" : "to backup")
              << " non-InnoDB tables and files";
 
-  run_data_threads(from,
+  run_data_threads(from, "" /* no suffix filtering */,
                    std::bind(backup_thread_func, std::placeholders::_1,
                              prep_mode, rsync_tmpfile, context),
                    xtrabackup_parallel, "backup");
@@ -2323,8 +2335,9 @@ bool copy_back(int argc, char **argv) {
                << " threads for parallel data files transfer";
   }
 
-  ret = run_data_threads(".", copy_back_thread_func, xtrabackup_parallel,
-                         "copy-back");
+  ret =
+      run_data_threads(".", "" /* no suffix filtering */, copy_back_thread_func,
+                       xtrabackup_parallel, "copy-back");
   if (!ret) goto cleanup;
 
   /* copy buffer pool dump */
@@ -2601,8 +2614,9 @@ bool decrypt_decompress() {
     xb::error() << "Error compiling filename regex";
     return (false);
   }
-  ret = run_data_threads(".", decrypt_decompress_thread_func,
-                         xtrabackup_parallel, "decrypt and decompress");
+  ret = run_data_threads(".", "" /* no suffix filtering */,
+                         decrypt_decompress_thread_func, xtrabackup_parallel,
+                         "decrypt and decompress");
 
   debug_sync_point("decrypt_decompress_func");
 
@@ -2617,6 +2631,39 @@ bool decrypt_decompress() {
   os_event_global_destroy();
 
   return (ret);
+}
+
+void xtrabackup_apply_deltas_parallel(datadir_thread_ctxt_t *ctx) {
+  bool ret = true;
+  datadir_entry_t entry;
+  THD *thd = nullptr;
+
+  if (my_thread_init()) {
+    ret = false;
+    goto cleanup;
+  }
+
+  /* create THD to get thread number in the error log */
+  thd = create_thd(false, false, true, 0, 0);
+
+  while (ctx->queue->pop(entry)) {
+    if (entry.is_empty_dir) continue;
+
+    ret = xtrabackup_apply_delta(entry, nullptr);
+    if (!ret) {
+      goto cleanup;
+    }
+  }
+
+cleanup:
+  my_thread_end();
+  destroy_thd(thd);
+
+  mutex_enter(ctx->count_mutex);
+  --(*ctx->count);
+  mutex_exit(ctx->count_mutex);
+
+  ctx->ret = ret;
 }
 
 #ifdef HAVE_VERSION_CHECK

--- a/storage/innobase/xtrabackup/src/backup_copy.h
+++ b/storage/innobase/xtrabackup/src/backup_copy.h
@@ -85,4 +85,23 @@ void version_check();
 #endif
 bool directory_exists(const char *dir, bool create);
 
+/** Execute a callback fun for every file discovered. The files are discovered
+and callback is invoked in parallel threads
+@param[in] dir                the directory to be scanned for file
+@param[in] suffix             file extensions. If provided, only files with
+                              extension are processed
+@param[in] func               the callback to be executed on every file
+                              discovered
+@param[in] n                  the thread number that processes the file
+@param[in] thread_description description of the thread actions
+@return true on success, false on error */
+template <typename F>
+bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
+                      const char *thread_description);
+
+struct datadir_thread_ctxt_t;
+
+/** Apply the .delta files parallely
+@param[in,out] ctx the shared context structure used by all threads */
+void xtrabackup_apply_deltas_parallel(datadir_thread_ctxt_t *ctx);
 #endif

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -5318,6 +5318,27 @@ static space_id_t get_space_id_from_page_0(const char *file_name) {
   return (space_id);
 }
 
+/** Track tablespaces that are found by delta files (incremental prepare).
+This is hash is later used to detect the dropped tablespaces. See
+rm_if_not_found()
+@param[in] dest_space_name the tablespace name */
+static void xb_delta_add_to_hash(const char *dest_space_name) {
+  static std::mutex mtx;  // Function-local static mutex
+  std::lock_guard<std::mutex> lock(mtx);
+
+  /* remember space name used by incremental prepare. This hash is later used to
+  detect the dropped tablespaces and remove them. Check rm_if_not_found() */
+  xb_filter_entry_t *table =
+      static_cast<xb_filter_entry_t *>(ut::malloc_withkey(
+          UT_NEW_THIS_FILE_PSI_KEY,
+          sizeof(xb_filter_entry_t) + strlen(dest_space_name) + 1));
+
+  table->name = ((char *)table) + sizeof(xb_filter_entry_t);
+  strcpy(table->name, dest_space_name);
+  HASH_INSERT(xb_filter_entry_t, name_hash, inc_dir_tables_hash,
+              ut::hash_string(table->name), table);
+}
+
 /***********************************************************************
 Searches for matching tablespace file for given .delta file and space_id
 in given directory. When matching tablespace found, renames it to match the
@@ -5339,7 +5360,6 @@ static pfs_os_file_t xb_delta_open_matching_space(
   char dest_space_name[FN_REFLEN * 2 + 1];
   bool ok;
   pfs_os_file_t file = XB_FILE_UNDEFINED;
-  xb_filter_entry_t *table;
   fil_space_t *fil_space;
   space_id_t f_space_id;
   os_file_create_t create_option = OS_FILE_OPEN;
@@ -5373,17 +5393,7 @@ static pfs_os_file_t xb_delta_open_matching_space(
     xb::error() << "cannot create dir " << dest_dir;
     return file;
   }
-
-  /* remember space name used by incremental prepare. This hash is later used to
-  detect the dropped tablespaces and remove them. Check rm_if_not_found() */
-  table = static_cast<xb_filter_entry_t *>(ut::malloc_withkey(
-      UT_NEW_THIS_FILE_PSI_KEY,
-      sizeof(xb_filter_entry_t) + strlen(dest_space_name) + 1));
-
-  table->name = ((char *)table) + sizeof(xb_filter_entry_t);
-  strcpy(table->name, dest_space_name);
-  HASH_INSERT(xb_filter_entry_t, name_hash, inc_dir_tables_hash,
-              ut::hash_string(table->name), table);
+  xb_delta_add_to_hash(dest_space_name);
 
   if (space_id != SPACE_UNKNOWN && !fsp_is_ibd_tablespace(space_id)) {
     /* since undo tablespaces cannot be renamed, we must either open existing
@@ -5569,7 +5579,7 @@ exit:
 /************************************************************************
 Applies a given .delta file to the corresponding data file.
 @return true on success */
-static bool xtrabackup_apply_delta(
+bool xtrabackup_apply_delta(
     const datadir_entry_t &entry, /*!<in: datadir entry */
     void * /*data*/) {
   pfs_os_file_t src_file = XB_FILE_UNDEFINED;
@@ -5925,8 +5935,10 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
 Applies all .delta files from incremental_dir to the full backup.
 @return true on success. */
 static bool xtrabackup_apply_deltas() {
-  return xb_process_datadir(xtrabackup_incremental_dir, ".delta",
-                            xtrabackup_apply_delta, NULL);
+  bool ret = run_data_threads(xtrabackup_incremental_dir, ".delta",
+                              xtrabackup_apply_deltas_parallel,
+                              xtrabackup_parallel, "apply-delta");
+  return ret;
 }
 
 /* replace log file in redo directory to xtrabackup_log
@@ -6798,13 +6810,82 @@ static void read_metadata() {
   }
 }
 
+/** Extend the tablespace size if the header size and the actual size mismatch
+@param[in] node     the file node object that is currently extended
+@param[in] thread_n the thread number that processes the tablespace
+@return true on success, false on failure */
+static bool xtrabackup_space_extend(fil_node_t *node, uint thread_n) {
+  byte *header;
+  ulint size;
+  mtr_t mtr;
+  buf_block_t *block;
+
+  fil_space_t *space = node->space;
+
+  /* Align space sizes along with fsp header. We want to process
+  each space once, so skip all nodes except the first one in a
+  multi-node space. */
+  if (node != &space->files.front()) {
+    return true;
+  }
+
+  mtr_start(&mtr);
+
+  mtr_s_lock(fil_space_get_latch(space->id), &mtr, UT_LOCATION_HERE);
+
+  block = buf_page_get(page_id_t(space->id, 0), page_size_t(space->flags),
+                       RW_S_LATCH, UT_LOCATION_HERE, &mtr);
+  header = FSP_HEADER_OFFSET + buf_block_get_frame(block);
+
+  size = mtr_read_ulint(header + FSP_SIZE, MLOG_4BYTES, &mtr);
+
+  mtr_commit(&mtr);
+
+  bool res = fil_space_extend(space, size);
+
+  ut_ad(res);
+  return (res);
+}
+
+/** Extend the tablespace size (if required) parallely. xtrabackup_parallel
+number of threads are used to parallel extension of files
+@param[in]     ctxt          shared context used by all threads */
+static void space_extend_thread_func(data_thread_ctxt_t *ctxt) {
+  uint num = ctxt->num;
+  fil_node_t *node;
+
+  /*
+    Initialize mysys thread-specific memory so we can
+    use mysys functions in this thread.
+  */
+  my_thread_init();
+
+  /* create THD to get thread number in the error log */
+  THD *thd = create_thd(false, false, true, 0, 0);
+  debug_sync_point("space_extend_thread_func");
+
+  while ((node = datafiles_iter_next(ctxt->it)) != NULL && !*(ctxt->error)) {
+    /* extend the datafile */
+    if (!xtrabackup_space_extend(node, num)) {
+      xb::error() << "failed to extend datafile " << node->name;
+      *(ctxt->error) = true;
+    }
+  }
+
+  mutex_enter(ctxt->count_mutex);
+  (*ctxt->count)--;
+  mutex_exit(ctxt->count_mutex);
+
+  destroy_thd(thd);
+  my_thread_end();
+}
+
 static void xtrabackup_prepare_func(int argc, char **argv) {
   ulint err;
   datafiles_iter_t *it;
   fil_node_t *node;
   fil_space_t *space;
   IORequest write_request(IORequest::WRITE);
-
   read_metadata();
 
   if (!strcmp(metadata_type_str, "full-backuped")) {
@@ -6979,39 +7060,48 @@ skip_check:
     exit(EXIT_FAILURE);
   }
 
-  while ((node = datafiles_iter_next(it)) != NULL) {
-    byte *header;
-    ulint size;
-    mtr_t mtr;
-    buf_block_t *block;
+  /* Create space extending threads */
+  {
+    uint count;
+    ib_mutex_t count_mutex;
+    bool space_extending_error = false;
+    data_thread_ctxt_t *data_threads = (data_thread_ctxt_t *)ut::malloc_withkey(
+        UT_NEW_THIS_FILE_PSI_KEY,
+        sizeof(data_thread_ctxt_t) * xtrabackup_parallel);
+    count = xtrabackup_parallel;
+    mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &count_mutex);
 
-    space = node->space;
-
-    /* Align space sizes along with fsp header. We want to process
-    each space once, so skip all nodes except the first one in a
-    multi-node space. */
-    if (node != &space->files.front()) {
-      continue;
+    for (uint i = 0; i < (uint)xtrabackup_parallel; i++) {
+      data_threads[i].it = it;
+      data_threads[i].num = i + 1;
+      data_threads[i].count = &count;
+      data_threads[i].count_mutex = &count_mutex;
+      data_threads[i].error = &space_extending_error;
+      os_thread_create(PFS_NOT_INSTRUMENTED, i, space_extend_thread_func,
+                       data_threads + i)
+          .start();
     }
 
-    mtr_start(&mtr);
+    /* Wait for threads to exit */
+    while (1) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      mutex_enter(&count_mutex);
+      if (count == 0) {
+        mutex_exit(&count_mutex);
+        break;
+      }
+      mutex_exit(&count_mutex);
+    }
 
-    mtr_s_lock(fil_space_get_latch(space->id), &mtr, UT_LOCATION_HERE);
+    mutex_free(&count_mutex);
+    ut::free(data_threads);
+    datafiles_iter_free(it);
 
-    block = buf_page_get(page_id_t(space->id, 0), page_size_t(space->flags),
-                         RW_S_LATCH, UT_LOCATION_HERE, &mtr);
-    header = FSP_HEADER_OFFSET + buf_block_get_frame(block);
-
-    size = mtr_read_ulint(header + FSP_SIZE, MLOG_4BYTES, &mtr);
-
-    mtr_commit(&mtr);
-
-    bool res = fil_space_extend(space, size);
-
-    ut_a(res);
+    if (space_extending_error) {
+      ib::error() << "Tablespace extending failed";
+      exit(EXIT_FAILURE);
+    }
   }
-
-  datafiles_iter_free(it);
 
   if (xtrabackup_export) {
     xb::info() << "export option is specified.";

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -333,4 +333,10 @@ bool xb_process_datadir(const char *path,   /*!<in: datadir path */
 @param[in,out]	buf		log header buffer
 @param[in]	lsn		lsn to update */
 void update_log_temp_checkpoint(byte *buf, lsn_t lsn);
+
+/** Apply the data from .delta to the tablespace
+@param[in] entry  the .delta file entry
+@return true on success, false on error */
+bool xtrabackup_apply_delta(const datadir_entry_t &entry, void *);
+
 #endif /* XB_XTRABACKUP_H */

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
@@ -1,0 +1,168 @@
+##########################################################################
+# PXB-3427 : Parallelize incremental delta apply in incremental backup prepare
+##########################################################################
+
+. inc/common.sh
+
+start_server --innodb_file_per_table --innodb_buffer_pool-size=1G --innodb_log_file_size=1G
+
+num_tables=1000
+num_threads=16
+batch_size=$((num_tables / num_threads))
+pids=()
+
+function create_stored_proc() {
+ local dbname=${1:-test};
+ mysql "$dbname" << EOF
+DELIMITER $$
+
+CREATE PROCEDURE create_table_range(IN start_idx INT, IN end_idx INT)
+BEGIN
+    DECLARE i INT;
+    SET i = start_idx;
+
+    WHILE i <= end_idx DO
+        SET @query = CONCAT('CREATE TABLE t', i, ' (
+            id INT PRIMARY KEY AUTO_INCREMENT,
+            name CHAR(255) DEFAULT ''DefaultName'',
+            address CHAR(255) DEFAULT ''DefaultAddress'',
+            city CHAR(255) DEFAULT ''DefaultCity'',
+            country CHAR(255) DEFAULT ''DefaultCountry'',
+            description CHAR(255) DEFAULT ''DefaultDescription''
+        )');
+        PREPARE stmt FROM @query;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+        SET i = i + 1;
+    END WHILE;
+END$$
+
+DELIMITER ;
+
+EOF
+}
+
+function drop_stored_proc() {
+local dbname=${1:-test};
+mysql -e "DROP PROCEDURE create_table_range" "$dbname"
+}
+
+create_tables_parallel() {
+    local start_idx=$1
+    local end_idx=$2
+    local dbname=${3:-test}  # Use third parameter if provided, otherwise default to 'test'
+    mysql -e "CALL create_table_range($start_idx, $end_idx);" $dbname &
+    pids+=($!)  # Store the process ID
+}
+
+create_tables() {
+    local dbname=${1:-test}
+for ((i=0; i<num_threads; i++)); do
+    start=$((i * batch_size + 1))
+    end=$(( (i + 1) * batch_size ))
+
+    # Handle remainder in the last batch
+    if (( i == num_threads - 1 )); then
+        end=$num_tables
+    fi
+
+    create_tables_parallel "$start" "$end" "$dbname"
+done
+
+# Wait only for MySQL processes to finish
+for pid in "${pids[@]}"; do
+    wait "$pid"
+done
+}
+
+create_stored_proc
+create_tables
+drop_stored_proc
+
+# Take backup
+vlog "Creating the backup directory: $topdir/backup"
+backup_dir="$topdir/backup"
+xtrabackup --backup --target-dir=$topdir/full_backup --parallel=$num_threads
+
+
+insert_records_thread() {
+    local start_idx=$1
+    local end_idx=$2
+    for ((i=start_idx; i<=end_idx; i++)); do
+        mysql -e "INSERT INTO t$i (id, name, address, city, country, description) VALUES 
+            (NULL, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT),
+            (NULL, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT),
+            (NULL, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT),
+            (NULL, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT),
+            (NULL, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT); INSERT INTO t$i SELECT NULL, name, address, city, country, description FROM t$i; INSERT INTO t$i SELECT NULL, name, address, city, country, description FROM t$i;INSERT INTO t$i SELECT NULL, name, address, city, country, description FROM t$i; " test
+    done &
+    pids+=($!)
+}
+
+# Clear process ID array
+pids=()
+
+# Step 2: Insert records using 16 parallel connections
+for ((i=0; i<num_threads; i++)); do
+    start=$((i * batch_size + 1))
+    end=$(( (i + 1) * batch_size ))
+    if (( i == num_threads - 1 )); then
+        end=$num_tables
+    fi
+    insert_records_thread "$start" "$end"
+done
+
+# Ensure all inserts complete
+for pid in "${pids[@]}"; do
+    wait "$pid"
+done
+
+stop_server
+start_server --innodb_buffer_pool-size=1G --innodb_log_file_size=1G
+
+# Do an incremental parallel backup
+xtrabackup --backup --parallel=$num_threads \
+    --incremental-basedir=$topdir/full_backup --target-dir=$topdir/inc_backup
+
+stop_server
+# Remove datadir
+rm -r $mysql_datadir
+
+vlog "Applying log"
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full_backup --parallel=$num_threads
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc_backup --parallel=$num_threads \
+    --target-dir=$topdir/full_backup 2> $topdir/inc.log
+
+check_pattern_numbers() {
+    local log_file="$1"
+    local expected_max="$2"
+
+    if [[ ! -f "$log_file" ]]; then
+        echo "Error: File not found!"
+        return 1
+    fi
+
+    # Calculate the sum of unique numbers before [Note] in lines containing "Applying .* to .*"
+    local sum=$(grep -oP '\d+(?= \[Note\] \[MY-011825\] \[Xtrabackup\] Applying .* to .*)' "$log_file" | sort -nu | awk '{sum+=$1} END {print sum}')
+
+    # Expected sum of numbers from 1 to expected_max
+    local expected_sum=$((expected_max * (expected_max + 1) / 2))
+
+    if [[ "$sum" -ne "$expected_sum" ]]; then
+        echo "Error: Missing numbers in sequence"
+        return 1
+    fi
+
+    echo "Success: All numbers from 1 to $expected_max are present."
+    return 0
+}
+
+run_cmd check_pattern_numbers $topdir/inc.log $num_threads
+
+xtrabackup --prepare --target-dir=$topdir/full_backup --parallel=$num_threads
+
+vlog "Restoring MySQL datadir"
+mkdir -p $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/full_backup --parallel=8
+
+start_server


### PR DESCRIPTION
…prepare

Problem:
--------
xtrabackup on incremental backups, creates a .delta file for every IBD file found.

On incremental prepare phase, the pages from .delta are applied to the actual tablespace. The .delta files are processed serially

Fix:
----
1. Apply .delta files paralelly with the number of threads from --parallel option
2. At the end of apply, there is space extension (increasing the ibd size according the size recorded in header), this is also executed parallely now with the --parallel number of threads.