### PR TITLE
[8.0] PXB-3624: Fix HTTP connection uninitialization order

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
+++ b/storage/innobase/xtrabackup/src/xbcloud/CMakeLists.txt
@@ -50,7 +50,8 @@ MYSQL_ADD_EXECUTABLE(xbcloud
   s3_ec2.cc
   ../xbcrypt_common.cc
   ../file_utils.cc
-  swift.cc)
+  swift.cc
+  library_version_check.cc)
 
 SET_TARGET_PROPERTIES(xbcloud
         PROPERTIES LINKER_LANGUAGE CXX

--- a/storage/innobase/xtrabackup/src/xbcloud/http.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/http.cc
@@ -371,8 +371,8 @@ bool Event_handler::init() {
 }
 
 Event_handler::~Event_handler() {
-  if (loop != nullptr) ev_loop_destroy(loop);
   if (curl_multi != nullptr) curl_multi_cleanup(curl_multi);
+  if (loop != nullptr) ev_loop_destroy(loop);
 }
 
 void Event_handler::main_loop() { ev_loop(loop, 0); }

--- a/storage/innobase/xtrabackup/src/xbcloud/library_version_check.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/library_version_check.cc
@@ -1,0 +1,74 @@
+/******************************************************
+Copyright (c) 2025 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#include "library_version_check.h"
+#include <curl/curl.h>
+#include <optional>
+#include <string>
+#include <tuple>
+#include "msg.h"
+
+namespace xbcloud {
+
+// Semantic version ([major].[minor].[patch]).
+using version = std::tuple<unsigned int, unsigned int, unsigned int>;
+
+static std::string version_to_string(const version &ver) {
+  return std::to_string(std::get<0>(ver)) + "." +
+         std::to_string(std::get<1>(ver)) + "." +
+         std::to_string(std::get<2>(ver));
+}
+
+static std::optional<std::string> check_curl_version() {
+  auto *curl_ver = curl_version_info(CURLVERSION_NOW);
+  if (!curl_ver) {
+    return "Failed to detect libcurl version.";
+  }
+
+  auto ver = version((curl_ver->version_num >> 16) & 0xff,
+                     (curl_ver->version_num >> 8) & 0xff,
+                     curl_ver->version_num & 0xff);
+
+  if ((ver == version(7, 64, 0)) ||
+      (ver >= version(8, 11, 1) && ver < version(8, 12, 0))) {
+    return "Unsupported libcurl version: " + version_to_string(ver);
+  }
+
+  return {};
+}
+
+void check_library_versions() {
+  bool warning_found = false;
+
+  auto warn = [&warning_found](const std::optional<std::string> &info) {
+    if (info) {
+      warning_found = true;
+      msg_ts("Dependency warning: %s\n", info->c_str());
+    }
+  };
+
+  warn(check_curl_version());
+
+  if (warning_found) {
+    msg_ts(
+        "Please consult Percona XtraBackup documentation about incompatible "
+        "dependencies.\n");
+  }
+}
+
+}  // namespace xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/library_version_check.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/library_version_check.h
@@ -1,0 +1,28 @@
+/******************************************************
+Copyright (c) 2025 Percona LLC and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+*******************************************************/
+
+#ifndef XBCLOUD_LIBRARY_VERSION_CHECK_H
+#define XBCLOUD_LIBRARY_VERSION_CHECK_H
+
+namespace xbcloud {
+
+void check_library_versions();
+
+}  // namespace xbcloud
+
+#endif  // XBCLOUD_LIBRARY_VERSION_CHECK_H

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -44,6 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 #include "crc_glue.h"
 
+#include "library_version_check.h"
 #include "msg.h"
 #include "xbcloud/azure.h"
 #include "xbcloud/s3.h"
@@ -467,8 +468,8 @@ static struct my_option my_long_options[] = {
     {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}};
 
 static void print_version() {
-  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname, XBCLOUD_VERSION, SYSTEM_TYPE,
-         MACHINE_TYPE, XBCLOUD_REVISION);
+  printf("%s  Ver %s for %s (%s) (revision id: %s)\n", my_progname,
+         XBCLOUD_VERSION, SYSTEM_TYPE, MACHINE_TYPE, XBCLOUD_REVISION);
 }
 
 static void usage() {
@@ -561,7 +562,6 @@ static bool get_one_option(int optid,
 }
 
 static const char *load_default_groups[] = {"xbcloud", 0};
-
 
 static void get_env_args() {
   get_env_value(opt_swift_auth_url, "OS_AUTH_URL");
@@ -833,9 +833,7 @@ void put_func(put_thread_ctxt_t &cntx) {
   xb_rstream_chunk_t chunk;
   xb_rstream_result_t res;
 
-
   memset(&chunk, 0, sizeof(chunk));
-
 
   if (!h.init()) {
     msg_ts("%s: Failed to initialize event handler.\n", my_progname);
@@ -1311,6 +1309,8 @@ int main(int argc, char **argv) {
   if (parse_args(argc, argv)) {
     return EXIT_FAILURE;
   }
+
+  check_library_versions();
 
   std::unique_ptr<Object_store> object_store = nullptr;
   if (opt_verbose) {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3624

Problem
=======

Wrong uninitialization order resulted in libcurl connections using libev event loops that have already been destroyed.

We discovered that libcurl versions affected by CVE-2025-0665 cause a crash in xbcloud.

Fix
===

Uninitialization order of libcurl multi handles and libev event loops has been fixed.

Support for affected versions of libcurl has been dropped, and a warning is now displayed when xbcloud is run with an unsupported version of libcurl.