### PR TITLE
[8.0] PXB-3470: xbstream does long post-processing after receiving al…

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -2535,7 +2535,8 @@ bool decrypt_decompress_file(const char *filepath, uint thread_n) {
   }
   if (ds_data->fs_support_punch_hole) {
     char error[512];
-    if (!restore_sparseness(dest_filepath, opt_read_buffer_size, error)) {
+    if (!restore_sparseness(dest_filepath, opt_read_buffer_size,
+                            error IF_DEBUG(, true))) {
       xb::warn() << "restore_sparseness failed for file: " << dest_filepath
                  << " Error: " << error;
     }

--- a/storage/innobase/xtrabackup/src/file_utils.cc
+++ b/storage/innobase/xtrabackup/src/file_utils.cc
@@ -70,6 +70,11 @@ inline page_type_t fil_page_get_type(const byte *page) {
   return (static_cast<page_type_t>(mach_read_from_2(page + XB_FIL_PAGE_TYPE)));
 }
 
+inline bool is_page_io_compressed(const byte *page) {
+  return (fil_page_get_type(page) == XB_FIL_PAGE_COMPRESSED ||
+          fil_page_get_type(page) == XB_FIL_PAGE_COMPRESSED_AND_ENCRYPTED);
+}
+
 /** Calculates the smallest multiple of m that is not smaller than n
  when m is a power of two.  In other words, rounds n up to m * k.
  @param n in: number to round up
@@ -276,8 +281,42 @@ xb_fil_cur_result_t datafile_read(datafile_cur_t *cursor) {
   return (XB_FIL_CUR_SUCCESS);
 }
 
+/** Check if an IBD file is IO compressed or not. We just check page numbers
+1 & 2. This is because the first 7 pages are created when an IBD file is
+created. This is the minimum size of a tablespace. So it is sufficient to check
+only two pages.
+Note that page 0 is not compressed. So we check page number 1 & 2 only. */
+class PageCompressionTracker {
+ public:
+  explicit PageCompressionTracker(ulint page_size)
+      : page_size_{page_size},
+        is_compressed_{false, false},
+        checked_exit_{false} {}
+
+  // Call this for every page
+  bool record(ulint buf_offset, const byte *page) {
+    const ulint page_num = buf_offset / page_size_;
+
+    if (page_num == 1 || page_num == 2) {
+      is_compressed_[page_num - 1] = is_page_io_compressed(page);
+    }
+
+    if (page_num == 3 && !checked_exit_) {
+      checked_exit_ = true;  // Ensure we only check once
+      return !is_compressed_[0] && !is_compressed_[1];  // true = can exit early
+    }
+
+    return false;
+  }
+
+ private:
+  const ulint page_size_;
+  bool is_compressed_[2];  // 0 => page 1, 1 => page 2
+  bool checked_exit_;      // ensures we only check once at page 3
+};
+
 bool restore_sparseness(const char *src_file_path, uint buffer_size,
-                        char error[512]) {
+                        char error[512], bool opt_verbose) {
   datafile_cur_t cursor;
   size_t page_size = 0;
   size_t seek = 0;
@@ -288,7 +327,7 @@ bool restore_sparseness(const char *src_file_path, uint buffer_size,
     return false;
   }
   auto punch_hole_func = [&](const auto page) {
-    if (fil_page_get_type(page) == XB_FIL_PAGE_COMPRESSED) {
+    if (is_page_io_compressed(page)) {
 #ifdef UNIV_DEBUG
       assert(page_size % (size_t)cursor.statinfo.st_blksize == 0);
 #endif
@@ -331,8 +370,20 @@ bool restore_sparseness(const char *src_file_path, uint buffer_size,
 #endif
     }
 
+    PageCompressionTracker compression_tracker(page_size);
+
     for (ulint i = 0; i < cursor.buf_read / page_size; ++i) {
       const auto page = cursor.buf + buf_offset;
+
+      if (compression_tracker.record(buf_offset, page)) {
+        if (opt_verbose) {
+          msg("File %s is not sparse, skipping restore_sparseness\n",
+              src_file_path);
+        }
+        datafile_close(&cursor);
+        return true;
+      }
+
       if (!punch_hole_func(page)) return false;
 
       buf_offset += page_size;

--- a/storage/innobase/xtrabackup/src/file_utils.h
+++ b/storage/innobase/xtrabackup/src/file_utils.h
@@ -174,7 +174,7 @@ xb_fil_cur_result_t datafile_read(datafile_cur_t *cursor);
   @return false in case of error, true otherwise
 */
 bool restore_sparseness(const char *src_file_path, uint buffer_size,
-                        char error[512]);
+                        char error[512], bool opt_verbose = false);
 
 /**
   Open FIFO file for writing. Wait up to timeout seconds for it to return a

--- a/storage/innobase/xtrabackup/src/xbstream.cc
+++ b/storage/innobase/xtrabackup/src/xbstream.cc
@@ -592,7 +592,8 @@ static void extract_worker_thread_func(extract_ctxt_t &ctxt) {
                qpress_offset] = 0;
 
         char error[512];
-        if (!restore_sparseness(path, XBSTREAM_BUFFER_SIZE, error)) {
+        if (!restore_sparseness(path, XBSTREAM_BUFFER_SIZE, error,
+                                opt_verbose)) {
           msg("%s: restore_sparseness failed for file %s: %s\n", my_progname,
               chunk.path, error);
         }

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -1,5 +1,10 @@
 set -eu
 
+function is_sparse_file() {
+    let n=$(stat --printf "%b*%B/%s" $1)
+    [ "$n" = "0" ]
+}
+
 ### save a copy of backup directory
 function save_backup()
 {

--- a/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
@@ -9,11 +9,6 @@ require_server_version_higher_than 5.7.10
 require_lz4
 require_zstd
 
-function is_sparse_file() {
-    let n=$(stat --printf "%b*%B/%s" $1)
-    [ "$n" = "0" ]
-}
-
 function is_multiple_of_page_size() {
     let n=$(stat --printf "%s" $1)
     remainder=$((n % 16384 ))

--- a/storage/innobase/xtrabackup/test/suites/compression/check_sparseness.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/check_sparseness.sh
@@ -1,0 +1,168 @@
+. inc/common.sh
+. inc/keyring_file.sh
+
+require_lz4
+require_zstd
+require_debug_pxb_version
+
+cleanup() {
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP TABLE t4;
+DROP TABLE t5;
+EOF
+}
+
+grep_sparse_msg() {
+  local filename=$1
+  local errfile=$2
+
+  grep -q "File .*$filename is not sparse, skipping restore_sparseness" "$errfile"
+}
+
+check_sparse_msgs() {
+  local errfile="$1"
+
+  # These should have the "not sparse" message
+  for file in sys/sys_config.ibd mysql.ibd "test/t5.ibd"; do
+    if ! grep_sparse_msg "$file" "$errfile"; then
+      die "$file is not sparse, but the 'skipping restore_sparseness' message is missing"
+    fi
+  done
+
+  # These should NOT have the message (i.e., they are sparse)
+  for file in "test/t1.ibd" "test/t2.ibd" "test/t3.ibd" "test/t4.ibd"; do
+    if grep_sparse_msg "$file" "$errfile"; then
+      die "$file is sparse, but the 'skipping restore_sparseness' message is present"
+    fi
+  done
+}
+
+check_sparseness() {
+  local mysql_datadir="$1"
+
+  # Expected sparse files
+  for file in "t1.ibd" "t2.ibd" "t3.ibd" "t4.ibd"; do
+    full_path="$mysql_datadir/test/$file"
+    if ! is_sparse_file "$full_path"; then
+      cleanup
+      die "$file is expected to be sparse, but it is NOT"
+    fi
+  done
+
+  # Expected non-sparse files
+  for file in "sys/sys_config.ibd" "mysql.ibd" "test/t5.ibd"; do
+    full_path="$mysql_datadir/$file"
+    if is_sparse_file "$full_path"; then
+      cleanup
+      die "$file is NOT expected to be sparse, but it IS"
+    fi
+  done
+
+  echo "All sparseness checks passed"
+}
+
+check_and_start_server_sparse() {
+start_server
+
+if grep -q 'PUNCH HOLE support not available' $MYSQLD_ERRFILE ; then
+    skip 'punch hole support is not available'
+fi
+
+run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+
+CREATE TABLE t1 (c1 BLOB) COMPRESSION='zlib';
+CREATE TABLE t2 (c1 BLOB) COMPRESSION='lz4';
+CREATE TABLE t3 (c1 BLOB) COMPRESSION='zlib' ENCRYPTION='y';
+CREATE TABLE t4 (c1 BLOB) COMPRESSION='lz4' ENCRYPTION='y';
+CREATE TABLE t5 (c1 BLOB);
+EOF
+
+for i in {1..5} ; do
+  run_cmd $MYSQL $MYSQL_ARGS test <<EOF
+INSERT INTO t$i VALUES (REPEAT('x', 5000));
+
+INSERT INTO t$i SELECT * FROM t$i;
+INSERT INTO t$i SELECT * FROM t$i;
+INSERT INTO t$i SELECT * FROM t$i;
+INSERT INTO t$i SELECT * FROM t$i;
+
+EOF
+done
+
+# wait for InnoDB to flush all dirty pages
+innodb_wait_for_flush_all
+
+if ! is_sparse_file $mysql_datadir/test/t1.ibd ; then
+     cleanup
+     die "t1.ibd is expected to be sparse, but it is NOT"
+fi
+}
+
+take_backup_local_and_stream() {
+  extra_args=$1
+  xtrabackup --backup --target-dir=$topdir/backup --transition-key=123 ${extra_args}
+
+  mkdir $topdir/backuplsn
+
+  xtrabackup --backup --target-dir=$topdir/tmp --transition-key=123 \
+           --extra-lsndir=$topdir/backuplsn \
+           --stream=xbstream ${extra_args} > $topdir/backup.xbs
+
+  record_db_state test
+}
+
+decompress_from_dir() {
+  xtrabackup --decompress --remove-original --target-dir=$topdir/backup 2>&1 |tee  $topdir/decompress_dir.log
+
+  check_sparse_msgs $topdir/decompress_dir.log
+  check_sparseness $topdir/backup
+  rm -rf $topdir/decompress_dir.log
+  restore_and_verify $topdir/backup
+  rm -rf $topdir/backup
+}
+
+decompress_from_stream() {
+  rm -rf $topdir/backup_stream && mkdir $topdir/backup_stream
+  xbstream -x -v -C $topdir/backup_stream --decompress < $topdir/backup.xbs 2>&1 |tee $topdir/decompress_stream.log
+
+  check_sparse_msgs $topdir/decompress_stream.log
+  check_sparseness $topdir/backup_stream
+  rm -rf $topdir/decompress_stream.log
+  restore_and_verify $topdir/backup_stream
+  rm -rf $topdir/backup_stream
+}
+
+restore_and_verify() {
+    local TARGETDIR=$1
+    xtrabackup --prepare --target-dir=$TARGETDIR --transition-key=123 \
+               --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+    stop_server
+
+    rm -rf $mysql_datadir
+
+    xtrabackup --copy-back --target-dir=$TARGETDIR --transition-key=123 \
+               --generate-new-master-key \
+               --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+    start_server
+    verify_db_state test
+}
+
+echo "Test with lz4"
+check_and_start_server_sparse
+vlog "Taking backup with LZ4 compression"
+take_backup_local_and_stream "--compress=lz4 --read-buffer-size=1M"
+decompress_from_dir
+decompress_from_stream
+stop_server
+rm -rf $mysql_datadir
+
+echo "Test with zstd"
+check_and_start_server_sparse
+vlog "Taking backup with LZ4 compression"
+take_backup_local_and_stream "--compress=zstd --read-buffer-size=1M"
+decompress_from_dir
+decompress_from_stream


### PR DESCRIPTION
…l data

https://perconadev.atlassian.net/browse/PXB-3470

Problem:

If the backup is compressed backup (--compress option used), decompressing a backup, either via xbstream --decompress or with xtrabackup --decompress, to restore sparseness , on every IBD (whether the IBD is sparse or not) in backup/stream, xtrabackup/xbstream tries to restore sparseness on ALL compressed IBD files.

Example:
A . CREATE TABLE t1(a INT);                     -> regular IBD

B. CREATE TABLE t2(a INT) COMPRESSION='zlib';   -> sparse IBD

When xtrabackup --compress is used, both t1.ibd and t2.ibd are stored as t1.ibd.zstd and t2.ibd.zstd. After decompression, we would like to restore the sparseness of the IBD file. Because of this fix 079ea2bb, we try restore sparseness on both t1.ibd and t2.ibd.

After the decompression, we don't know if t1.ibd is sparse or not. So there is no choice. We try to restore sparseness on all IBDs. There is no harm from the redundant restore sparseness operation. It will check page header and if it is not sparse compressed, it will skip. But the problem is extra IO and CPU to do this. Imagine doing this on 1TB of IBD files.

Fix:
----
When we try restore_sparseness() on all IBDs, quickly abort if both Page 1 & Page 2 are not marked as IO compressed (Page compression). This involves still some IO(about 3 three pages) but it is minimal and further improvements can be done later based on evidence.