### PR TITLE
PXB-3543 [8.0] : Xtrabackup 8.0 is extremely slow when performing incremenal backup for 1 Million Tables

### DIFF
--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -72,9 +72,16 @@ static bool wf_incremental_init(xb_write_filt_ctxt_t *ctxt, char *dst_name,
       (cursor->page_size / 4 + 1) * cursor->page_size + UNIV_PAGE_SIZE_MAX;
   cp->delta_buf_base = static_cast<byte *>(
       ut::malloc_withkey(UT_NEW_THIS_FILE_PSI_KEY, buf_size));
-  memset(cp->delta_buf_base, 0, buf_size);
   cp->delta_buf =
       static_cast<byte *>(ut_align(cp->delta_buf_base, UNIV_PAGE_SIZE_MAX));
+
+  /* OPTIMIZATION: Only zero the first page (header/index page).
+  Previously, we zeroed the entire buffer (~67MB), which triggered massive
+  OS page faults (asm_exc_page_fault) and consumed significant CPU (~80%).
+  We only need the header page to be clean so that no garbage follows the
+  0xFFFFFFFF sentinel. The data pages are overwritten by memcpy or never
+  written to disk.*/
+  memset(cp->delta_buf, 0, cursor->page_size);
 
   /* write delta meta info */
   snprintf(meta_name, sizeof(meta_name), "%s%s", dst_name,
@@ -135,7 +142,11 @@ static bool wf_incremental_process(xb_write_filt_ctxt_t *ctxt,
       }
 
       /* clear buffer */
-      memset(cp->delta_buf, 0, page_size / 4 * page_size);
+      /* OPTIMIZATION: Only clear the header page for the next batch.
+      The rest of the buffer will be overwritten by new data pages.
+      Since we track 'npages', we never write the dirty tail to disk,
+      so zeroing the whole buffer is wasted memory bandwidth.*/
+      memset(cp->delta_buf, 0, page_size);
       /*"xtra"*/
       mach_write_to_4(cp->delta_buf, 0x78747261UL);
       cp->npages = 1;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3543

Optimize incremental backup buffer initialization

**Problem:**
Incremental backups were suffering from extremely high CPU usage (up to 82% in perf reports) attributed to `__memset_avx512_unaligned_erms`. The root cause was the initialization of the delta buffer (~67MB per thread). The kernel lazily allocates physical RAM, so the initial `memset` triggered millions of Page Faults (`asm_exc_page_fault`), forcing the kernel to pause execution, allocate RAM, and zero it out. Additionally, flushing the buffer involved a redundant `memset` that wasted memory bandwidth.

**Solution:**
1. Removed the full-buffer `memset` in `wf_incremental_init`.
2. Removed the full-buffer `memset` in `wf_incremental_process` (flush loop).
3. Replaced both with a "surgical" `memset` that only zeroes the first page (the Index Page).

**Safety Analysis:**
The delta buffer consists of Page 0 (Index/Header) and Pages 1..N (Data).
- **Page 0:** Must be zeroed to ensure the file headers are clean and no garbage data exists after the `0xFFFFFFFF` sentinel. The new `memset` handles this.
- **Pages 1..N:** These are populated sequentially via `memcpy`. We track the number of valid pages (`npages`) and only write `npages * page_size` to disk. Any "dirty" or uninitialized memory at the tail of the buffer is never read and never written to the file.

**Impact:**
- Eliminates the "First Touch" page fault storm during initialization.
- Saves ~67MB of memory write bandwidth per flush cycle per thread.
- Drastically reduces system CPU time during incremental backups.