### PR TITLE
PXB-3328 [8.4] : Add --check-tables option to validate InnoDB indexes during prepare

### DIFF
--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -4096,7 +4096,8 @@ static void btr_validate_report2(
 @return true if ok */
 static bool btr_validate_level(
     dict_index_t *index, const trx_t *trx, ulint level,
-    bool lockout IF_DEBUG(, Index_details &index_details)) {
+    bool lockout IF_DEBUG(, Index_details &index_details),
+    blob_ref_map *blob_map = nullptr) {
   buf_block_t *block;
   page_t *page;
   buf_block_t *right_block = nullptr; /* remove warning */
@@ -4169,13 +4170,40 @@ static bool btr_validate_level(
       ret = false;
     }
 
+#ifdef XTRABACKUP
+    /* In xtrabackup --check-tables we report corruption instead of crashing.
+       InnoDB uses ut_a here because space ID mismatch or wrong page level
+       during B-tree descent is unrecoverable for a running server. In
+       xtrabackup we only need a damage report. */
+    if (index->space != block->page.id.space() ||
+        index->space != page_get_space_id(page)) {
+      btr_validate_report1(index, level, block);
+      ib::error() << "B-tree corruption: space ID mismatch during descent."
+                  << " Expected " << index->space << ", got block space "
+                  << block->page.id.space() << ", page space "
+                  << page_get_space_id(page) << " in index " << index->name();
+      mtr_commit(&mtr);
+      mem_heap_free(heap);
+      return false;
+    }
+    if (page_is_leaf(page)) {
+      btr_validate_report1(index, level, block);
+      ib::error() << "B-tree corruption: unexpected leaf page "
+                  << page_get_page_no(page) << " during descent to level "
+                  << level << " in index " << index->name();
+      mtr_commit(&mtr);
+      mem_heap_free(heap);
+      return false;
+    }
+#else
     ut_a(index->space == block->page.id.space());
     ut_a(index->space == page_get_space_id(page));
+    ut_a(!page_is_leaf(page));
+#endif /* XTRABACKUP */
 #ifdef UNIV_ZIP_DEBUG
     page_zip = buf_block_get_page_zip(block);
     ut_a(!page_zip || page_zip_validate(page_zip, page, index));
 #endif /* UNIV_ZIP_DEBUG */
-    ut_a(!page_is_leaf(page));
 
     page_cur_set_before_first(block, &cursor);
     page_cur_move_to_next(&cursor);
@@ -4222,6 +4250,7 @@ static bool btr_validate_level(
   }
 
   do {
+    ulint cur_page_no;
     mem_heap_empty(heap);
     offsets = offsets2 = nullptr;
     if (!srv_read_only_mode) {
@@ -4237,7 +4266,32 @@ static bool btr_validate_level(
     ut_a(!page_zip || page_zip_validate(page_zip, page, index));
 #endif /* UNIV_ZIP_DEBUG */
 
+#ifdef XTRABACKUP
+    /* In xtrabackup --check-tables we report corruption instead of crashing.
+       Space ID mismatch in the page scan means the page does not belong to
+       this index's tablespace -- severe corruption. Stop traversing this
+       index because sibling links on a corrupted page are untrustworthy. */
+    if (block->page.id.space() != index->space) {
+      btr_validate_report1(index, level, block);
+      ib::error() << "B-tree corruption: page space ID "
+                  << block->page.id.space() << " != index space "
+                  << index->space << " on page " << block->page.id.page_no()
+                  << " in index " << index->name();
+      ret = false;
+      right_page_no = FIL_NULL;
+      goto node_ptr_fails;
+    }
+#else
     ut_a(block->page.id.space() == index->space);
+#endif /* XTRABACKUP */
+
+    DBUG_EXECUTE_IF("check_table_wrong_index_id", {
+      thread_local bool injected = false;
+      if (!injected && btr_page_get_index_id(page) == index->id) {
+        mach_write_to_8(page + PAGE_HEADER + PAGE_INDEX_ID, index->id + 1);
+        injected = true;
+      }
+    });
 
     if (fseg_page_is_free(seg, block->page.id.space(),
                           block->page.id.page_no())) {
@@ -4252,7 +4306,7 @@ static bool btr_validate_level(
 
       ret = false;
 
-    } else if (!page_validate(page, index)) {
+    } else if (!page_validate(page, index, true, blob_map)) {
       btr_validate_report1(index, level, block);
       ret = false;
 
@@ -4263,17 +4317,53 @@ static bool btr_validate_level(
       ret = false;
     }
 
+#ifdef XTRABACKUP
+    /* In xtrabackup --check-tables we report corruption instead of crashing.
+       Page level mismatch means the page has wrong metadata (e.g. all-zero
+       page from unflushed redo). Stop traversal -- sibling links are
+       untrustworthy on a corrupted page. */
+    if (btr_page_get_level(page) != level) {
+      btr_validate_report1(index, level, block);
+      ib::error() << "B-tree corruption: page level "
+                  << btr_page_get_level(page) << " != expected level " << level
+                  << " on page " << page_get_page_no(page) << " in index "
+                  << index->name();
+      ret = false;
+      right_page_no = FIL_NULL;
+      goto node_ptr_fails;
+    }
+#else
     ut_a(btr_page_get_level(page) == level);
+#endif /* XTRABACKUP */
     right_page_no = btr_page_get_next(page, &mtr);
     left_page_no = btr_page_get_prev(page, &mtr);
-    const ulint cur_page_no = page_get_page_no(page);
+    cur_page_no = page_get_page_no(page);
 
 #ifdef UNIV_DEBUG
     index_details.add_page(cur_page_no, level);
 #endif /* UNIV_DEBUG */
 
+#ifdef XTRABACKUP
+    /* In xtrabackup --check-tables we report corruption instead of crashing.
+       An empty non-root page indicates corruption (e.g. all-zero page from
+       unflushed redo, or truncated tablespace). Stop traversal -- an
+       all-zero page has FIL_PAGE_NEXT=0 which would loop through non-B-tree
+       pages indefinitely. */
+    if (page_is_empty(page) &&
+        !(level == 0 && page_get_page_no(page) == dict_index_get_page(index))) {
+      btr_validate_report1(index, level, block);
+      ib::error() << "B-tree corruption: page " << page_get_page_no(page)
+                  << " is empty but is not the root page"
+                  << " in index " << index->name()
+                  << ". Possible all-zero (unflushed) page.";
+      ret = false;
+      right_page_no = FIL_NULL;
+      goto node_ptr_fails;
+    }
+#else
     ut_a(!page_is_empty(page) ||
          (level == 0 && page_get_page_no(page) == dict_index_get_page(index)));
+#endif /* XTRABACKUP */
 
     if (right_page_no != FIL_NULL) {
       const rec_t *right_rec;
@@ -4285,6 +4375,14 @@ static bool btr_validate_level(
 
       right_page = buf_block_get_frame(right_block);
 
+      DBUG_EXECUTE_IF("check_table_break_sibling_link", {
+        thread_local bool injected = false;
+        if (!injected && btr_page_get_prev(right_page, &mtr) != 0) {
+          mach_write_to_4(right_page + FIL_PAGE_PREV, 0);
+          injected = true;
+        }
+      });
+
       const auto fil_page_prev = btr_page_get_prev(right_page, &mtr);
       if (fil_page_prev != cur_page_no) {
         btr_validate_report2(index, level, block, right_block);
@@ -4295,9 +4393,15 @@ static bool btr_validate_level(
 
         ret = false;
 #ifdef UNIV_DEBUG
-        /* In debug build, it is best to fail with an assert. */
-        const bool siblings_link_correct = false;
-        ut_ad(siblings_link_correct);
+        {
+          bool skip_assert = false;
+          DBUG_EXECUTE_IF("check_table_break_sibling_link",
+                          skip_assert = true;);
+          if (!skip_assert) {
+            const bool siblings_link_correct = false;
+            ut_ad(siblings_link_correct);
+          }
+        }
 #endif /* UNIV_DEBUG */
       }
 
@@ -4342,9 +4446,25 @@ static bool btr_validate_level(
     }
 
     if (level > 0 && left_page_no == FIL_NULL) {
+#ifdef XTRABACKUP
+      /* In xtrabackup --check-tables we report corruption instead of
+         crashing. Missing min-record flag on the leftmost non-leaf page
+         indicates B-tree structural corruption. */
+      if (!(REC_INFO_MIN_REC_FLAG &
+            rec_get_info_bits(page_rec_get_next(page_get_infimum_rec(page)),
+                              page_is_comp(page)))) {
+        btr_validate_report1(index, level, block);
+        ib::error() << "B-tree corruption: min-record flag missing on"
+                    << " leftmost page " << page_get_page_no(page)
+                    << " at level " << level << " in index " << index->name();
+        ret = false;
+        goto node_ptr_fails;
+      }
+#else
       ut_a(REC_INFO_MIN_REC_FLAG &
            rec_get_info_bits(page_rec_get_next(page_get_infimum_rec(page)),
                              page_is_comp(page)));
+#endif /* XTRABACKUP */
     }
 
     /* Similarly skip the father node check for spatial index for now,
@@ -4425,15 +4545,61 @@ static bool btr_validate_level(
       }
 
       if (left_page_no == FIL_NULL) {
+#ifdef XTRABACKUP
+        /* In xtrabackup --check-tables we report corruption instead of
+           crashing. Wrong father pointer for leftmost child or unexpected
+           prev link on father page indicates structural corruption. */
+        if (node_ptr != page_rec_get_next(page_get_infimum_rec(father_page))) {
+          btr_validate_report1(index, level, block);
+          ib::error() << "B-tree corruption: leftmost child page "
+                      << page_get_page_no(page)
+                      << " has wrong father node pointer"
+                      << " in index " << index->name();
+          ret = false;
+          goto node_ptr_fails;
+        }
+        if (btr_page_get_prev(father_page, &mtr) != FIL_NULL) {
+          btr_validate_report1(index, level, block);
+          ib::error() << "B-tree corruption: father page of leftmost child"
+                      << " has unexpected prev link"
+                      << " in index " << index->name();
+          ret = false;
+          goto node_ptr_fails;
+        }
+#else
         ut_a(node_ptr == page_rec_get_next(page_get_infimum_rec(father_page)));
         ut_a(btr_page_get_prev(father_page, &mtr) == FIL_NULL);
+#endif /* XTRABACKUP */
       }
 
       if (right_page_no == FIL_NULL) {
         const rec_t *expected_node_ptr =
             page_rec_get_prev(page_get_supremum_rec(father_page));
+#ifdef XTRABACKUP
+        /* In xtrabackup --check-tables we report corruption instead of
+           crashing. Wrong father pointer for rightmost child or unexpected
+           next link on father page indicates structural corruption. */
+        if (node_ptr != expected_node_ptr) {
+          btr_validate_report1(index, level, block);
+          ib::error() << "B-tree corruption: rightmost child page "
+                      << page_get_page_no(page)
+                      << " has wrong father node pointer"
+                      << " in index " << index->name();
+          ret = false;
+          goto node_ptr_fails;
+        }
+        if (btr_page_get_next(father_page, &mtr) != FIL_NULL) {
+          btr_validate_report1(index, level, block);
+          ib::error() << "B-tree corruption: father page of rightmost child"
+                      << " has unexpected next link"
+                      << " in index " << index->name();
+          ret = false;
+          goto node_ptr_fails;
+        }
+#else
         ut_a(node_ptr == expected_node_ptr);
         ut_a(btr_page_get_next(father_page, &mtr) == FIL_NULL);
+#endif /* XTRABACKUP */
       } else {
         const rec_t *right_node_ptr;
 
@@ -4584,9 +4750,10 @@ static bool btr_validate_spatial_index(
 /** Checks the consistency of an index tree.
  @return true if ok */
 bool btr_validate_index(
-    dict_index_t *index, /*!< in: index */
-    const trx_t *trx,    /*!< in: transaction or NULL */
-    bool lockout)        /*!< in: true if X-latch index is intended */
+    dict_index_t *index,    /*!< in: index */
+    const trx_t *trx,       /*!< in: transaction or NULL */
+    bool lockout,           /*!< in: true if X-latch index is intended */
+    blob_ref_map *blob_map) /*!< in: optional LOB reference map */
 {
 #ifdef UNIV_DEBUG
   Index_details index_details;
@@ -4650,7 +4817,7 @@ bool btr_validate_index(
 
   for (ulint i = 0; i <= n; ++i) {
     if (!btr_validate_level(index, trx, n - i,
-                            lockout IF_DEBUG(, index_details))) {
+                            lockout IF_DEBUG(, index_details), blob_map)) {
       ok = false;
       break;
     }

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -3561,20 +3561,39 @@ bool fseg_page_is_free(fseg_header_t *seg_header, /*!< in: segment header */
 
   fil_space_t *space = fil_space_get(space_id);
 
+#ifdef XTRABACKUP
+  if (space == nullptr) {
+    ib::error() << "Cannot load tablespace for space_id: " << space_id
+                << " page_no: " << page;
+    return true;
+  }
+#endif /* XTRABACKUP */
+
   mtr_start(&mtr);
 
   mtr_x_lock_space(space, &mtr);
 
   const page_size_t page_size(space->flags);
 
-  seg_inode = fseg_inode_get(seg_header, space_id, page_size, &mtr);
+  if (seg_header != nullptr) {
+    seg_inode = fseg_inode_get(seg_header, space_id, page_size, &mtr);
 
-  ut_a(seg_inode);
-  ut_ad(mach_read_from_4(seg_inode + FSEG_MAGIC_N) == FSEG_MAGIC_N_VALUE);
-  ut_ad(!((page_offset(seg_inode) - FSEG_ARR_OFFSET) % FSEG_INODE_SIZE));
+    ut_a(seg_inode);
+    ut_ad(mach_read_from_4(seg_inode + FSEG_MAGIC_N) == FSEG_MAGIC_N_VALUE);
+    ut_ad(!((page_offset(seg_inode) - FSEG_ARR_OFFSET) % FSEG_INODE_SIZE));
+  }
 
   descr = xdes_get_descriptor(space_id, page, page_size, &mtr);
+#ifdef XTRABACKUP
+  if (descr == nullptr) {
+    ib::error() << "Cannot get extent descriptor for space_id: " << space_id
+                << " page_no: " << page;
+    mtr_commit(&mtr);
+    return true;
+  }
+#else
   ut_a(descr);
+#endif /* XTRABACKUP */
 
   auto is_free =
       xdes_mtr_get_bit(descr, XDES_FREE_BIT, page % FSP_EXTENT_SIZE, &mtr);

--- a/storage/innobase/include/btr0btr.h
+++ b/storage/innobase/include/btr0btr.h
@@ -41,6 +41,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "gis0type.h"
 #include "mtr0mtr.h"
 #include "page0cur.h"
+#include "page0page.h"
 #include "univ.i"
 
 /** Maximum record size which can be stored on a page, without using the
@@ -571,7 +572,8 @@ the index.
 [[nodiscard]] bool btr_validate_index(
     dict_index_t *index, /*!< in: index */
     const trx_t *trx,    /*!< in: transaction or 0 */
-    bool lockout);       /*!< in: true if X-latch index is intended */
+    bool lockout,        /*!< in: true if X-latch index is intended */
+    blob_ref_map *blob_map = nullptr); /*!< in: optional LOB reference map */
 
 /** Creates SDI index and stores the root page numbers in page 1 & 2
 @param[in]      space_id        tablespace id

--- a/storage/innobase/include/page0page.h
+++ b/storage/innobase/include/page0page.h
@@ -37,6 +37,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #ifndef page0page_h
 #define page0page_h
 
+#include <unordered_map>
 #include "univ.i"
 
 #include "buf0buf.h"
@@ -761,15 +762,33 @@ bool page_simple_validate_old(
 bool page_simple_validate_new(
     const page_t *page); /*!< in: index page in ROW_FORMAT!=REDUNDANT */
 
+/** A blob map to track the first page no of external LOB and its parent record
+which is the <page_no, heap_no>. This is used to find duplicate external LOB
+pages that are shared between two records.  This can happen only on corruption.
+--check-tables uses this map to report corruption. */
+using blob_ref_map = std::unordered_map<page_no_t, std::pair<page_no_t, ulint>>;
+
 /** This function checks the consistency of an index page.
-@param[in]  page   index page
-@param[in]  index  data dictionary index containing the page record type
+@param[in]  page      index page
+@param[in]  index     data dictionary index containing the page record type
 definition
 @param[in]  check_min_rec  check whether min rec flag (REC_INFO_MIN_REC_FLAG)
 is correctly set in the page. The default value is true.
+@param[in]  blob_map  optional blob reference map for LOB duplicate tracking
 @return true if ok */
 bool page_validate(const page_t *page, dict_index_t *index,
-                   bool check_min_rec = true);
+                   bool check_min_rec = true, blob_ref_map *blob_map = nullptr);
+
+/** Validate that the external LOB's first page is not shared between records of
+a clustered index.
+@param[in] rec       physical record
+@param[in] index     index of the table
+@param[in] offsets   the record offset array
+@param[in] blob_map  optional blob reference map for tracking
+@return true if OK, false if external LOB is shared between two records */
+bool page_rec_blob_validate(const rec_t *rec, const dict_index_t *index,
+                            const ulint *offsets,
+                            blob_ref_map *blob_map = nullptr);
 
 /** Looks in the page record list for a record with the given heap number.
  @return record, NULL if not found */

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -46,6 +46,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "lock0lock.h"
 #include "srv0srv.h"
 #endif /* !UNIV_HOTBACKUP */
+#include "lob0lob.h"
 
 /*                      THE INDEX PAGE
                         ==============
@@ -1721,6 +1722,114 @@ bool page_rec_validate(
   return true;
 }
 
+bool page_rec_blob_validate(const rec_t *rec, const dict_index_t *index,
+                            const ulint *offsets, blob_ref_map *blob_map) {
+  if (blob_map == nullptr) {
+    return true;
+  }
+
+  if (!index->is_clustered()) {
+    return true;
+  }
+
+  const page_t *page = page_align(rec);
+  if (!page_is_leaf(page)) {
+    return true;
+  }
+
+  if (!page_rec_is_user_rec(rec)) {
+    return true;
+  }
+
+  if (!rec_offs_any_extern(offsets)) {
+    return true;
+  }
+
+  if (rec_get_deleted_flag(rec, rec_offs_comp(offsets))) {
+    return true;
+  }
+
+  ulint n_fields = rec_offs_n_fields(offsets);
+
+  for (ulint i = 0; i < n_fields; i++) {
+    if (rec_offs_nth_extern(index, offsets, i)) {
+      byte *field_ref = const_cast<byte *>(
+          lob::btr_rec_get_field_ref(index, rec, offsets, i));
+
+      lob::ref_t ref(field_ref);
+      if (!ref.is_owner() || ref.is_null_relaxed() || ref.is_being_modified()) {
+        continue;
+      }
+
+      if (ref.length() == 0) {
+        continue;
+      }
+
+      space_id_t blob_space_id = ref.space_id();
+      page_no_t blob_page_no = ref.page_no();
+
+      page_id_t blob_page_id(blob_space_id, blob_page_no);
+
+      if (fil_space_get(blob_space_id) == nullptr) {
+        ib::error() << "Invalid record. The record's blob reference points"
+                    << " to a missing tablespace " << blob_space_id
+                    << " page_no: " << page_get_page_no(page)
+                    << " heap_no: " << page_rec_get_heap_no(rec);
+        return false;
+      }
+
+      page_no_t blob_space_size = fil_space_get_size(blob_space_id);
+      if (blob_page_no >= blob_space_size) {
+        ib::error() << "Invalid record. The record's blob reference points"
+                    << " outside the tablespace"
+                    << " page_no: " << page_get_page_no(page)
+                    << " heap_no: " << page_rec_get_heap_no(rec) << " blob "
+                    << blob_page_id << " space_size: " << blob_space_size;
+        return false;
+      }
+
+      bool is_free = fseg_page_is_free(nullptr, blob_space_id, blob_page_no);
+      if (is_free) {
+        ib::error() << "Invalid record. The record's blob reference is marked"
+                    << " as free although the record owns it "
+                    << " page_no: " << page_get_page_no(page)
+                    << " heap_no: " << page_rec_get_heap_no(rec);
+        ib::error() << "BLOB reference that is marked free " << blob_page_id;
+
+        return false;
+      }
+
+      DBUG_EXECUTE_IF(
+          "simulate_lob_corruption", if (blob_map->size() >= 5) {
+            (*blob_map)[blob_page_no] = std::make_pair(
+                page_get_page_no(page) - 1, page_rec_get_heap_no(rec) - 1);
+          });
+
+      auto it = blob_map->find(blob_page_no);
+      if (it == blob_map->end()) {
+        (*blob_map)[blob_page_no] =
+            std::make_pair(page_get_page_no(page), page_rec_get_heap_no(rec));
+      } else {
+        auto val = it->second;
+        ib::error() << "Invalid record! External LOB first page cannot be "
+                       "shared between "
+                       "two records";
+        ib::error() << "The external LOB first page is " << blob_page_id;
+        ib::error() << "The first occurrence of the external LOB first page is "
+                       "in record : page_no: "
+                    << val.first << " with heap_no: " << val.second;
+        ib::error()
+            << "The second occurrence of the external LOB first page is "
+               "in record: page_no: "
+            << page_get_page_no(page)
+            << " with heap no: " << page_rec_get_heap_no(rec);
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 #ifndef UNIV_HOTBACKUP
 #ifdef UNIV_DEBUG
 /** Checks that the first directory slot points to the infimum record and
@@ -2123,8 +2232,8 @@ bool page_is_spatial_non_leaf(const rec_t *rec, dict_index_t *index) {
   return (dict_index_is_spatial(index) && !page_is_leaf(page_align(rec)));
 }
 
-bool page_validate(const page_t *page, dict_index_t *index,
-                   bool check_min_rec) {
+bool page_validate(const page_t *page, dict_index_t *index, bool check_min_rec,
+                   blob_ref_map *blob_map) {
   const page_dir_slot_t *slot;
   mem_heap_t *heap;
   byte *buf;
@@ -2232,6 +2341,11 @@ bool page_validate(const page_t *page, dict_index_t *index,
     }
 
     if (UNIV_UNLIKELY(!page_rec_validate(rec, offsets))) {
+      goto func_exit;
+    }
+
+    if (!page_rec_blob_validate(const_cast<byte *>(rec), index, offsets,
+                                blob_map)) {
       goto func_exit;
     }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -61,6 +61,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <sys/resource.h>
 
+#include <btr0btr.h>
 #include <btr0sea.h>
 #include <buf0dblwr.h>
 #include <dict0dd.h>
@@ -159,6 +160,7 @@ bool xtrabackup_print_param = false;
 
 bool xtrabackup_export = false;
 bool xtrabackup_apply_log_only = false;
+bool xtrabackup_check_tables = false;
 
 longlong xtrabackup_use_memory = 100 * 1024 * 1024L;
 bool xtrabackup_use_memory_set = false;
@@ -784,6 +786,7 @@ enum options_xtrabackup {
   OPT_XTRA_TABLES_COMPATIBILITY_CHECK,
   OPT_XTRA_CHECK_PRIVILEGES,
   OPT_XTRA_READ_BUFFER_SIZE,
+  OPT_XTRA_CHECK_TABLES,
 };
 
 struct my_option xb_client_options[] = {
@@ -804,6 +807,12 @@ struct my_option xb_client_options[] = {
      "create files to import to another database when prepare.",
      (G_PTR *)&xtrabackup_export, (G_PTR *)&xtrabackup_export, 0, GET_BOOL,
      NO_ARG, 0, 0, 0, 0, 0, 0},
+    {"check-tables", OPT_XTRA_CHECK_TABLES,
+     "Validate all InnoDB B-tree indexes during --prepare. "
+     "Runs after redo apply (including --apply-log-only). "
+     "Read-only: does not modify any InnoDB data.",
+     (G_PTR *)&xtrabackup_check_tables, (G_PTR *)&xtrabackup_check_tables, 0,
+     GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"apply-log-only", OPT_XTRA_APPLY_LOG_ONLY,
      "stop recovery process not to progress LSN after applying log when "
      "prepare.",
@@ -3397,7 +3406,6 @@ void io_watching_thread() {
   io_watching_thread_running = false;
 }
 
-
 /**************************************************************************
 Datafiles copying thread.*/
 static void data_copy_thread_func(data_thread_ctxt_t *ctxt) {
@@ -3618,7 +3626,6 @@ Initializes the I/O and tablespace cache subsystems. */
 static bool xb_fil_io_init(void)
 /*================*/
 {
-
   if (!os_aio_init(srv_n_read_io_threads, srv_n_write_io_threads)) {
     xb::error() << "Cannot initialize AIO sub-system.";
     return false;
@@ -3756,7 +3763,6 @@ void xb_data_files_close(void)
   fil_close_all_files();
 
   fil_close();
-
 
   srv_shutdown_state = SRV_SHUTDOWN_NONE;
 }
@@ -6734,6 +6740,67 @@ static void space_extend_thread_func(data_thread_ctxt_t *ctxt) {
   my_thread_end();
 }
 
+/** Validate all indexes of all tables in tablespaces assigned to this thread.
+Threads share a datafiles_iter and each grabs the next tablespace to check.
+On corruption, sets *ctxt->error to true but does NOT stop -- all threads
+run to completion so the operator gets a full damage report.
+@param[in]     ctxt          shared context used by all threads */
+static void check_tables_thread_func(data_thread_ctxt_t *ctxt) {
+  fil_node_t *node;
+
+  my_thread_init();
+  THD *thd = create_thd(false, false, true, 0, 0);
+
+  while ((node = datafiles_iter_next(ctxt->it)) != NULL) {
+    fil_space_t *space = node->space;
+
+    if (!fsp_is_ibd_tablespace(space->id)) {
+      continue;
+    }
+
+    auto result = xb::prepare::dict_load_from_spaces_sdi(space->id);
+    if (std::get<0>(result) != DB_SUCCESS) {
+      xb::error() << "Cannot load dictionary for tablespace " << space->name;
+      mutex_enter(ctxt->count_mutex);
+      *(ctxt->error) = true;
+      mutex_exit(ctxt->count_mutex);
+      continue;
+    }
+
+    for (auto table : std::get<1>(result)) {
+      xb::info() << "Checking: " << table->name.m_name;
+      blob_ref_map blob_map;
+      for (dict_index_t *index = table->first_index(); index != nullptr;
+           index = index->next()) {
+        if (!index->is_committed()) continue;
+        blob_ref_map *blob_map_ptr = nullptr;
+        if (index->is_clustered()) {
+          blob_map_ptr = &blob_map;
+        }
+        bool valid = btr_validate_index(index, nullptr, false, blob_map_ptr);
+        DBUG_EXECUTE_IF("check_table_inject_corruption", valid = false;);
+        if (!valid) {
+          xb::error() << "Index " << index->name() << " of table "
+                      << table->name.m_name << " is corrupted.";
+          mutex_enter(ctxt->count_mutex);
+          *(ctxt->error) = true;
+          mutex_exit(ctxt->count_mutex);
+        }
+      }
+      mutex_enter(&(dict_sys->mutex));
+      dd_table_close(table, thd, nullptr, true);
+      mutex_exit(&(dict_sys->mutex));
+    }
+  }
+
+  mutex_enter(ctxt->count_mutex);
+  (*ctxt->count)--;
+  mutex_exit(ctxt->count_mutex);
+
+  destroy_thd(thd);
+  my_thread_end();
+}
+
 static void xtrabackup_prepare_func(int argc, char **argv) {
   ulint err;
   datafiles_iter_t *it;
@@ -6974,7 +7041,6 @@ skip_check:
 
   srv_apply_log_only = (bool)xtrabackup_apply_log_only;
 
-
   xb::info() << "Starting InnoDB instance for recovery.";
   xb::info() << "Using " << xtrabackup_use_memory
              << " bytes for buffer pool (set by "
@@ -7087,6 +7153,61 @@ skip_check:
     }
 
     datafiles_iter_free(it);
+  }
+
+  /* TODO: When both --export and --check-tables are specified, both blocks
+  iterate tablespaces and call dict_load_from_spaces_sdi() independently.
+  A future optimization should unify them into a single pass to avoid
+  loading the dictionary twice. */
+
+  if (xtrabackup_check_tables) {
+    xb::info() << "Starting table checks (--check-tables).";
+    bool check_failed = false;
+    uint ct_count;
+    ib_mutex_t ct_count_mutex;
+
+    it = datafiles_iter_new(nullptr);
+    if (it == NULL) {
+      xb::error() << "datafiles_iter_new() failed.";
+      exit(EXIT_FAILURE);
+    }
+
+    data_thread_ctxt_t *ct_threads = (data_thread_ctxt_t *)ut::malloc_withkey(
+        UT_NEW_THIS_FILE_PSI_KEY,
+        sizeof(data_thread_ctxt_t) * xtrabackup_parallel);
+    ct_count = xtrabackup_parallel;
+    mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &ct_count_mutex);
+
+    for (uint i = 0; i < (uint)xtrabackup_parallel; i++) {
+      ct_threads[i].it = it;
+      ct_threads[i].num = i + 1;
+      ct_threads[i].count = &ct_count;
+      ct_threads[i].count_mutex = &ct_count_mutex;
+      ct_threads[i].error = &check_failed;
+      os_thread_create(PFS_NOT_INSTRUMENTED, i, check_tables_thread_func,
+                       ct_threads + i)
+          .start();
+    }
+
+    while (1) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+      mutex_enter(&ct_count_mutex);
+      if (ct_count == 0) {
+        mutex_exit(&ct_count_mutex);
+        break;
+      }
+      mutex_exit(&ct_count_mutex);
+    }
+
+    mutex_free(&ct_count_mutex);
+    ut::free(ct_threads);
+    datafiles_iter_free(it);
+
+    if (check_failed) {
+      xb::error() << "Table check failed. The backup may be corrupted.";
+      goto error_cleanup;
+    }
+    xb::info() << "All table checks passed.";
   }
 
   /* Check whether the log is applied enough or not. */
@@ -8019,6 +8140,11 @@ int main(int argc, char **argv) {
   if (xtrabackup_throttle && !xtrabackup_backup) {
     xtrabackup_throttle = 0;
     xb::warn() << "--throttle has effect only with --backup";
+  }
+
+  if (xtrabackup_check_tables && !xtrabackup_prepare) {
+    xb::error() << "--check-tables is only valid with --prepare";
+    exit(EXIT_FAILURE);
   }
 
   /* cannot execute both for now */

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -132,6 +132,7 @@ extern ulong xtrabackup_encrypt_algo;
 extern uint xtrabackup_encrypt_threads;
 extern ulonglong xtrabackup_encrypt_chunk_size;
 extern bool xtrabackup_export;
+extern bool xtrabackup_check_tables;
 extern char *xtrabackup_incremental_basedir;
 extern char *xtrabackup_extra_lsndir;
 extern char *xtrabackup_incremental_dir;

--- a/storage/innobase/xtrabackup/test/t/check_tables.sh
+++ b/storage/innobase/xtrabackup/test/t/check_tables.sh
@@ -1,0 +1,454 @@
+############################################################################
+# Test --check-tables on prepare: positive multi-combination scenario,
+# real IBD corruption (broken sibling link), and page checksum corruption.
+#
+# Scenario 1 covers: encrypted, compressed, plain, general tablespace,
+#   FTS (fulltext), INSTANT ALTER, functional index, virtual column index,
+#   GIS/spatial index, and HASH-partitioned tables.
+# Scenario 6: Invalid --check-tables combinations (--copy-back, --backup).
+# Scenario 7: --prepare --export --check-tables combined.
+############################################################################
+
+. inc/keyring_file.sh
+. inc/keyring_common.sh
+
+configure_server_with_component
+
+mysql test <<'EOF'
+CREATE TABLE t_enc (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) ENCRYPTION='y';
+CREATE TABLE t_comp (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+CREATE TABLE t_plain (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100));
+CREATE TABLESPACE ts_general ADD DATAFILE 'ts_general.ibd' ENGINE=InnoDB;
+CREATE TABLE t_gen1 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) TABLESPACE ts_general;
+CREATE TABLE t_gen2 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) TABLESPACE ts_general;
+CREATE TABLE t_gen3 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) TABLESPACE ts_general;
+CREATE TABLE t_gen4 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) TABLESPACE ts_general;
+CREATE TABLE t_gen5 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) TABLESPACE ts_general;
+CREATE TABLE t_fts (a INT PRIMARY KEY AUTO_INCREMENT, b TEXT, FULLTEXT INDEX ft_idx(b)) ENGINE=InnoDB;
+CREATE TABLE t_instant (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100));
+CREATE TABLE t_funcidx (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100), INDEX idx_func((UPPER(b))));
+CREATE TABLE t_virtual (a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT AS (b * 2) VIRTUAL, INDEX idx_virtual(c));
+CREATE TABLE t_gis (a INT PRIMARY KEY AUTO_INCREMENT, g GEOMETRY NOT NULL SRID 0, SPATIAL INDEX idx_gis(g));
+CREATE TABLE t_part (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100)) PARTITION BY HASH(a) PARTITIONS 3;
+CREATE TABLE t_part_range (a INT NOT NULL, b VARCHAR(100), PRIMARY KEY (a)) PARTITION BY RANGE(a) (PARTITION p0 VALUES LESS THAN (101), PARTITION p1 VALUES LESS THAN (201), PARTITION pmax VALUES LESS THAN MAXVALUE);
+CREATE TABLE t_json_mvi (a INT PRIMARY KEY AUTO_INCREMENT, doc JSON, tags JSON, KEY idx_tags ((CAST(tags->'$[*]' AS UNSIGNED ARRAY))));
+CREATE TABLE t_fk_parent (a INT PRIMARY KEY AUTO_INCREMENT, code VARCHAR(10) NOT NULL, UNIQUE KEY uk_code (code));
+CREATE TABLE t_fk_child (a INT PRIMARY KEY AUTO_INCREMENT, parent_id INT, parent_code VARCHAR(10), KEY idx_pid (parent_id), KEY idx_code (parent_code), CONSTRAINT fk_pid FOREIGN KEY (parent_id) REFERENCES t_fk_parent (a) ON DELETE CASCADE, CONSTRAINT fk_code FOREIGN KEY (parent_code) REFERENCES t_fk_parent (code) ON DELETE SET NULL);
+CREATE TABLE t_invisible (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(100), c INT INVISIBLE, d INT AS (c * 2) VIRTUAL INVISIBLE, KEY idx_c (c));
+EOF
+
+for i in $(seq 1 100); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_enc (b) VALUES ('enc_init_${i}');
+     INSERT INTO t_comp (b) VALUES ('comp_init_${i}');
+     INSERT INTO t_plain (b) VALUES ('plain_init_${i}');
+     INSERT INTO t_gen1 (b) VALUES ('gen1_init_${i}');
+     INSERT INTO t_gen2 (b) VALUES ('gen2_init_${i}');
+     INSERT INTO t_gen3 (b) VALUES ('gen3_init_${i}');
+     INSERT INTO t_gen4 (b) VALUES ('gen4_init_${i}');
+     INSERT INTO t_gen5 (b) VALUES ('gen5_init_${i}');
+     INSERT INTO t_fts (b) VALUES ('fts_init_${i}');
+     INSERT INTO t_instant (b) VALUES ('inst_init_${i}');
+     INSERT INTO t_funcidx (b) VALUES ('func_init_${i}');
+     INSERT INTO t_virtual (b) VALUES (${i});
+     INSERT INTO t_gis (g) VALUES (ST_GeomFromText('POINT(${i} ${i})'));
+     INSERT INTO t_part (b) VALUES ('part_init_${i}');
+     INSERT INTO t_part_range (a, b) VALUES (${i}, 'range_init_${i}');
+     INSERT INTO t_json_mvi (doc, tags) VALUES ('{\"name\": \"u${i}\"}', '[${i}, $((i+1))]');
+     INSERT INTO t_fk_parent (code) VALUES ('C${i}');
+     INSERT INTO t_fk_child (parent_id, parent_code) VALUES (${i}, 'C${i}');
+     INSERT INTO t_invisible (b, c) VALUES ('inv_init_${i}', ${i});"
+done
+
+vlog "INSTANT ALTER: add column c to t_instant after initial data"
+mysql test <<EOF
+ALTER TABLE t_instant ADD COLUMN c INT DEFAULT 42, ALGORITHM=INSTANT;
+ALTER TABLE t_instant ADD COLUMN d VARCHAR(50) DEFAULT 'added', ALGORITHM=INSTANT;
+ALTER TABLE t_instant DROP COLUMN d, ALGORITHM=INSTANT;
+ALTER TABLE t_instant ADD COLUMN e BIGINT, ALGORITHM=INSTANT;
+EOF
+
+vlog "Full backup"
+xtrabackup --backup --target-dir=$topdir/full \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup_full.log >&2)
+
+for i in $(seq 101 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_enc (b) VALUES ('enc_inc1_${i}');
+     INSERT INTO t_comp (b) VALUES ('comp_inc1_${i}');
+     INSERT INTO t_plain (b) VALUES ('plain_inc1_${i}');
+     INSERT INTO t_gen1 (b) VALUES ('gen1_inc1_${i}');
+     INSERT INTO t_gen2 (b) VALUES ('gen2_inc1_${i}');
+     INSERT INTO t_gen3 (b) VALUES ('gen3_inc1_${i}');
+     INSERT INTO t_gen4 (b) VALUES ('gen4_inc1_${i}');
+     INSERT INTO t_gen5 (b) VALUES ('gen5_inc1_${i}');
+     INSERT INTO t_fts (b) VALUES ('fts_inc1_${i}');
+     INSERT INTO t_instant (b, c, e) VALUES ('inst_inc1_${i}', ${i}, ${i}*10);
+     INSERT INTO t_funcidx (b) VALUES ('func_inc1_${i}');
+     INSERT INTO t_virtual (b) VALUES (${i});
+     INSERT INTO t_gis (g) VALUES (ST_GeomFromText('POINT(${i} ${i})'));
+     INSERT INTO t_part (b) VALUES ('part_inc1_${i}');
+     INSERT INTO t_part_range (a, b) VALUES (${i}, 'range_inc1_${i}');
+     INSERT INTO t_json_mvi (doc, tags) VALUES ('{\"name\": \"u${i}\"}', '[${i}, $((i+1))]');
+     INSERT INTO t_fk_parent (code) VALUES ('D${i}');
+     INSERT INTO t_fk_child (parent_id, parent_code) VALUES (${i}, 'D${i}');
+     INSERT INTO t_invisible (b, c) VALUES ('inv_inc1_${i}', ${i});"
+done
+
+vlog "Incremental backup 1"
+xtrabackup --backup --incremental-basedir=$topdir/full \
+           --target-dir=$topdir/inc1 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup_inc1.log >&2)
+
+for i in $(seq 201 300); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_enc (b) VALUES ('enc_inc2_${i}');
+     INSERT INTO t_comp (b) VALUES ('comp_inc2_${i}');
+     INSERT INTO t_plain (b) VALUES ('plain_inc2_${i}');
+     INSERT INTO t_gen1 (b) VALUES ('gen1_inc2_${i}');
+     INSERT INTO t_gen2 (b) VALUES ('gen2_inc2_${i}');
+     INSERT INTO t_gen3 (b) VALUES ('gen3_inc2_${i}');
+     INSERT INTO t_gen4 (b) VALUES ('gen4_inc2_${i}');
+     INSERT INTO t_gen5 (b) VALUES ('gen5_inc2_${i}');
+     INSERT INTO t_fts (b) VALUES ('fts_inc2_${i}');
+     INSERT INTO t_instant (b, c, e) VALUES ('inst_inc2_${i}', ${i}, ${i}*10);
+     INSERT INTO t_funcidx (b) VALUES ('func_inc2_${i}');
+     INSERT INTO t_virtual (b) VALUES (${i});
+     INSERT INTO t_gis (g) VALUES (ST_GeomFromText('POINT(${i} ${i})'));
+     INSERT INTO t_part (b) VALUES ('part_inc2_${i}');
+     INSERT INTO t_part_range (a, b) VALUES (${i}, 'range_inc2_${i}');
+     INSERT INTO t_json_mvi (doc, tags) VALUES ('{\"name\": \"u${i}\"}', '[${i}, $((i+1))]');
+     INSERT INTO t_fk_parent (code) VALUES ('E${i}');
+     INSERT INTO t_fk_child (parent_id, parent_code) VALUES (${i}, 'E${i}');
+     INSERT INTO t_invisible (b, c) VALUES ('inv_inc2_${i}', ${i});"
+done
+
+vlog "Incremental backup 2"
+xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+           --target-dir=$topdir/inc2 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup_inc2.log >&2)
+
+record_db_state test
+
+vlog "Prepare full with --apply-log-only --check-tables (should run check)"
+xtrabackup --prepare --apply-log-only --check-tables --target-dir=$topdir/full \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2>&1 | tee $topdir/prepare_full.log
+grep log-applied $topdir/full/xtrabackup_checkpoints
+grep -q "Starting table checks" $topdir/prepare_full.log || \
+  die "check-tables should run during --apply-log-only prepare"
+grep -q "All table checks passed" $topdir/prepare_full.log || \
+  die "Table checks did not pass during --apply-log-only prepare"
+
+vlog "Prepare inc1 with --apply-log-only --check-tables (should run check)"
+xtrabackup --prepare --apply-log-only --check-tables \
+           --incremental-dir=$topdir/inc1 --target-dir=$topdir/full \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2>&1 | tee $topdir/prepare_inc1.log
+grep log-applied $topdir/full/xtrabackup_checkpoints
+grep -q "Starting table checks" $topdir/prepare_inc1.log || \
+  die "check-tables should run during incremental --apply-log-only prepare"
+grep -q "All table checks passed" $topdir/prepare_inc1.log || \
+  die "Table checks did not pass during incremental --apply-log-only prepare"
+
+vlog "Prepare inc2 with --check-tables (final prepare, should run check)"
+xtrabackup --prepare --check-tables \
+           --incremental-dir=$topdir/inc2 --target-dir=$topdir/full \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2>&1 | tee $topdir/prepare_inc2.log
+grep full-prepared $topdir/full/xtrabackup_checkpoints
+grep -q "Starting table checks" $topdir/prepare_inc2.log || \
+  die "check-tables did not start on final prepare"
+grep -q "Checking: test/t_enc" $topdir/prepare_inc2.log || \
+  die "Encrypted table not checked"
+grep -q "Checking: test/t_comp" $topdir/prepare_inc2.log || \
+  die "Compressed table not checked"
+grep -q "Checking: test/t_plain" $topdir/prepare_inc2.log || \
+  die "Plain table not checked"
+grep -q "Checking: test/t_gen1" $topdir/prepare_inc2.log || \
+  die "General tablespace table t_gen1 not checked"
+grep -q "Checking: test/t_gen2" $topdir/prepare_inc2.log || \
+  die "General tablespace table t_gen2 not checked"
+grep -q "Checking: test/t_gen3" $topdir/prepare_inc2.log || \
+  die "General tablespace table t_gen3 not checked"
+grep -q "Checking: test/t_gen4" $topdir/prepare_inc2.log || \
+  die "General tablespace table t_gen4 not checked"
+grep -q "Checking: test/t_gen5" $topdir/prepare_inc2.log || \
+  die "General tablespace table t_gen5 not checked"
+grep -q "Checking: test/t_fts" $topdir/prepare_inc2.log || \
+  die "FTS table not checked"
+grep -q "Checking: test/t_instant" $topdir/prepare_inc2.log || \
+  die "INSTANT ALTER table not checked"
+grep -q "Checking: test/t_funcidx" $topdir/prepare_inc2.log || \
+  die "Functional index table not checked"
+grep -q "Checking: test/t_virtual" $topdir/prepare_inc2.log || \
+  die "Virtual column index table not checked"
+grep -q "Checking: test/t_gis" $topdir/prepare_inc2.log || \
+  die "GIS/spatial table not checked"
+grep -q "Checking: test/t_part" $topdir/prepare_inc2.log || \
+  die "Partitioned table not checked"
+grep -q "Checking: test/t_part_range" $topdir/prepare_inc2.log || \
+  die "RANGE partitioned table not checked"
+grep -q "Checking: test/t_json_mvi" $topdir/prepare_inc2.log || \
+  die "JSON multi-valued index table not checked"
+grep -q "Checking: test/t_fk_parent" $topdir/prepare_inc2.log || \
+  die "FK parent table not checked"
+grep -q "Checking: test/t_fk_child" $topdir/prepare_inc2.log || \
+  die "FK child table not checked"
+grep -q "Checking: test/t_invisible" $topdir/prepare_inc2.log || \
+  die "Invisible columns table not checked"
+grep -q "All table checks passed" $topdir/prepare_inc2.log || \
+  die "Table checks did not pass"
+
+vlog "Restore and verify"
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/full
+configure_keyring_file_component
+start_server
+verify_db_state test
+
+#
+# Scenario 2: Real IBD corruption (broken FIL_PAGE_NEXT sibling link)
+#
+vlog "=== Scenario 2: Real IBD corruption ==="
+
+vlog "Create a table with enough rows for multiple leaf pages"
+mysql test <<EOF
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+EOF
+
+for i in $(seq 1 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t1 (b) VALUES (REPEAT('x', 200));"
+done
+
+xtrabackup --backup --target-dir=$topdir/backup2 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup2.log >&2)
+
+vlog "Prepare with --apply-log-only first"
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup2 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/prepare_s2_alog.log >&2)
+
+vlog "Corrupt PAGE_INDEX_ID on leaf page 6 of test/t1.ibd"
+page_size=16384
+page_no=6
+# PAGE_INDEX_ID sits at PAGE_HEADER(38) + 28 = 66 bytes from page start
+index_id_offset=$((page_size * page_no + 66))
+printf '\xff\xff\xff\xff\xff\xff\xff\xff' | dd of=$topdir/backup2/test/t1.ibd \
+  bs=1 seek=$index_id_offset count=8 conv=notrunc
+$MYSQL_BASEDIR/bin/innochecksum -w crc32 --no-check $topdir/backup2/test/t1.ibd
+
+vlog "Prepare with --check-tables should fail"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+  --target-dir=$topdir/backup2 2>&1 | tee $topdir/prepare_corrupt.log
+
+grep -q "Starting table checks" $topdir/prepare_corrupt.log || \
+  die "check-tables did not start"
+grep -q "is corrupted" $topdir/prepare_corrupt.log || \
+  die "Corruption not detected"
+grep -q "Table check failed" $topdir/prepare_corrupt.log || \
+  die "Table check failed message not found"
+
+#
+# Scenario 3: Page checksum corruption (no checksum fix)
+#
+vlog "=== Scenario 3: Page checksum corruption ==="
+
+mysql test <<EOF
+CREATE TABLE t2 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+EOF
+
+for i in $(seq 1 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t2 (b) VALUES (REPEAT('y', 200));"
+done
+
+xtrabackup --backup --target-dir=$topdir/backup3 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup3.log >&2)
+
+vlog "Prepare with --apply-log-only first"
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup3 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/prepare_s3_alog.log >&2)
+
+vlog "Corrupt a data byte in page 4 WITHOUT fixing checksum"
+page_size=16384
+page_no=4
+offset=$((page_size * page_no + 100))
+printf '\xDE' | dd of=$topdir/backup3/test/t2.ibd \
+  bs=1 seek=$offset count=1 conv=notrunc
+
+vlog "Prepare with --check-tables should fail (checksum mismatch)"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+  --target-dir=$topdir/backup3 2>&1 | tee $topdir/prepare_checksum.log
+
+vlog "Scenario 3 passed: xtrabackup exited with non-zero status"
+
+#
+# Scenario 4: All-zero page (simulates unflushed page from redo)
+#
+vlog "=== Scenario 4: All-zero page corruption ==="
+
+mysql test <<EOF
+CREATE TABLE t3 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+EOF
+
+for i in $(seq 1 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t3 (b) VALUES (REPEAT('z', 200));"
+done
+
+xtrabackup --backup --target-dir=$topdir/backup4 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup4.log >&2)
+
+vlog "Prepare with --apply-log-only first"
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup4 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/prepare_s4_alog.log >&2)
+
+vlog "Zero out leaf page 5 to simulate unflushed page"
+page_size=16384
+page_no=5
+dd if=/dev/zero of=$topdir/backup4/test/t3.ibd \
+  bs=$page_size seek=$page_no count=1 conv=notrunc
+
+vlog "Prepare with --check-tables should fail (all-zero page detected)"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+  --target-dir=$topdir/backup4 2>&1 | tee $topdir/prepare_zero.log
+
+grep -q "Starting table checks" $topdir/prepare_zero.log || \
+  die "check-tables did not start"
+grep -q "is corrupted" $topdir/prepare_zero.log || \
+  die "All-zero page corruption not detected at index level"
+grep -q "Table check failed" $topdir/prepare_zero.log || \
+  die "Table check failed message not found for all-zero page"
+
+vlog "Scenario 4 passed: all-zero page corruption detected gracefully"
+
+#
+# Scenario 5: Multiple corrupted tables -- verify ALL are reported
+#
+vlog "=== Scenario 5: Multiple corrupted tables ==="
+
+mysql test <<EOF
+CREATE TABLE t_multi1 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+CREATE TABLE t_multi2 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+CREATE TABLE t_multi3 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+EOF
+
+for i in $(seq 1 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_multi1 (b) VALUES (REPEAT('m', 200));
+     INSERT INTO t_multi2 (b) VALUES (REPEAT('n', 200));
+     INSERT INTO t_multi3 (b) VALUES (REPEAT('o', 200));"
+done
+
+xtrabackup --backup --target-dir=$topdir/backup5 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup5.log >&2)
+
+vlog "Prepare with --apply-log-only first"
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup5 \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/prepare_s5_alog.log >&2)
+
+vlog "Corrupt PAGE_INDEX_ID on all three tables"
+page_size=16384
+page_no=5
+
+for tbl in t_multi1 t_multi2 t_multi3; do
+  index_id_offset=$((page_size * page_no + 66))
+  printf '\xff\xff\xff\xff\xff\xff\xff\xff' | dd of=$topdir/backup5/test/${tbl}.ibd \
+    bs=1 seek=$index_id_offset count=8 conv=notrunc
+  $MYSQL_BASEDIR/bin/innochecksum -w crc32 --no-check $topdir/backup5/test/${tbl}.ibd
+done
+
+vlog "Prepare with --check-tables should fail and report ALL corrupted tables"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+  --target-dir=$topdir/backup5 2>&1 | tee $topdir/prepare_multi.log
+
+grep -q "test/t_multi1" $topdir/prepare_multi.log || \
+  die "Corruption in t_multi1 not reported"
+grep -q "test/t_multi2" $topdir/prepare_multi.log || \
+  die "Corruption in t_multi2 not reported"
+grep -q "test/t_multi3" $topdir/prepare_multi.log || \
+  die "Corruption in t_multi3 not reported"
+
+corrupt_count=$(grep -c "is corrupted" $topdir/prepare_multi.log)
+if [ "$corrupt_count" -lt 3 ]; then
+  die "Expected at least 3 'is corrupted' messages, got $corrupt_count"
+fi
+
+grep -q "Table check failed" $topdir/prepare_multi.log || \
+  die "Table check failed message not found"
+
+vlog "Scenario 5 passed: all corrupted tables reported"
+
+#
+# Scenario 6: Invalid --check-tables combinations
+#
+vlog "=== Scenario 6: Invalid --check-tables combinations ==="
+
+vlog "Test --copy-back --check-tables (should fail)"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --copy-back --check-tables \
+  --target-dir=$topdir/full 2>&1 | tee $topdir/invalid_copyback.log
+grep -q "check-tables is only valid with --prepare" $topdir/invalid_copyback.log || \
+  die "--copy-back --check-tables did not produce expected error"
+
+vlog "Test --backup --check-tables (should fail)"
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup --check-tables \
+  --target-dir=$topdir/backup_invalid 2>&1 | tee $topdir/invalid_backup.log
+grep -q "check-tables is only valid with --prepare" $topdir/invalid_backup.log || \
+  die "--backup --check-tables did not produce expected error"
+
+vlog "Scenario 6 passed: invalid combinations rejected"
+
+#
+# Scenario 7: --prepare --export --check-tables (combined)
+#
+vlog "=== Scenario 7: --prepare --export --check-tables ==="
+
+mysql test <<EOF
+CREATE TABLE t_export (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+EOF
+
+for i in $(seq 1 100); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_export (b) VALUES ('export_${i}');"
+done
+
+xtrabackup --backup --target-dir=$topdir/backup_export \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2> >(tee $topdir/backup_export.log >&2)
+
+vlog "Prepare with --export --check-tables"
+xtrabackup --prepare --export --check-tables \
+           --target-dir=$topdir/backup_export \
+           --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
+           2>&1 | tee $topdir/prepare_export.log
+
+grep -q "export option is specified" $topdir/prepare_export.log || \
+  die "Export did not run"
+grep -q "Starting table checks" $topdir/prepare_export.log || \
+  die "check-tables did not run with --export"
+grep -q "Checking: test/t_export" $topdir/prepare_export.log || \
+  die "Export table not checked"
+grep -q "All table checks passed" $topdir/prepare_export.log || \
+  die "Table checks did not pass with --export"
+
+test -f $topdir/backup_export/test/t_export.cfg || \
+  die ".cfg export file not created"
+
+vlog "Scenario 7 passed: --prepare --export --check-tables works correctly"

--- a/storage/innobase/xtrabackup/test/t/check_tables_debug.sh
+++ b/storage/innobase/xtrabackup/test/t/check_tables_debug.sh
@@ -1,0 +1,125 @@
+############################################################################
+# Test --check-tables corruption detection via DBUG_EXECUTE_IF debug points.
+# Requires a debug build of xtrabackup.
+#
+# Sub-tests:
+#   A) check_table_break_sibling_link  -- broken FIL_PAGE_NEXT/PREV chain
+#   B) check_table_wrong_index_id      -- page belongs to wrong index
+#   C) check_table_set_wrong_min_bit   -- min-record flag on wrong record
+#   D) check_table_inject_corruption   -- catch-all validation failure
+#   E) simulate_lob_corruption         -- LOB corruption detection
+############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+
+start_server --innodb_file_per_table
+
+vlog "Create table with enough rows for a multi-level B-tree"
+mysql test <<EOF
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b VARCHAR(200));
+CREATE TABLE t_lob (a INT PRIMARY KEY AUTO_INCREMENT, b LONGBLOB);
+EOF
+
+for i in $(seq 1 200); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t1 (b) VALUES (REPEAT('x', 200));"
+done
+
+for i in $(seq 1 10); do
+  run_cmd $MYSQL $MYSQL_ARGS test -e \
+    "INSERT INTO t_lob (b) VALUES (REPEAT('B', 100000));"
+done
+
+vlog "Take backup"
+xtrabackup --backup --target-dir=$topdir/backup
+
+#
+# Sub-test A: Broken sibling link
+#
+vlog "=== Sub-test A: check_table_break_sibling_link ==="
+cp -r $topdir/backup $topdir/backup_a
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --debug=d,check_table_break_sibling_link \
+  --target-dir=$topdir/backup_a 2>&1 | tee $topdir/prepare_a.log
+
+grep -q "broken FIL_PAGE_NEXT" $topdir/prepare_a.log || \
+  grep -q "FIL_PAGE_PREV" $topdir/prepare_a.log || \
+  die "Sub-test A: broken sibling link message not found"
+grep -q "is corrupted" $topdir/prepare_a.log || \
+  die "Sub-test A: corruption not detected"
+grep -q "Table check failed" $topdir/prepare_a.log || \
+  die "Sub-test A: Table check failed message not found"
+vlog "Sub-test A passed"
+
+#
+# Sub-test B: Index ID mismatch
+#
+vlog "=== Sub-test B: check_table_wrong_index_id ==="
+cp -r $topdir/backup $topdir/backup_b
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --debug=d,check_table_wrong_index_id \
+  --target-dir=$topdir/backup_b 2>&1 | tee $topdir/prepare_b.log
+
+grep -q "Page index id" $topdir/prepare_b.log || \
+  die "Sub-test B: index ID mismatch message not found"
+grep -q "is corrupted" $topdir/prepare_b.log || \
+  die "Sub-test B: corruption not detected"
+grep -q "Table check failed" $topdir/prepare_b.log || \
+  die "Sub-test B: Table check failed message not found"
+vlog "Sub-test B passed"
+
+#
+# Sub-test C: Min-record flag (existing debug point in page_validate)
+#
+vlog "=== Sub-test C: check_table_set_wrong_min_bit ==="
+cp -r $topdir/backup $topdir/backup_c
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --debug=d,check_table_set_wrong_min_bit \
+  --target-dir=$topdir/backup_c 2>&1 | tee $topdir/prepare_c.log
+
+grep -q "is corrupted" $topdir/prepare_c.log || \
+  die "Sub-test C: corruption not detected"
+grep -q "Table check failed" $topdir/prepare_c.log || \
+  die "Sub-test C: Table check failed message not found"
+vlog "Sub-test C passed"
+
+#
+# Sub-test D: Catch-all injection
+#
+vlog "=== Sub-test D: check_table_inject_corruption ==="
+cp -r $topdir/backup $topdir/backup_d
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --debug=d,check_table_inject_corruption \
+  --target-dir=$topdir/backup_d 2>&1 | tee $topdir/prepare_d.log
+
+grep -q "is corrupted" $topdir/prepare_d.log || \
+  die "Sub-test D: corruption not detected"
+grep -q "Table check failed" $topdir/prepare_d.log || \
+  die "Sub-test D: Table check failed message not found"
+vlog "Sub-test D passed"
+
+#
+# Sub-test E: LOB corruption (duplicate external LOB first page)
+#
+vlog "=== Sub-test E: simulate_lob_corruption ==="
+cp -r $topdir/backup $topdir/backup_e
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
+  --debug=d,simulate_lob_corruption \
+  --target-dir=$topdir/backup_e 2>&1 | tee $topdir/prepare_e.log
+
+grep -q "External LOB first page cannot be shared" $topdir/prepare_e.log || \
+  die "Sub-test E: LOB duplicate message not found"
+grep -q "is corrupted" $topdir/prepare_e.log || \
+  die "Sub-test E: corruption not detected"
+grep -q "Table check failed" $topdir/prepare_e.log || \
+  die "Sub-test E: Table check failed message not found"
+vlog "Sub-test E passed"
+
+vlog "All debug sub-tests passed"


