### PR TITLE
PXB-3498: [xbcloud] Fix HTTP request signing when retrying

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -79,6 +79,7 @@ IF (WITH_UNIT_TESTS AND CMAKE_VERSION VERSION_GREATER 3.22.1)
     ADD_EXECUTABLE(xbcloud-t xbcloud-t.cc
       http.cc
       s3.cc
+      s3_ec2.cc
       azure.cc
       swift.cc)
 

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -226,9 +226,10 @@ void Azure_client::set_endpoint(const std::string &ep, bool development_storage,
 
 bool Azure_client::delete_object(const std::string &container,
                                  const std::string &name) {
+  auto sign_fun = get_sign_fun(container, name);
   Http_request req(Http_request::DELETE, protocol, host,
-                   "/" + container + "/" + name);
-  signer->sign_request(container, name, req, time(0));
+                   "/" + container + "/" + name, sign_fun);
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -259,14 +260,15 @@ bool Azure_client::async_delete_object(const std::string &container,
                                        const std::string &name,
                                        Event_handler *h,
                                        const async_delete_callback_t callback) {
+  auto sign_fun = get_sign_fun(container, name);
   Http_request *req = new Http_request(Http_request::DELETE, protocol, host,
-                                       "/" + container + "/" + name);
+                                       "/" + container + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to delere object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
     return false;
   }
-  signer->sign_request(container, name, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -306,8 +308,10 @@ bool Azure_client::async_delete_object(const std::string &container,
 Http_buffer Azure_client::download_object(const std::string &container,
                                           const std::string &name,
                                           bool &success) {
-  Http_request req(Http_request::GET, protocol, host, container + "/" + name);
-  signer->sign_request(container, name, req, time(0));
+  auto sign_fun = get_sign_fun(container, name);
+  Http_request req(Http_request::GET, protocol, host, container + "/" + name,
+                   sign_fun);
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -325,9 +329,10 @@ Http_buffer Azure_client::download_object(const std::string &container,
 }
 
 bool Azure_client::create_container(const std::string &name) {
-  Http_request req(Http_request::PUT, protocol, host, "/" + name);
+  auto sign_fun = get_sign_fun(name, "");
+  Http_request req(Http_request::PUT, protocol, host, "/" + name, sign_fun);
   req.add_param("restype", "container");
-  signer->sign_request(name, "", req, time(0));
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -355,10 +360,11 @@ bool Azure_client::create_container(const std::string &name) {
 }
 
 bool Azure_client::container_exists(const std::string &name, bool &exists) {
-  Http_request req(Http_request::HEAD, protocol, host, "/" + name);
+  auto sign_fun = get_sign_fun(name, "");
+  Http_request req(Http_request::HEAD, protocol, host, "/" + name, sign_fun);
   req.add_param("comp", "metadata");
   req.add_param("restype", "container");
-  signer->sign_request(name, "", req, time(0));
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -381,11 +387,13 @@ bool Azure_client::container_exists(const std::string &name, bool &exists) {
 bool Azure_client::upload_object(const std::string &container,
                                  const std::string &name,
                                  const Http_buffer &contents) {
-  Http_request req(Http_request::PUT, protocol, host, container + "/" + name);
+  auto sign_fun = get_sign_fun(container, name);
+  Http_request req(Http_request::PUT, protocol, host, container + "/" + name,
+                   sign_fun);
   req.add_header("Content-Length", std::to_string(contents.size()));
   req.add_header(AZURE_BLOB_TYPE_HEADER, "BlockBlob");
   req.append_payload(contents);
-  signer->sign_request(container, name, req, time(0));
+  req.sign();
 
   Http_response resp;
 
@@ -430,8 +438,10 @@ bool Azure_client::async_upload_object(
     const Http_buffer &contents, Event_handler *h,
     async_upload_callback_t callback,
     const Http_request::headers_t &extra_http_headers) {
+  auto sign_fun = get_sign_fun(container, name);
+
   Http_request *req = new Http_request(Http_request::PUT, protocol, host,
-                                       "/" + container + "/" + name);
+                                       "/" + container + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to upload object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
@@ -445,7 +455,7 @@ bool Azure_client::async_upload_object(
     req->add_header(h.first, h.second);
   }
   req->append_payload(contents);
-  signer->sign_request(container, name, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -477,8 +487,9 @@ bool Azure_client::async_download_object(
     const std::string &container, const std::string &name, Event_handler *h,
     const async_download_callback_t callback,
     const Http_request::headers_t &extra_http_headers) {
+  auto sign_fun = get_sign_fun(container, name);
   Http_request *req = new Http_request(Http_request::GET, protocol, host,
-                                       "/" + container + "/" + name);
+                                       "/" + container + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to download object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
@@ -487,7 +498,7 @@ bool Azure_client::async_download_object(
   for (const auto &h : extra_http_headers) {
     req->add_header(h.first, h.second);
   }
-  signer->sign_request(container, name, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -538,7 +549,9 @@ bool Azure_client::list_objects_with_prefix(const std::string &container,
   std::string next_marker;
 
   while (truncated) {
-    Http_request req(Http_request::GET, protocol, host, "/" + container);
+    auto sign_fun = get_sign_fun(container, "");
+    Http_request req(Http_request::GET, protocol, host, "/" + container,
+                     sign_fun);
     req.add_param("comp", "list");
     req.add_param("restype", "container");
     req.add_param("maxresults", "1000");
@@ -546,7 +559,7 @@ bool Azure_client::list_objects_with_prefix(const std::string &container,
     if (truncated == true) {
       req.add_param("marker", next_marker);
     }
-    signer->sign_request(container, "", req, time(0));
+    req.sign();
 
     Http_response resp;
     if (!http_client->make_request(req, resp)) {

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.h
@@ -77,9 +77,9 @@ class Azure_client {
       std::function<void(bool, const Http_buffer &)>;
   using async_delete_callback_t = std::function<void(bool)>;
 
+ private:
   std::unique_ptr<Azure_signer> signer;
 
- private:
   const Http_client *http_client;
 
   std::string endpoint;
@@ -106,6 +106,13 @@ class Azure_client {
       Http_request *req, Http_response *resp, const Http_client *http_client,
       Event_handler *h, Azure_client::async_download_callback_t callback,
       CURLcode rc, const Http_connection *conn, ulong count);
+
+  Http_request::sign_fun_t get_sign_fun(const std::string &container,
+                                        const std::string &name) {
+    return [this, container, name](Http_request &req) {
+      signer->sign_request(container, name, req, time(0));
+    };
+  }
 
  public:
   Azure_client(const Http_client *client, const std::string &storage_account,

--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -634,8 +634,7 @@ void Http_client::callback(CLIENT *client, std::string container,
            delay, name.c_str(), count);
     std::this_thread::sleep_for(std::chrono::milliseconds(delay));
     resp->reset_body();
-    client->signer->sign_request(client->hostname(container), container, *req,
-                                 time(0));
+    req->sign();
     http_client->make_async_request(
         *req, *resp, h,
         std::bind(&Http_client::callback<CLIENT, CALLBACK>, this, client,

--- a/storage/innobase/xtrabackup/src/xbcloud/http.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.h
@@ -141,6 +141,7 @@ class Http_request {
   using headers_t = std::map<std::string, std::string>;
   using param_t = std::pair<std::string, std::string>;
   using params_t = std::map<std::string, std::string>;
+  using sign_fun_t = std::function<void(Http_request &)>;
 
  private:
   method_t method_;
@@ -150,14 +151,16 @@ class Http_request {
   headers_t headers_;
   params_t params_;
   Http_buffer payload_;
+  sign_fun_t sign_fun_;
 
  public:
   Http_request(method_t method, protocol_t protocol, const std::string host,
-               const std::string &path)
+               const std::string &path, const sign_fun_t &sign_fun)
       : method_(method),
         protocol_(protocol),
         host_(host),
-        path_(uri_escape_path(path)) {}
+        path_(uri_escape_path(path)),
+        sign_fun_(sign_fun) {}
   void add_header(const std::string &name, const std::string &value) {
     headers_[name] = value;
   }
@@ -190,6 +193,11 @@ class Http_request {
   protocol_t protocol() const { return protocol_; }
   const Http_buffer &payload() const { return payload_; }
   std::string query_string() const;
+  void sign() {
+    if (sign_fun_) {
+      sign_fun_(*this);
+    }
+  }
 };
 
 class Http_response {
@@ -339,6 +347,7 @@ class Event_handler {
 class Http_client {
  public:
   using async_callback_t = std::function<void(CURLcode, Http_connection *)>;
+
  private:
   bool insecure{false};
   bool verbose{false};

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -41,7 +41,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 namespace xbcloud {
 
-
 bool S3_response::parse_http_response(Http_response &http_response) {
   using namespace rapidxml;
 
@@ -291,9 +290,10 @@ void S3_signerV2::sign_request(const std::string &hostname,
 
 bool S3_client::delete_object(const std::string &bucket,
                               const std::string &name) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request req(Http_request::DELETE, protocol, hostname(bucket),
-                   bucketname(bucket) + "/" + name);
-  signer->sign_request(hostname(bucket), bucket, req, time(0));
+                   bucketname(bucket) + "/" + name, sign_fun);
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -323,15 +323,16 @@ bool S3_client::delete_object(const std::string &bucket,
 bool S3_client::async_delete_object(const std::string &bucket,
                                     const std::string &name, Event_handler *h,
                                     const async_delete_callback_t callback) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request *req =
       new Http_request(Http_request::DELETE, protocol, hostname(bucket),
-                       bucketname(bucket) + "/" + name);
+                       bucketname(bucket) + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to delere object %s/%s. Out of memory.\n", my_progname,
            bucket.c_str(), name.c_str());
     return false;
   }
-  signer->sign_request(hostname(bucket), bucket, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -370,9 +371,10 @@ bool S3_client::async_delete_object(const std::string &bucket,
 
 Http_buffer S3_client::download_object(const std::string &bucket,
                                        const std::string &name, bool &success) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request req(Http_request::GET, protocol, hostname(bucket),
-                   bucketname(bucket) + "/" + name);
-  signer->sign_request(hostname(bucket), bucket, req, time(0));
+                   bucketname(bucket) + "/" + name, sign_fun);
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -390,8 +392,9 @@ Http_buffer S3_client::download_object(const std::string &bucket,
 }
 
 bool S3_client::create_bucket(const std::string &name) {
+  auto sign_fun = get_sign_fun(name);
   Http_request req(Http_request::PUT, protocol, hostname(name),
-                   bucketname(name) + "/");
+                   bucketname(name) + "/", sign_fun);
 
   if (default_s3_region != region) {
     req.append_payload(
@@ -401,7 +404,7 @@ bool S3_client::create_bucket(const std::string &name) {
     req.append_payload(region);
     req.append_payload("</LocationConstraint></CreateBucketConfiguration>");
   }
-  signer->sign_request(hostname(name), name, req, time(0));
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -473,9 +476,10 @@ bool S3_client::probe_api_version_and_lookup(const std::string &bucket) {
 }
 
 bool S3_client::bucket_exists(const std::string &name, bool &exists) {
+  auto sign_fun = get_sign_fun(name);
   Http_request req(Http_request::HEAD, protocol, hostname(name),
-                   bucketname(name) + "/");
-  signer->sign_request(hostname(name), name, req, time(0));
+                   bucketname(name) + "/", sign_fun);
+  req.sign();
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {
@@ -498,11 +502,12 @@ bool S3_client::bucket_exists(const std::string &name, bool &exists) {
 bool S3_client::upload_object(const std::string &bucket,
                               const std::string &name,
                               const Http_buffer &contents) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request req(Http_request::PUT, protocol, hostname(bucket),
-                   bucketname(bucket) + "/" + name);
+                   bucketname(bucket) + "/" + name, sign_fun);
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload(contents);
-  signer->sign_request(hostname(bucket), bucket, req, time(0));
+  req.sign();
 
   Http_response resp;
 
@@ -547,9 +552,10 @@ bool S3_client::async_upload_object(
     const Http_buffer &contents, Event_handler *h,
     async_upload_callback_t callback,
     const Http_request::headers_t &extra_http_headers) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request *req =
       new Http_request(Http_request::PUT, protocol, hostname(bucket),
-                       bucketname(bucket) + "/" + name);
+                       bucketname(bucket) + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to upload object %s/%s. Out of memory.\n", my_progname,
            bucket.c_str(), name.c_str());
@@ -560,7 +566,7 @@ bool S3_client::async_upload_object(
     req->add_header(h.first, h.second);
   }
   req->append_payload(contents);
-  signer->sign_request(hostname(bucket), bucket, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -592,9 +598,10 @@ bool S3_client::async_download_object(
     const std::string &bucket, const std::string &name, Event_handler *h,
     const async_download_callback_t callback,
     const Http_request::headers_t &extra_http_headers) {
+  auto sign_fun = get_sign_fun(bucket);
   Http_request *req =
       new Http_request(Http_request::GET, protocol, hostname(bucket),
-                       bucketname(bucket) + "/" + name);
+                       bucketname(bucket) + "/" + name, sign_fun);
   if (req == nullptr) {
     msg_ts("%s: Failed to download object %s/%s. Out of memory.\n", my_progname,
            bucket.c_str(), name.c_str());
@@ -603,7 +610,7 @@ bool S3_client::async_download_object(
   for (const auto &h : extra_http_headers) {
     req->add_header(h.first, h.second);
   }
-  signer->sign_request(hostname(bucket), bucket, *req, time(0));
+  req->sign();
 
   Http_response *resp = new Http_response();
   if (resp == nullptr) {
@@ -630,8 +637,9 @@ bool S3_client::list_objects_with_prefix(const std::string &bucket,
   std::string next_marker;
 
   while (truncated) {
+    auto sign_fun = get_sign_fun(bucket);
     Http_request req(Http_request::GET, protocol, hostname(bucket),
-                     bucketname(bucket) + "/");
+                     bucketname(bucket) + "/", sign_fun);
     req.add_param("max-keys", "1000");
     req.add_param("prefix", prefix);
     if (!next_marker.empty()) {
@@ -640,7 +648,7 @@ bool S3_client::list_objects_with_prefix(const std::string &bucket,
     if (!continuation_token.empty()) {
       req.add_param("continuation-token", continuation_token);
     }
-    signer->sign_request(hostname(bucket), bucket, req, time(0));
+    req.sign();
 
     Http_response resp;
     if (!http_client->make_request(req, resp)) {

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -137,9 +137,9 @@ class S3_client {
       std::function<void(bool, const Http_buffer &)>;
   using async_delete_callback_t = std::function<void(bool)>;
 
+ private:
   std::unique_ptr<S3_signer> signer;
 
- private:
   const Http_client *http_client;
   std::shared_ptr<S3_ec2_instance> ec2_instance;
   s3_api_version_t api_version{S3_V_AUTO};
@@ -182,6 +182,12 @@ class S3_client {
       Http_request *req, Http_response *resp, const Http_client *http_client,
       Event_handler *h, S3_client::async_download_callback_t callback,
       CURLcode rc, const Http_connection *conn, ulong count);
+
+  Http_request::sign_fun_t get_sign_fun(const std::string &bucket) {
+    return [this, bucket](Http_request &req) {
+      signer->sign_request(hostname(bucket), bucket, req, time(0));
+    };
+  }
 
  public:
   S3_client(const Http_client *client, const std::string &region,

--- a/storage/innobase/xtrabackup/src/xbcloud/s3_ec2.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3_ec2.cc
@@ -101,8 +101,8 @@ bool S3_ec2_instance::parse_keys_response(const Http_response &http_response) {
 
 bool S3_ec2_instance::fetch_metadata() {
   /* token */
-  Http_request token_req(Http_request::PUT, Http_request::HTTP, host,
-                         token_url);
+  Http_request token_req(Http_request::PUT, Http_request::HTTP, host, token_url,
+                         nullptr);
   token_req.add_header("X-aws-ec2-metadata-token-ttl-seconds",
                        std::to_string(token_ttl));
   Http_response token_resp;
@@ -116,7 +116,7 @@ bool S3_ec2_instance::fetch_metadata() {
 
   /* profile id */
   Http_request profile_req(Http_request::GET, Http_request::HTTP, host,
-                           metadata_url);
+                           metadata_url, nullptr);
   profile_req.add_header("X-aws-ec2-metadata-token", token);
   Http_response profile_resp;
   if (!http_client->make_request(profile_req, profile_resp)) {
@@ -129,7 +129,7 @@ bool S3_ec2_instance::fetch_metadata() {
 
   /* metadata */
   Http_request metadata_req(Http_request::GET, Http_request::HTTP, host,
-                            metadata_url + profile);
+                            metadata_url + profile, nullptr);
   metadata_req.add_header("X-aws-ec2-metadata-token", token);
   Http_response metadata_resp;
   if (!http_client->make_request(metadata_req, metadata_resp)) {

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -71,7 +71,7 @@ bool Keystone_client::temp_auth(auth_info_t &auth_info) {
     return false;
   }
 
-  Http_request req(Http_request::GET, protocol, host, path);
+  Http_request req(Http_request::GET, protocol, host, path, nullptr);
   req.add_header("X-Auth-User", user);
   req.add_header("X-Auth-Key", key);
 
@@ -161,7 +161,8 @@ bool Keystone_client::auth_v2(const std::string &swift_region,
   writer.EndObject();  // auth
   writer.EndObject();  // root
 
-  Http_request req(Http_request::POST, protocol, host, path + "tokens");
+  Http_request req(Http_request::POST, protocol, host, path + "tokens",
+                   nullptr);
   req.add_header("Content-Type", "application/json");
   req.add_header("Accept", "application/json");
 
@@ -422,7 +423,8 @@ bool Keystone_client::auth_v3(const std::string &swift_region,
   writer.EndObject();  // auth
   writer.EndObject();  // root
 
-  Http_request req(Http_request::POST, protocol, host, path + "auth/tokens/");
+  Http_request req(Http_request::POST, protocol, host, path + "auth/tokens/",
+                   nullptr);
   req.add_header("Content-Type", "application/json");
   req.add_header("Accept", "application/json");
 
@@ -592,7 +594,7 @@ bool Swift_client::validate_response(const Http_request &req,
 bool Swift_client::delete_object(const std::string &container,
                                  const std::string &name) {
   Http_request req(Http_request::DELETE, protocol, host,
-                   path + container + "/" + name);
+                   path + container + "/" + name, nullptr);
   req.add_header("X-Auth-Token", token);
 
   Http_response resp;
@@ -615,7 +617,7 @@ bool Swift_client::async_delete_object(const std::string &container,
                                        Event_handler *h,
                                        const async_delete_callback_t callback) {
   Http_request *req = new Http_request(Http_request::DELETE, protocol, host,
-                                       path + container + "/" + name);
+                                       path + container + "/" + name, nullptr);
   if (req == nullptr) {
     msg_ts("%s: Failed to delete object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
@@ -653,7 +655,7 @@ Http_buffer Swift_client::download_object(const std::string &container,
                                           const std::string &name,
                                           bool &success) {
   Http_request req(Http_request::GET, protocol, host,
-                   path + container + "/" + name);
+                   path + container + "/" + name, nullptr);
   req.add_header("X-Auth-Token", token);
 
   Http_response resp;
@@ -681,7 +683,7 @@ void Swift_client::download_callback(
 }
 
 bool Swift_client::create_container(const std::string &name) {
-  Http_request req(Http_request::PUT, protocol, host, path + name);
+  Http_request req(Http_request::PUT, protocol, host, path + name, nullptr);
   req.add_header("X-Auth-Token", token);
 
   Http_response resp;
@@ -700,7 +702,7 @@ bool Swift_client::create_container(const std::string &name) {
 }
 
 bool Swift_client::container_exists(const std::string &name, bool &exists) {
-  Http_request req(Http_request::GET, protocol, host, path + name);
+  Http_request req(Http_request::GET, protocol, host, path + name, nullptr);
   req.add_header("Content-Type", "application/json");
   req.add_header("X-Auth-Token", token);
 
@@ -730,7 +732,7 @@ bool Swift_client::upload_object(const std::string &container,
                                  const std::string &name,
                                  const Http_buffer &contents) {
   Http_request req(Http_request::PUT, protocol, host,
-                   path + container + "/" + name);
+                   path + container + "/" + name, nullptr);
   req.append_payload(contents);
   req.add_header("Content-Type", "application/octet-stream");
   req.add_header("X-Auth-Token", token);
@@ -771,7 +773,7 @@ bool Swift_client::async_upload_object(const std::string &container,
                                        Event_handler *h,
                                        async_upload_callback_t callback) {
   Http_request *req = new Http_request(Http_request::PUT, protocol, host,
-                                       path + container + "/" + name);
+                                       path + container + "/" + name, nullptr);
   if (req == nullptr) {
     msg_ts("%s: Failed to upload object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
@@ -805,7 +807,7 @@ bool Swift_client::async_download_object(const std::string &container,
                                          Event_handler *h,
                                          async_download_callback_t callback) {
   Http_request *req = new Http_request(Http_request::GET, protocol, host,
-                                       path + container + "/" + name);
+                                       path + container + "/" + name, nullptr);
   if (req == nullptr) {
     msg_ts("%s: Failed to download object %s/%s. Out of memory.\n", my_progname,
            container.c_str(), name.c_str());
@@ -834,7 +836,8 @@ bool Swift_client::list_objects_with_prefix(const std::string &container,
                                             const std::string &prefix,
                                             std::vector<std::string> &objects) {
   while (true) {
-    Http_request req(Http_request::GET, protocol, host, path + container);
+    Http_request req(Http_request::GET, protocol, host, path + container,
+                     nullptr);
     req.add_header("Content-Type", "application/json");
     req.add_header("X-Auth-Token", token);
     req.add_param("format", "json");

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
@@ -156,15 +156,17 @@ TEST(s3_client, basicEndpoint) {
 }
 
 TEST(s3v4_signer, basicDNS) {
+  S3_signerV4 signer(LOOKUP_DNS, "example-region", "access_key", "secret_key");
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("mybucket.myhost", "", req, 1555892546);
+  };
   Http_request req(Http_request::GET, Http_request::HTTPS, "mybucket.hyhost",
-                   "myobject/");
+                   "myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV4 signer(LOOKUP_DNS, "example-region", "access_key", "secret_key");
-
-  signer.sign_request("mybucket.myhost", "", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(req.headers().at("Authorization").c_str(),
                "AWS4-HMAC-SHA256 "
@@ -177,15 +179,17 @@ TEST(s3v4_signer, basicDNS) {
 }
 
 TEST(s3v4_signer, basicPATH) {
+  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key");
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("myhost", "mybucket", req, 1555892546);
+  };
   Http_request req(Http_request::GET, Http_request::HTTPS, "hyhost",
-                   "mybucket/myobject/");
+                   "mybucket/myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key");
-
-  signer.sign_request("myhost", "mybucket", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(req.headers().at("Authorization").c_str(),
                "AWS4-HMAC-SHA256 "
@@ -198,16 +202,19 @@ TEST(s3v4_signer, basicPATH) {
 }
 
 TEST(s3v4_signer, sessionToken) {
+  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key",
+                     "session_token");
+
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("myhost", "mybucket", req, 1555892546);
+  };
   Http_request req(Http_request::GET, Http_request::HTTPS, "hyhost",
-                   "mybucket/myobject/");
+                   "mybucket/myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key",
-                     "session_token");
-
-  signer.sign_request("myhost", "mybucket", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(req.headers().at("Authorization").c_str(),
                "AWS4-HMAC-SHA256 "
@@ -220,16 +227,19 @@ TEST(s3v4_signer, sessionToken) {
 }
 
 TEST(s3v4_signer, storageClass) {
+  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key",
+                     "session_token", "storage_class");
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("myhost", "mybucket", req, 1555892546);
+  };
+
   Http_request req(Http_request::GET, Http_request::HTTPS, "hyhost",
-                   "mybucket/myobject/");
+                   "mybucket/myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV4 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key",
-                     "session_token", "storage_class");
-
-  signer.sign_request("myhost", "mybucket", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(
       req.headers().at("Authorization").c_str(),
@@ -242,30 +252,34 @@ TEST(s3v4_signer, storageClass) {
 }
 
 TEST(s3v2_signer, basicDNS) {
+  S3_signerV2 signer(LOOKUP_DNS, "example-region", "access_key", "secret_key");
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("mybucket.myhost", "", req, 1555892546);
+  };
   Http_request req(Http_request::GET, Http_request::HTTPS, "mybucket.hyhost",
-                   "myobject/");
+                   "myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV2 signer(LOOKUP_DNS, "example-region", "access_key", "secret_key");
-
-  signer.sign_request("mybucket.myhost", "", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(req.headers().at("Authorization").c_str(),
                "AWS access_key:0oalADiTB2mEnSgKkj5mFXEJZU4=");
 }
 
 TEST(s3v2_signer, basicPATH) {
+  S3_signerV2 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key");
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("myhost", "mybucket", req, 1555892546);
+  };
   Http_request req(Http_request::GET, Http_request::HTTPS, "hyhost",
-                   "mybucket/myobject/");
+                   "mybucket/myobject/", sign_fun);
   req.add_header("Content-Length", "4");
   req.add_header("Content-Type", "application/octet-stream");
   req.append_payload("test", 4);
 
-  S3_signerV2 signer(LOOKUP_PATH, "example-region", "access_key", "secret_key");
-
-  signer.sign_request("myhost", "mybucket", req, 1555892546);
+  req.sign();
 
   ASSERT_STREQ(req.headers().at("Authorization").c_str(),
                "AWS access_key:VQ+0g9rlqRH9SMeRubHF2FW9jeI=");
@@ -549,19 +563,23 @@ TEST(azure_client, basicEndpoint) {
 }
 
 TEST(azure_signer, basicDNS) {
-  Http_request req(Http_request::GET, Http_request::HTTPS, "my_host",
-                   "my_container/my_object");
-
-  req.add_header("Content-Length", "4");
-  req.add_header("Content-Type", "application/octet-stream");
-  req.add_header("x-ms-blob-type", "BlockBlob");
-  req.append_payload("test", 4);
   Azure_signer signer(
       "my-storage-account",
       "zUfvsKXc6+2RMJCwvnElnG/"
       "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/b3OAg==",
       0);
-  signer.sign_request("mycontainer", "myblob", req, 1555892546);
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("mycontainer", "myblob", req, 1555892546);
+  };
+
+  Http_request req(Http_request::GET, Http_request::HTTPS, "my_host",
+                   "my_container/my_object", sign_fun);
+
+  req.add_header("Content-Length", "4");
+  req.add_header("Content-Type", "application/octet-stream");
+  req.add_header("x-ms-blob-type", "BlockBlob");
+  req.append_payload("test", 4);
+  req.sign();
 
   ASSERT_STREQ(
       req.headers().at("Authorization").c_str(),
@@ -570,19 +588,23 @@ TEST(azure_signer, basicDNS) {
 }
 
 TEST(azure_signer, storageClass) {
-  Http_request req(Http_request::GET, Http_request::HTTPS, "my_host",
-                   "my_container/my_object");
-
-  req.add_header("Content-Length", "4");
-  req.add_header("Content-Type", "application/octet-stream");
-  req.add_header("x-ms-blob-type", "BlockBlob");
-  req.append_payload("test", 4);
   Azure_signer signer(
       "my-storage-account",
       "zUfvsKXc6+2RMJCwvnElnG/"
       "Kk7wxQ8V4TPXIuZ53qFwJNtpLUEjYdBe9iGTkMgwUGFHVfFgn2qkgoqDP/i3OAg==",
       0, "storage_class");
-  signer.sign_request("mycontainer", "myblob", req, 1555892546);
+  auto sign_fun = [&signer](Http_request &req) {
+    signer.sign_request("mycontainer", "myblob", req, 1555892546);
+  };
+
+  Http_request req(Http_request::GET, Http_request::HTTPS, "my_host",
+                   "my_container/my_object", sign_fun);
+
+  req.add_header("Content-Length", "4");
+  req.add_header("Content-Type", "application/octet-stream");
+  req.add_header("x-ms-blob-type", "BlockBlob");
+  req.append_payload("test", 4);
+  req.sign();
 
   ASSERT_STREQ(
       req.headers().at("Authorization").c_str(),


### PR DESCRIPTION
Using `xbcloud`, when there is a problem downloading a file and it's going to be retried, the new request should be signed again for S3 and Azure. But the parameters used were only valid for S3.

That means that if you're downloading from Azure, once a file fails to download, the retry is going to miscalculate the authorization token, that would receive a `403 Unauthorized` and the whole downloading process stop.

This PR fixes that problem. The approach is encapsulating the signing process and the related data in a `std::function` in the `Http_request` object. This way, you just have to call `req->sign()` to resign the request, you don't need to know what data it needs, etc.

**This bug was found in a production service**. The fix was also tested in the same service with successful result.