### PR TITLE
[8.0] PXB-3426 : Using KMIP component causes double free of memory on error paths

### DIFF
--- a/components/keyrings/keyring_kmip/backend/backend.cc
+++ b/components/keyrings/keyring_kmip/backend/backend.cc
@@ -110,6 +110,9 @@ bool Keyring_kmip_backend::store(const Metadata &metadata,
     if (id.empty()) {
       return true;
     }
+    if (!ctx.op_activate(id)) {
+      return true;
+    }
     data.set_extension({id});
   } catch (...) {
     mysql_components_handle_std_exception(__func__);


### PR DESCRIPTION

Problem:
--------

After the implementation of KMIP key activate feature, xtrabackup usage of
KMIP keys probably causes an error. Due to bug in libkmip, there is a double
free of memory. This caused random crashes because the freed memory would have
been allocated for other components.

Fix:
----
1. Cherry pick the commit that implemented the key activate feature from PS (b1135408b1d1585112871bfbf870bd6cebf3753f).
2. Use the latest libkmip, ie 0.3.2 in the submodule pointer