### PR TITLE
[8.4] PXB-3437 : PXB does not skip component_keyring_vault.cnf during copy-…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1801,6 +1801,7 @@ bool copy_incremental_over_full() {
       xtrabackup::components::XTRABACKUP_KEYRING_FILE_CONFIG,
       xtrabackup::components::XTRABACKUP_KEYRING_KMIP_CONFIG,
       xtrabackup::components::XTRABACKUP_KEYRING_KMS_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_VAULT_CONFIG,
       "ib_lru_dump",
       nullptr};
   bool ret = true;
@@ -2010,6 +2011,7 @@ bool should_skip_file_on_copy_back(const char *filepath) {
       xtrabackup::components::XTRABACKUP_KEYRING_FILE_CONFIG,
       xtrabackup::components::XTRABACKUP_KEYRING_KMIP_CONFIG,
       xtrabackup::components::XTRABACKUP_KEYRING_KMS_CONFIG,
+      xtrabackup::components::XTRABACKUP_KEYRING_VAULT_CONFIG,
       ".qp",
       ".lz4",
       ".zst",


### PR DESCRIPTION
…back operation

https://perconadev.atlassian.net/browse/PXB-3437

Problem:
--------
After a backup and prepare operation, component keyring config is required to generate new master key before copy-back. Keyring config (vault,kmip,kms etc) are passed via
 1. command line option --component-keyring-config
 2. the component cnf file can be placed in the backup directory

When user choses option 2, the component cnf file shouldn't be copied back. But incase of vault, component_keyring_vault.cnf is still copied back and it fails as the destination server might already have this config file.

Fix:
----
This problem doesn't exist for FILE, KMIP, KMS keyring plugins as their configs are skipped. Add VAULT config file (component_keyring_vault.cnf) to the skip list