### PR TITLE
Followup fix PXB-3279: Adjust copying file message format.

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3256,10 +3256,10 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
   action = xb_get_copy_action();
 
   if (xtrabackup_stream) {
-    xb::info() << action << " file with space_id " << node->space->id << " "
+    xb::info() << "space_id: " << node->space->id << ", " << action
                << node_path;
   } else {
-    xb::info() << action << " file with space_id " << node->space->id << " "
+    xb::info() << "space_id: " << node->space->id << ", " << action << " "
                << node_path << " to " << dstfile->path;
   }
 
@@ -3283,12 +3283,11 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
 
   /* close */
   if (xtrabackup_stream) {
-    xb::info() << "Done: " << action << " file with space_id "
-               << node->space->id << " " << node_path;
+    xb::info() << "space_id: " << node->space->id << ", Done: " << action << " "
+               << node_path;
   } else {
-    xb::info() << "Done: " << action << " file with space_id "
-               << node->space->id << " " << node_path << " to "
-               << dstfile->path;
+    xb::info() << "space_id: " << node->space->id << ", Done: " << action << " "
+               << node_path << " to " << dstfile->path;
   }
 
   xb_fil_cur_close(&cursor);


### PR DESCRIPTION
Print space_id: <number> before the "Copying or Done" messages.