### PR TITLE
[trunk] PXB-3458 : Ignore invalid innodb_undo_directory setting in --copy-back mode

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -160,7 +160,6 @@ struct datadir_thread_ctxt_t {
   bool ret;
 };
 
-
 /************************************************************************
 Trim leading slashes from absolute path so it becomes relative */
 static const char *trim_dotslash(const char *path) {
@@ -2290,7 +2289,15 @@ bool copy_back(int argc, char **argv) {
 
   /* copy undo tablespaces */
   if (srv_undo_tablespaces > 0) {
-    dst_dir = (srv_undo_dir && *srv_undo_dir) ? srv_undo_dir : mysql_data_home;
+    dst_dir = mysql_data_home;
+
+    // If innodb_undo_directory is set, use it as the destination directory.
+    // Ignore innodb_undo_directory if it's set to "./" (default value), because
+    // it will make xtrabackup try to copy files back to backup directory,
+    // resulting in "file exists" errors.
+    if (srv_undo_dir && *srv_undo_dir && strcmp(srv_undo_dir, "./") != 0) {
+      dst_dir = srv_undo_dir;
+    }
 
     ds_data = ds_create(dst_dir, DS_TYPE_LOCAL);
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3458

Problem
-------
When backup-my.cnf is used in --copy-back mode, it sets innodb_undo_directory setting to "./". This doesn't make sense in this mode, and results in a backup restoration error.

Fix
---
We ignore innodb_undo_directory setting if it's set to "./" in --copy-back mode.