### PR TITLE
Using HeadBucket for backups is dangerous in multi-tenant S3 buckets

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -431,7 +431,7 @@ bool S3_client::create_bucket(const std::string &name) {
   return true;
 }
 
-bool S3_client::probe_api_version_and_lookup(const std::string &bucket) {
+bool S3_client::probe_api_version_and_lookup(const std::string &bucket, const std::string &backup) {
   for (auto lookup : {LOOKUP_DNS, LOOKUP_PATH}) {
     if (bucket_lookup != LOOKUP_AUTO && bucket_lookup != lookup) {
       continue;
@@ -455,7 +455,7 @@ bool S3_client::probe_api_version_and_lookup(const std::string &bucket) {
       api_version = version;
 
       bool exists;
-      if (bucket_exists(bucket.c_str(), exists)) {
+      if (object_exists(bucket.c_str(), backup.c_str(), exists)) {
         msg_ts("%s: Successfully connected.\n", my_progname);
         return true;
       }
@@ -479,6 +479,29 @@ bool S3_client::bucket_exists(const std::string &name, bool &exists) {
   Http_request req(Http_request::HEAD, protocol, hostname(name),
                    bucketname(name) + "/");
   signer->sign_request(hostname(name), name, req, time(0));
+
+  Http_response resp;
+  if (!http_client->make_request(req, resp)) {
+    return false;
+  }
+
+  if (resp.ok()) {
+    exists = true;
+    return true;
+  }
+
+  if (resp.http_code() == 404) {
+    exists = false;
+    return true;
+  }
+
+  return false;
+}
+
+bool S3_client::object_exists(const std::string &bucket, const std::string &name, bool &exists) {
+  Http_request req(Http_request::HEAD, protocol, hostname(bucket),
+                   bucketname(bucket) + "/" + name);
+  signer->sign_request(hostname(bucket), bucket, req, time(0));
 
   Http_response resp;
   if (!http_client->make_request(req, resp)) {

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -227,13 +227,15 @@ class S3_client {
 
   void set_api_version(s3_api_version_t version) { api_version = version; }
 
-  bool probe_api_version_and_lookup(const std::string &bucket);
+  bool probe_api_version_and_lookup(const std::string &bucket, const std::string &backup);
 
   bool delete_object(const std::string &bucket, const std::string &name);
 
   bool create_bucket(const std::string &name);
 
   bool bucket_exists(const std::string &name, bool &exists);
+
+  bool object_exists(const std::string &bucket, const std::string &name, bool &exists);
 
   bool upload_object(const std::string &bucket, const std::string &name,
                      const Http_buffer &contents);
@@ -303,8 +305,8 @@ class S3_object_store : public Object_store {
   void set_ec2_instance(std::shared_ptr<S3_ec2_instance> instance) {
     s3_client.set_ec2_instance(instance);
   }
-  bool probe_api_version_and_lookup(const std::string &bucket) {
-    return s3_client.probe_api_version_and_lookup(bucket);
+  bool probe_api_version_and_lookup(const std::string &bucket, const std::string &backup) {
+    return s3_client.probe_api_version_and_lookup(bucket, backup);
   }
   virtual bool create_container(const std::string &name) override {
     return s3_client.create_bucket(name);

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud-t.cc
@@ -51,7 +51,7 @@ TEST(s3_client, basicDNSv4) {
                 HasHeader("Authorization")),
           Response(200, "", std::vector<char *>{})))
       .WillOnce(Return(true));
-  c.probe_api_version_and_lookup("probe-bucket");
+  c.probe_api_version_and_lookup("probe-bucket", "probe-backup");
 
   EXPECT_CALL(
       http_client,
@@ -102,7 +102,7 @@ TEST(s3_client, basicPATHv4) {
                 HasHeader("Authorization")),
           Response(200, "", std::vector<char *>{})))
       .WillOnce(Return(true));
-  c.probe_api_version_and_lookup("probe-bucket");
+  c.probe_api_version_and_lookup("probe-bucket", "probe-backup");
 
   EXPECT_CALL(
       http_client,
@@ -142,7 +142,7 @@ TEST(s3_client, basicEndpoint) {
                 HasHeader("Authorization")),
           Response(200, "", std::vector<char *>{})))
       .WillOnce(Return(true));
-  c.probe_api_version_and_lookup("probe-bucket");
+  c.probe_api_version_and_lookup("probe-bucket", "probe-backup");
 
   EXPECT_CALL(
       http_client,

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -931,21 +931,11 @@ end:
 
 bool xbcloud_put(Object_store *store, const std::string &container,
                  const std::string &backup_name) {
-  bool exists;
   std::atomic<bool> has_errors{false};
   Http_buffer buf_md5 = Http_buffer();
   std::string last_file_prefix = backup_name + "/xtrabackup_tablespaces";
   auto last_file_size = last_file_prefix.size();
   bool file_found = false;
-  if (!store->container_exists(container, exists)) {
-    return false;
-  }
-
-  if (!exists) {
-    if (!store->create_container(container)) {
-      return false;
-    }
-  }
 
   std::vector<std::string> object_list;
   if (!store->list_objects_in_directory(container, backup_name, object_list)) {
@@ -1488,7 +1478,7 @@ int main(int argc, char **argv) {
     container_name = opt_s3_bucket;
 
     if (!reinterpret_cast<S3_object_store *>(object_store.get())
-             ->probe_api_version_and_lookup(container_name)) {
+             ->probe_api_version_and_lookup(container_name, backup_name)) {
       return EXIT_FAILURE;
     }
     if (ec2_instance->get_is_ec2_instance_with_profile()) {
@@ -1525,7 +1515,7 @@ int main(int argc, char **argv) {
     container_name = opt_google_bucket;
 
     if (!reinterpret_cast<S3_object_store *>(object_store.get())
-             ->probe_api_version_and_lookup(container_name)) {
+             ->probe_api_version_and_lookup(container_name, backup_name)) {
       return EXIT_FAILURE;
     }
   } else if (opt_storage == AZURE) {


### PR DESCRIPTION
### Proposal

This project uses HeadBucket to determine the signature version to use, as well as whether the bucket exists before creating backups. The problem with this is that in IAM, there is literally no way to let a user call HeadBucket while also preventing them from listing objects inside that bucket. This is because HeadBucket requires the `s3:ListBucket` permission.

There are zero air-tight IAM workarounds that would prevent this permission from also allowing users to list objects inside the bucket. Here are some examples:
1. Grant s3:ListBucket conditionally on the "" prefix - does not allow HeadBucket because HeadBucket does not pass a prefix parameter, and so it is denied.
2. Grant s3:ListBucket conditionally on a specific directory - same as above.
3. Grant s3:ListBucket conditionally on `"Null": {"s3:prefix": "true"}` - this actually still allows listing all objects in the bucket, just not specifying a prefix.
4. Grant s3:ListBucket conditionally on everything except `*/*` - can still specify a prefix without a slash and list objects.

There has been extensive discussion around this issue as it relates to the CNPG plugin:
https://github.com/EnterpriseDB/barman/issues/929
https://github.com/EnterpriseDB/barman/issues/1101
https://github.com/hashicorp/terraform-provider-aws/issues/17195

The initial suggestion was to use ListObjectsV2 with a prefix rather than HeadBucket - this works in terms of security, but it is more expensive in terms of AWS API calls, and so was rejected.

The final solution as it relates to CNPG was to completely remove cloud connectivity + bucket existence checks before running backups. I propose the same here, which would require to remove the signature checks and require that it is provider; or instead to use HeadObject, which can be scoped to a directory.

### Use-Case

The use case is for multi-tenant S3 buckets. Using HeadBucket in this scenario is a non-starter because it would allow users to see backups of other users.

### Anything else?

This is a requirement to resolve https://github.com/percona/percona-xtradb-cluster-operator/issues/2251, because that operator calls HeadBucket in itself, as well as by virtue of calling xbcloud.