### PR DESCRIPTION
## JIRA
https://perconadev.atlassian.net/browse/PXB-3328

## Problem
After `xtrabackup --prepare` completes redo apply, there is no built-in way to verify that the B-tree indexes are structurally correct. Users must restore and run `CHECK TABLE` on a live server to find corruption. This delays discovery and complicates backup validation workflows.

## Solution
Add `--check-tables` to `xtrabackup --prepare` which validates every committed InnoDB index after recovery. This is a prepare-phase-only option: it is rejected with `--backup`, `--copy-back`, `--move-back`, and other non-prepare modes. It can be combined with `--export` to validate indexes and produce export artifacts in a single prepare invocation. Works with both `--apply-log-only` and final prepare since validation is strictly read-only.

## Implementation

### 1. Tablespace filtering
All ibd tablespaces are validated via a single `fsp_is_ibd_tablespace()` check, covering both file-per-table and general (shared) tablespaces including partitions. System (`ibdata`), undo, and temporary tablespaces are excluded.

### 2. Dictionary loading
For each qualifying tablespace, load `dict_table_t` objects via `dict_load_from_spaces_sdi()`, similar to what `--export` already does.

### 3. Parallel B-tree validation
Spawn `--parallel` worker threads that call `btr_validate_index()` on every committed index. All corruptions are reported (no fail-fast). Per-index and per-table names are printed for each failure.

