### PR TITLE
Fixed ld error and override warning when compiling xbcloud-t. (when using the ``-DWITH_UNIT_TESTS:BOOL=TRUE`` cmake flag)

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -79,6 +79,7 @@ IF (WITH_UNIT_TESTS AND CMAKE_VERSION VERSION_GREATER 3.22.1)
     ADD_EXECUTABLE(xbcloud-t xbcloud-t.cc
       http.cc
       s3.cc
+      s3_ec2.cc
       azure.cc
       swift.cc)
 

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
@@ -11,7 +11,7 @@ using namespace ::testing;
 
 class Mock_http_client : public xbcloud::Http_client {
  public:
-  MOCK_CONST_METHOD2(make_request, bool(const Http_request &, Http_response &));
+  MOCK_METHOD(bool, make_request, (const Http_request &, Http_response &), (const, override));
 };
 
 MATCHER_P3(Response, code, body, headers, "") {


### PR DESCRIPTION
## How to reproduce
### Used CMake flags
```bash
CMAKE_SRC_CONFIGURE_PARAMS=(
    -DBUILD_CONFIG:STRING=xtrabackup_release
    -DINSTALL_LAYOUT:STRING="RPM"  
    -DENABLED_PROFILING:BOOL=TRUE
    -DENABLE_GCOV:BOOL=FALSE
    -DENABLE_GPROF:BOOL=FALSE
    -DENABLED_LOCAL_INFILE:BOOL=TRUE
    -DWITH_ASAN:BOOL=FALSE
    -DWITH_EXTRA_CHARSETS:STRING=all
    -DWITH_EDITLINE:STRING=system
    -DWITH_UNIT_TESTS:BOOL=TRUE
    -DWITH_VALGRIND:BOOL=FALSE
    -DWITH_ZLIB:STRING=system
    -DWITH_SSL:STRING=system
    -DWITH_CLIENT_PROTOCOL_TRACING:BOOL=FALSE
    -DWITH_LZ4:STRING=system
    -DWITH_MSAN:BOOL=FALSE
    -DWITH_PROTOBUF:STRING=bundled
    -DWITH_TEST_TRACE_PLUGIN:BOOL=FALSE
    -DWITH_UBSAN:BOOL=FALSE
    -DWITH_XTRABACKUP:BOOL=TRUE
    -DWITH_FIDO=system
    -DWITH_ICU=system
    -DWITH_RAPIDJSON:STRING=bundled
    -DWITH_MAN_PAGES=OFF
)
```
### Configure
```bash
cmake -B build ${CMAKE_SRC_CONFIGURE_PARAMS[@]}
```
### Compile
```bash
cmake --build build -j$(nproc)
```
### Install (optional)
```bash
cmake --install build
```

## Results
The warning appears at 26% of the compilation: 
![image](https://github.com/user-attachments/assets/bf1a784b-6d92-438b-8e80-ddbe552f8568)

And the error at 27% of the compilation:
![image](https://github.com/user-attachments/assets/4cf61b2a-e65a-45a5-af76-2e363a93bb3a)


## Notes
- The issues are in the trunk, 8.4 and 8.0 branches, so they need to be fixed on those three branches.
- I tested on a clean machine (not graphical) with just the requested dependencies, as specified [in the tutorial](https://docs.percona.com/percona-xtrabackup/8.4/compile-xtrabackup.html#2-installation-prerequisites).

---

Also... I'm wondering, how I can run the unit tests after compilation?
