### PR TITLE
PXB-3450 PXB 8.4.0-2 Fails to Prepare Backup Taken with PXB 8.4.0-1

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2656,11 +2656,13 @@ static bool xtrabackup_read_info(char *filename) {
 
   char lock[8];
   if (fscanf(fp, "lock_ddl_type = %7s\n", lock) != 1) {
-    r = false;
-    goto end;
+    xb::warn() << "lock_ddl_type parameter not found, defaulting to 'ON'";
+    opt_lock_ddl = LOCK_DDL_ON;
+  } else {
+    /* used to process the metadata files (.ren .del .new) created by backup
+     * when --lock-ddl=REDUCED  */
+    opt_lock_ddl = ddl_lock_type_from_str(string(lock));
   }
-  /* used at log0recv.cc to apply or not file operations */
-  opt_lock_ddl = ddl_lock_type_from_str(string(lock));
 end:
   fclose(fp);
   return (r);


### PR DESCRIPTION
Problem:
In PXB 8.4.0-2, a new parameter, 'opt_lock_ddl,' was introduced in the xtrabackup_info file.
When preparing a backup taken with PXB 8.4.0-1, PXB failed to locate the 'opt_lock_ddl' parameter in the xtrabackup_info file.

Solution:
Handle 'opt_lock_ddl' parameter as default 'ON' if not found in the xtrabackup_info file.