Index type handling:
- **B-tree** (regular, unique, prefix, functional, multi-valued): full `btr_validate_level()` per level
- **Spatial (R-tree)**: `btr_validate_spatial_index()` with relaxed ordering
- **Full-text (DICT_FTS)**: skipped (FTS uses auxiliary tables, not B-tree)
- **INSTANT ALTER**: handled transparently via `rec_validate()` which understands row versioning
- **Virtual/functional indexes**: validate materialized key values only, no expression evaluation

### 4. Graceful assertion handling
InnoDB's `btr_validate_level()` has 11 `ut_a()` assertions that crash on corrupted pages. Under `#ifdef XTRABACKUP` these are converted to soft errors that log a message and return false. Corrupted sibling links (e.g. all-zero pages with `FIL_PAGE_NEXT=0`) are handled by stopping traversal to prevent infinite loops.

### 5. LOB corruption detection (PS-9683)
Port of Percona Server fix to detect external LOB pages shared between two records. Uses `blob_ref_map` to track LOB first pages. Defensive checks added for corrupted LOB references (missing tablespace, out-of-bounds page number).

### 6. Option validation
`--check-tables` is only valid with `--prepare`. Using it with `--backup`, `--copy-back`, `--move-back`, or other modes produces an error and exits. It can be combined with `--export` (both run sequentially during prepare).

### 7. Test coverage

**`check_tables.sh`** (7 scenarios):
1. Positive multi-combo covering all major table/index types:
   encrypted, compressed, plain, general tablespace (5 tables),
   FTS, INSTANT ALTER (add/drop/re-add column churn), functional index,
   virtual column index, GIS/spatial index, HASH partition (3 parts),
   RANGE partition (3 parts), JSON multi-valued index, foreign key
   parent+child, invisible columns -- with double incremental backup
2. Physical `PAGE_INDEX_ID` corruption
3. Raw page checksum corruption
4. All-zero page corruption (unflushed page from redo)
5. Multiple corrupted tables — verifies all are reported
6. Invalid option combinations (`--copy-back --check-tables`, `--backup --check-tables`) — verifies rejection
7. `--prepare --export --check-tables` combined — verifies both export artifacts and index validation

**`check_tables_debug.sh`** (5 sub-tests):
Broken sibling link, wrong index ID, wrong min-record flag, catch-all injection, LOB duplicate detection