### PR TITLE
PXB-3490 : Invalid URL for Boost tarball in Xtrabackup 8.0.35-32

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -41,7 +41,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_77_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.bz2")
 SET(BOOST_DOWNLOAD_URL
-  "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
+  "https://archives.boost.io/release/1.77.0/source/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3490

Problem & Fix
--------------
The boost URL has become outdated since the version of 8.0.35 

Updated the URL to a new mirror (This is now same as Percona Server for MySQL and Oracle MySQL)