### PR TITLE
PXB-3747: report backup size and uncompressed size

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1594,6 +1594,24 @@ bool backup_start(Backup_context &context) {
   return (true);
 }
 
+/** Report backup_size to the error log.  A successful backup run must
+have produced on-disk output, so the leaf counter must be non-zero;
+a zero value indicates a silent reporting bug: assert in debug, warn
+and skip in release. */
+static void report_backup_size() {
+  const unsigned long long backup_size = get_final_backup_size();
+
+  ut_ad(backup_size > 0);
+  if (backup_size == 0) {
+    xb::warn() << "Backup size reporting failed: leaf counter returned 0";
+    return;
+  }
+
+  xb::info() << "Backup size: "
+             << xtrabackup::utils::human_readable(backup_size) << " ("
+             << backup_size << " bytes)";
+}
+
 /* Finsh the backup. Release all locks. Write down backup metadata.
 @return true if success. */
 bool backup_finish(Backup_context &context) {
@@ -1649,6 +1667,8 @@ bool backup_finish(Backup_context &context) {
   if (!write_xtrabackup_info(mysql_connection)) {
     return (false);
   }
+
+  report_backup_size();
 
   return (true);
 }

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -55,6 +55,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <chrono>
 #include <fstream>
 #include <functional>
+#include <iomanip>
 #include <queue>
 #include <set>
 #include <sstream>
@@ -377,7 +378,8 @@ bool backup_file_print(const char *filename, const char *message, int len) {
   stat.st_mtime = time(nullptr);
   stat.st_size = len;
 
-  dstfile = ds_open(ds_data, filename, &stat);
+  dstfile = ds_open_track_uncomp(ds_data, filename, &stat,
+                                 xb_global_track_uncomp_bytes());
   if (dstfile == NULL) {
     xb::error() << "cannot open the destination stream for " << filename;
     goto error;
@@ -576,7 +578,9 @@ bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
 
   strncpy(dst_name, cursor.rel_path, sizeof(dst_name));
 
-  dstfile = ds_open(datasink, trim_dotslash(dst_file_path), &cursor.statinfo);
+  dstfile =
+      ds_open_track_uncomp(datasink, trim_dotslash(dst_file_path),
+                           &cursor.statinfo, xb_global_track_uncomp_bytes());
   if (dstfile == NULL) {
     xb::error() << "cannot open the destination stream for " << dst_name;
     goto error;
@@ -1594,10 +1598,14 @@ bool backup_start(Backup_context &context) {
   return (true);
 }
 
-/** Report backup_size to the error log.  A successful backup run must
-have produced on-disk output, so the leaf counter must be non-zero;
-a zero value indicates a silent reporting bug: assert in debug, warn
-and skip in release. */
+/** Report backup_size (and, under --compress, uncompressed_backup_size
+and the compression ratio) to the error log.  A successful backup run
+must have produced on-disk output, so the leaf counter must be
+non-zero; under --compress at least one top-level ds_open_track_uncomp()
+must have enabled an uncomp_bytes counter, so xb_uncomp_bytes_counter
+must be non-zero too.  A zero value therefore indicates a silent
+reporting bug: assert in debug, warn and skip in release to avoid
+emitting misleading numbers (e.g. "Compression ratio: inf"). */
 static void report_backup_size() {
   const unsigned long long backup_size = get_final_backup_size();
 
@@ -1610,9 +1618,31 @@ static void report_backup_size() {
   xb::info() << "Backup size: "
              << xtrabackup::utils::human_readable(backup_size) << " ("
              << backup_size << " bytes)";
+
+  if (xtrabackup_compress == XTRABACKUP_COMPRESS_NONE) {
+    return;
+  }
+
+  const unsigned long long uncompressed_backup_size =
+      get_uncompressed_backup_size();
+
+  ut_ad(uncompressed_backup_size > 0);
+  if (uncompressed_backup_size == 0) {
+    xb::warn() << "Uncompressed backup size reporting failed: metrics"
+                  " counter is 0 despite --compress";
+    return;
+  }
+
+  xb::info() << "Uncompressed backup size: "
+             << xtrabackup::utils::human_readable(uncompressed_backup_size)
+             << " (" << uncompressed_backup_size << " bytes)";
+
+  const double ratio = (double)uncompressed_backup_size / (double)backup_size;
+  xb::info() << "Compression ratio: " << std::fixed << std::setprecision(2)
+             << ratio << "x";
 }
 
-/* Finsh the backup. Release all locks. Write down backup metadata.
+/* Finish the backup. Release all locks. Write down backup metadata.
 @return true if success. */
 bool backup_finish(Backup_context &context) {
   /* release all locks */

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1849,6 +1849,11 @@ char *get_xtrabackup_info(MYSQL *connection) {
   format_time(history_start_time, buf_start_time, time_buf_size);
   format_time(history_end_time, buf_end_time, time_buf_size);
 
+  /* Sampled here, after all data has drained to the leaf (see the
+  reordering in xtrabackup_backup_func()).  Embedded directly into
+  xtrabackup_info so consumers see the final on-disk byte count. */
+  const unsigned long long backup_size = get_final_backup_size();
+
   ut_a(uuid);
   ut_a(server_version);
   char *result = NULL;
@@ -1875,7 +1880,8 @@ char *get_xtrabackup_info(MYSQL *connection) {
                "format = %s\n"
                "compressed = %s\n"
                "encrypted = %s\n"
-               "lock_ddl_type = %s\n",
+               "lock_ddl_type = %s\n"
+               "backup_size = %llu\n",
                uuid,                                 /* uuid */
                opt_history ? opt_history : "",       /* name */
                tool_name,                            /* tool_name */
@@ -1901,7 +1907,8 @@ char *get_xtrabackup_info(MYSQL *connection) {
                xtrabackup_compress ? "compressed" : "N",     /* compressed */
                xtrabackup_encrypt ? "Y" : "N",               /* encrypted */
                ddl_lock_type_to_str(static_cast<lock_ddl_type_t>(opt_lock_ddl))
-                   .c_str()); /* lock-ddl */
+                   .c_str(), /* lock-ddl */
+               backup_size); /* backup_size */
 
   ut_a(ret != 0);
 

--- a/storage/innobase/xtrabackup/src/backup_mysql.cc
+++ b/storage/innobase/xtrabackup/src/backup_mysql.cc
@@ -1912,6 +1912,26 @@ char *get_xtrabackup_info(MYSQL *connection) {
 
   ut_a(ret != 0);
 
+  /* uncompressed_backup_size is only meaningful under --compress: it
+  reports the raw, pre-compression logical volume that fed the main
+  backup pipeline.  Without --compress, logical == physical, and the
+  backup_size line above already captures it. */
+  if (xtrabackup_compress != XTRABACKUP_COMPRESS_NONE) {
+    const unsigned long long uncompressed_backup_size =
+        get_uncompressed_backup_size();
+
+    char *tmp = NULL;
+    int ret2 = asprintf(&tmp, "%suncompressed_backup_size = %llu\n", result,
+                        uncompressed_backup_size);
+    if (ret2 < 0) {
+      xb::warn() << "Failed to append uncompressed_backup_size to"
+                 << " xtrabackup_info: " << strerror(errno);
+    } else {
+      free(result);
+      result = tmp;
+    }
+  }
+
   free(server_version);
   return result;
 }

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -111,6 +111,10 @@ ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat) {
   file = ctxt->datasink->open(ctxt, path, stat);
   if (file != NULL) {
     file->datasink = ctxt->datasink;
+    /* Save the ctxt this file is attached to so per-datasink state
+    (e.g. leaf bytes_written counters) can be reached from the write
+    paths via file->ctxt->ptr. */
+    file->ctxt = ctxt;
   }
 
   return file;
@@ -160,4 +164,30 @@ Set the destination pipe for a datasink (only makes sense for compress and
 tmpfile). */
 void ds_set_pipe(ds_ctxt_t *ctxt, ds_ctxt_t *pipe_ctxt) {
   ctxt->pipe_ctxt = pipe_ctxt;
+}
+
+const ds_ctxt_t *ds_leaf(const ds_ctxt_t *head) {
+  const ds_ctxt_t *c = head;
+  if (c == nullptr) return nullptr;
+  while (c->pipe_ctxt != nullptr) {
+    c = c->pipe_ctxt;
+  }
+  return c;
+}
+
+bool ds_find_metric(const ds_ctxt_t *node, std::string_view name,
+                    uint64_t *out) {
+  if (node == nullptr || node->datasink == nullptr ||
+      node->datasink->report_metrics == nullptr) {
+    return false;
+  }
+  std::vector<ds_metric> v;
+  node->datasink->report_metrics(node, v);
+  for (const auto &m : v) {
+    if (m.name == name) {
+      if (out != nullptr) *out = m.value;
+      return true;
+    }
+  }
+  return false;
 }

--- a/storage/innobase/xtrabackup/src/datasink.cc
+++ b/storage/innobase/xtrabackup/src/datasink.cc
@@ -113,10 +113,26 @@ ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat) {
     file->datasink = ctxt->datasink;
     /* Save the ctxt this file is attached to so per-datasink state
     (e.g. leaf bytes_written counters) can be reached from the write
-    paths via file->ctxt->ptr. */
+    paths via file->ctxt->ptr.  Tracking defaults to off; callers that
+    want uncompressed-byte accounting call ds_track_uncomp() or use
+    the ds_open_track_uncomp() convenience. */
     file->ctxt = ctxt;
+    file->uncomp_bytes = nullptr;
   }
 
+  return file;
+}
+
+void ds_track_uncomp(ds_file_t *file, xb_uncomp_bytes *uncomp_bytes) {
+  if (file != nullptr) {
+    file->uncomp_bytes = uncomp_bytes;
+  }
+}
+
+ds_file_t *ds_open_track_uncomp(ds_ctxt_t *ctxt, const char *path,
+                                MY_STAT *stat, xb_uncomp_bytes *uncomp_bytes) {
+  ds_file_t *file = ds_open(ctxt, path, stat);
+  ds_track_uncomp(file, uncomp_bytes);
   return file;
 }
 
@@ -124,7 +140,15 @@ ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat) {
 Write to a datasink file.
 @return 0 on success, 1 on error. */
 int ds_write(ds_file_t *file, const void *buf, size_t len) {
-  return file->datasink->write(file, buf, len);
+  const int rc = file->datasink->write(file, buf, len);
+  /* Bump the backup-run uncompressed byte counter with the logical
+  byte count only on success.  Wrapper-internal opens do not set
+  file->uncomp_bytes, so every logical byte is counted exactly once
+  at the top. */
+  if (rc == 0 && file->uncomp_bytes != nullptr) {
+    file->uncomp_bytes->add_uncompressed(len);
+  }
+  return rc;
 }
 
 /************************************************************************
@@ -143,11 +167,18 @@ Write sparse chunk if supported.
 int ds_write_sparse(ds_file_t *file, const void *buf, size_t len,
                     size_t sparse_map_size, const ds_sparse_chunk_t *sparse_map,
                     bool punch_hole_supported) {
-  if (file->datasink->write_sparse != nullptr) {
-    return file->datasink->write_sparse(file, buf, len, sparse_map_size,
-                                        sparse_map, punch_hole_supported);
+  if (file->datasink->write_sparse == nullptr) {
+    return 1;
   }
-  return 1;
+  const int rc = file->datasink->write_sparse(file, buf, len, sparse_map_size,
+                                              sparse_map, punch_hole_supported);
+  if (rc == 0 && file->uncomp_bytes != nullptr) {
+    /* `len` is the packed (hole-excluded) payload size: callers pre-pack
+    the buffer and pass its length here, and local_write_sparse writes
+    exactly that many bytes across the sparse_map chunks. */
+    file->uncomp_bytes->add_uncompressed(len);
+  }
+  return rc;
 }
 
 /************************************************************************

--- a/storage/innobase/xtrabackup/src/datasink.h
+++ b/storage/innobase/xtrabackup/src/datasink.h
@@ -21,7 +21,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #ifndef XB_DATASINK_H
 #define XB_DATASINK_H
 
+#include <my_compiler.h>
 #include <my_dir.h>
+#include <atomic>
 #include <cstdint>
 #include <string_view>
 #include <vector>
@@ -32,6 +34,39 @@ extern "C" {
 
 struct datasink_struct;
 typedef struct datasink_struct datasink_t;
+
+/* ---------------------------------------------------------------------
+   Backup-run uncompressed byte counter.
+
+   A single global instance (defined in xtrabackup.cc) receives the raw
+   byte count of every top-level ds_write / ds_write_sparse that has
+   tracking enabled.  Its definition lives here rather than in
+   xtrabackup.h so datasink.cc can inline add_uncompressed() without
+   pulling in the full xtrabackup include cone, which keeps standalone
+   tools (xbcrypt, xbstream) cheap to link.
+
+   Kept lexically distinct from the tier-1 ds_metric / report_metrics /
+   ds_find_metric system: that one describes per-datasink observations,
+   this one is a single backup-run aggregate.  No shared names.
+   --------------------------------------------------------------------- */
+
+struct xb_uncomp_bytes {
+  /** Record the raw byte count of one top-level ds_write /
+  ds_write_sparse.  Called by the datasink framework when the
+  issuing ds_file_t has tracking enabled. */
+  ALWAYS_INLINE void add_uncompressed(uint64_t n) {
+    uncompressed_bytes_.fetch_add(n, std::memory_order_relaxed);
+  }
+
+  /** @return total raw (pre-compression, hole-excluded) bytes
+  accumulated across all top-level tracked opens this run. */
+  ALWAYS_INLINE uint64_t get_uncompressed_backup_size() const {
+    return uncompressed_bytes_.load(std::memory_order_relaxed);
+  }
+
+ private:
+  std::atomic<uint64_t> uncompressed_bytes_{0};
+};
 
 typedef struct ds_ctxt {
   datasink_t *datasink = nullptr;
@@ -49,6 +84,11 @@ typedef struct {
   ds_open() so that leaves and other per-datasink counters can reach
   their private state via file->ctxt->ptr. */
   ds_ctxt_t *ctxt = nullptr;
+  /* Optional pointer to a backup-run uncompressed-byte counter that
+  should receive the raw byte count of every ds_write/ds_write_sparse
+  on this file.  NULL disables tracking.  Set by ds_track_uncomp() or
+  by the ds_open_track_uncomp() convenience. */
+  xb_uncomp_bytes *uncomp_bytes = nullptr;
 } ds_file_t;
 
 typedef struct {
@@ -119,8 +159,33 @@ Create a datasink of the specified type */
 ds_ctxt_t *ds_create(const char *root, ds_type_t type);
 
 /************************************************************************
-Open a datasink file. */
+Open a datasink file.  The returned file has uncompressed-byte tracking
+disabled (file->uncomp_bytes == NULL); callers that want per-byte
+accounting into a backup-run counter use ds_open_track_uncomp() or
+ds_track_uncomp(). */
 ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat);
+
+/** Enable uncompressed-byte tracking on an already-opened ds_file_t.
+After this call, every ds_write / ds_write_sparse on @p file adds its
+raw byte count to *@p uncomp_bytes.  Safe to call with file == nullptr
+(no-op).
+@param[in,out] file         file to bind; nullptr makes the call a no-op
+@param[in]     uncomp_bytes backup-run counter to receive the counts;
+                            nullptr leaves tracking disabled. */
+void ds_track_uncomp(ds_file_t *file, xb_uncomp_bytes *uncomp_bytes);
+
+/** Convenience: ds_open() followed by ds_track_uncomp().  Use at
+top-level backup opens (ds_data / ds_redo / ds_meta /
+ds_uncompressed_data).  Pipeline-internal opens inside wrappers keep
+using plain ds_open() so every logical byte is counted exactly once at
+the top.
+@param[in]     ctxt         pipeline to open through
+@param[in]     path         path relative to the pipeline root
+@param[in]     stat         size/mode hints for downstream datasinks
+@param[in,out] uncomp_bytes backup-run counter; nullptr to skip tracking
+@return newly opened file, or nullptr on error. */
+ds_file_t *ds_open_track_uncomp(ds_ctxt_t *ctxt, const char *path,
+                                MY_STAT *stat, xb_uncomp_bytes *uncomp_bytes);
 
 /************************************************************************
 Write to a datasink file.

--- a/storage/innobase/xtrabackup/src/datasink.h
+++ b/storage/innobase/xtrabackup/src/datasink.h
@@ -22,6 +22,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define XB_DATASINK_H
 
 #include <my_dir.h>
+#include <cstdint>
+#include <string_view>
+#include <vector>
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,23 +34,49 @@ struct datasink_struct;
 typedef struct datasink_struct datasink_t;
 
 typedef struct ds_ctxt {
-  datasink_t *datasink;
-  char *root;
-  void *ptr;
-  struct ds_ctxt *pipe_ctxt;
+  datasink_t *datasink = nullptr;
+  char *root = nullptr;
+  void *ptr = nullptr;
+  struct ds_ctxt *pipe_ctxt = nullptr;
   bool fs_support_punch_hole = false;
 } ds_ctxt_t;
 
 typedef struct {
-  void *ptr;
-  char *path;
-  datasink_t *datasink;
+  void *ptr = nullptr;
+  char *path = nullptr;
+  datasink_t *datasink = nullptr;
+  /* The datasink context this file was opened through.  Set by
+  ds_open() so that leaves and other per-datasink counters can reach
+  their private state via file->ctxt->ptr. */
+  ds_ctxt_t *ctxt = nullptr;
 } ds_file_t;
 
 typedef struct {
   size_t skip;
   size_t len;
 } ds_sparse_chunk_t;
+
+/* ---------------------------------------------------------------------
+   Tier-1 metrics: per-datasink observations.
+
+   Each datasink may publish zero or more named uint64 values about
+   itself via the report_metrics vtable slot.  The slot is optional
+   (may be null) -- a datasink that has nothing to say leaves it null.
+
+   A datasink's report_metrics output is a private namespace: names
+   within one datasink must be unique.  The same name MAY appear in a
+   different datasink's output and denotes a different metric there;
+   queries are therefore always scoped to a specific node (see
+   ds_find_metric() below) rather than flattened across a pipeline.
+   --------------------------------------------------------------------- */
+
+/** A single datum published by a datasink's report_metrics.  The name
+is a non-owning view (typically a string literal in the producer); the
+value is a snapshot at read time. */
+struct ds_metric {
+  std::string_view name;
+  uint64_t value;
+};
 
 struct datasink_struct {
   ds_ctxt_t *(*init)(const char *root);
@@ -59,6 +88,12 @@ struct datasink_struct {
                       bool punch_hole_supported);
   int (*close)(ds_file_t *file);
   void (*deinit)(ds_ctxt_t *ctxt);
+  /* Optional: append zero or more {name, value} entries describing
+  this datasink's internal state.  NULL means "no metrics".  Only the
+  three leaf datasinks populate this today (to publish
+  "bytes_written"); wrappers leave it null and future wrappers can
+  opt in by implementing it without any framework change. */
+  void (*report_metrics)(const ds_ctxt_t *ctxt, std::vector<ds_metric> &out);
 };
 
 /* Supported datasink types */
@@ -84,7 +119,7 @@ Create a datasink of the specified type */
 ds_ctxt_t *ds_create(const char *root, ds_type_t type);
 
 /************************************************************************
-Open a datasink file */
+Open a datasink file. */
 ds_file_t *ds_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *stat);
 
 /************************************************************************
@@ -117,6 +152,29 @@ void ds_destroy(ds_ctxt_t *ctxt);
 Set the destination pipe for a datasink (only makes sense for compress and
 tmpfile). */
 void ds_set_pipe(ds_ctxt_t *ctxt, ds_ctxt_t *pipe_ctxt);
+
+/** Walk the pipe_ctxt chain of @p head to its terminal node.
+@param[in] head  any node in a datasink pipeline
+@return the leaf ctxt (same as @p head if head has no pipe). */
+const ds_ctxt_t *ds_leaf(const ds_ctxt_t *head);
+
+/** Look up one named metric on a single datasink node.
+
+Invokes @p node->datasink->report_metrics (if any) and returns the
+first entry whose name equals @p name.  The lookup is scoped to a
+single node: pass ds_leaf(head) (or any other specific ctxt) to
+disambiguate when multiple datasinks in a pipeline publish metrics.
+
+Safe to call when the node is quiesced (e.g. from backup_finish).
+Returns false (and leaves *out untouched) if @p node is null, the
+datasink does not implement report_metrics, or the name is not
+published.
+@param[in]  node  a specific datasink ctxt (not a pipeline head)
+@param[in]  name  metric name to look up
+@param[out] out   receives the metric value on a hit; may be null
+@return true on hit, false otherwise. */
+bool ds_find_metric(const ds_ctxt_t *node, std::string_view name,
+                    uint64_t *out);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/storage/innobase/xtrabackup/src/ds_buffer.cc
+++ b/storage/innobase/xtrabackup/src/ds_buffer.cc
@@ -52,7 +52,8 @@ static int buffer_close(ds_file_t *file);
 static void buffer_deinit(ds_ctxt_t *ctxt);
 
 datasink_t datasink_buffer = {&buffer_init, &buffer_open,  &buffer_write,
-                              nullptr,      &buffer_close, &buffer_deinit};
+                              nullptr,      &buffer_close, &buffer_deinit,
+                              nullptr /* report_metrics */};
 
 /* Change the default buffer size */
 void ds_buffer_set_size(ds_ctxt_t *ctxt, size_t size) {
@@ -65,9 +66,9 @@ static ds_ctxt_t *buffer_init(const char *root) {
   ds_ctxt_t *ctxt;
   ds_buffer_ctxt_t *buffer_ctxt;
 
-  ctxt = static_cast<ds_ctxt *>(
-      my_malloc(PSI_NOT_INSTRUMENTED,
-                sizeof(ds_ctxt_t) + sizeof(ds_buffer_ctxt_t), MYF(MY_FAE)));
+  ctxt = static_cast<ds_ctxt *>(my_malloc(
+      PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t) + sizeof(ds_buffer_ctxt_t),
+      MYF(MY_FAE | MY_ZEROFILL)));
   buffer_ctxt = (ds_buffer_ctxt_t *)(ctxt + 1);
   buffer_ctxt->buffer_size = DS_DEFAULT_BUFFER_SIZE;
 

--- a/storage/innobase/xtrabackup/src/ds_compress.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress.cc
@@ -69,9 +69,9 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len);
 static int compress_close(ds_file_t *file);
 static void compress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_compress = {&compress_init,  &compress_open,
-                                &compress_write, nullptr,
-                                &compress_close, &compress_deinit};
+datasink_t datasink_compress = {
+    &compress_init,  &compress_open,   &compress_write, nullptr,
+    &compress_close, &compress_deinit, nullptr /* report_metrics */};
 
 static inline int write_uint32_le(ds_file_t *file, uint32_t n);
 static inline int write_uint64_le(ds_file_t *file, ulonglong n);

--- a/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
@@ -69,9 +69,9 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len);
 static int compress_close(ds_file_t *file);
 static void compress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_compress_lz4 = {&compress_init,  &compress_open,
-                                    &compress_write, nullptr,
-                                    &compress_close, &compress_deinit};
+datasink_t datasink_compress_lz4 = {
+    &compress_init,  &compress_open,   &compress_write, nullptr,
+    &compress_close, &compress_deinit, nullptr /* report_metrics */};
 
 static inline int write_uint32_le(ds_file_t *file, uint32_t n);
 

--- a/storage/innobase/xtrabackup/src/ds_compress_zstd.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_zstd.cc
@@ -52,9 +52,9 @@ static int compress_write(ds_file_t *file, const void *buf, size_t len);
 static int compress_close(ds_file_t *file);
 static void compress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_compress_zstd = {&compress_init,  &compress_open,
-                                     &compress_write, nullptr,
-                                     &compress_close, &compress_deinit};
+datasink_t datasink_compress_zstd = {
+    &compress_init,  &compress_open,   &compress_write, nullptr,
+    &compress_close, &compress_deinit, nullptr /* report_metrics */};
 
 static ds_ctxt_t *compress_init(const char *root) {
   ds_compress_ctxt_t *compress_ctxt = new ds_compress_ctxt_t;

--- a/storage/innobase/xtrabackup/src/ds_decompress.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress.cc
@@ -84,9 +84,10 @@ static int decompress_write(ds_file_t *file, const void *buf, size_t len);
 static int decompress_close(ds_file_t *file);
 static void decompress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decompress = {&decompress_init,  &decompress_open,
-                                  &decompress_write, nullptr,
-                                  &decompress_close, &decompress_deinit};
+datasink_t datasink_decompress = {
+    &decompress_init, &decompress_open,  &decompress_write,
+    nullptr,          &decompress_close, &decompress_deinit,
+    nullptr /* report_metrics */};
 
 static int decompress_process_metadata(ds_decompress_file_t *file,
                                        const char **ptr, size_t *len);

--- a/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress_lz4.cc
@@ -290,9 +290,10 @@ static int decompress_write(ds_file_t *file, const void *buf, size_t len);
 static int decompress_close(ds_file_t *file);
 static void decompress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decompress_lz4 = {&decompress_init,  &decompress_open,
-                                      &decompress_write, nullptr,
-                                      &decompress_close, &decompress_deinit};
+datasink_t datasink_decompress_lz4 = {
+    &decompress_init, &decompress_open,  &decompress_write,
+    nullptr,          &decompress_close, &decompress_deinit,
+    nullptr /* report_metrics */};
 
 static ds_ctxt_t *decompress_init(const char *root) {
   ds_decompress_lz4_ctxt_t *decompress_ctxt = new ds_decompress_lz4_ctxt_t;

--- a/storage/innobase/xtrabackup/src/ds_decompress_zstd.cc
+++ b/storage/innobase/xtrabackup/src/ds_decompress_zstd.cc
@@ -87,9 +87,10 @@ static int decompress_write(ds_file_t *file, const void *buf, size_t len);
 static int decompress_close(ds_file_t *file);
 static void decompress_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_decompress_zstd = {&decompress_init,  &decompress_open,
-                                       &decompress_write, nullptr,
-                                       &decompress_close, &decompress_deinit};
+datasink_t datasink_decompress_zstd = {
+    &decompress_init, &decompress_open,  &decompress_write,
+    nullptr,          &decompress_close, &decompress_deinit,
+    nullptr /* report_metrics */};
 
 static ds_ctxt_t *decompress_init(const char *root) {
   ds_ctxt_t *ctxt = new ds_ctxt_t;

--- a/storage/innobase/xtrabackup/src/ds_decrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_decrypt.cc
@@ -122,7 +122,8 @@ static int decrypt_close(ds_file_t *file);
 static void decrypt_deinit(ds_ctxt_t *ctxt);
 
 datasink_t datasink_decrypt = {&decrypt_init, &decrypt_open,  &decrypt_write,
-                               nullptr,       &decrypt_close, &decrypt_deinit};
+                               nullptr,       &decrypt_close, &decrypt_deinit,
+                               nullptr /* report_metrics */};
 
 static ds_ctxt_t *decrypt_init(const char *root) {
   if (xb_crypt_init(NULL)) {

--- a/storage/innobase/xtrabackup/src/ds_encrypt.cc
+++ b/storage/innobase/xtrabackup/src/ds_encrypt.cc
@@ -95,7 +95,8 @@ static int encrypt_close(ds_file_t *file);
 static void encrypt_deinit(ds_ctxt_t *ctxt);
 
 datasink_t datasink_encrypt = {&encrypt_init, &encrypt_open,  &encrypt_write,
-                               nullptr,       &encrypt_close, &encrypt_deinit};
+                               nullptr,       &encrypt_close, &encrypt_deinit,
+                               nullptr /* report_metrics */};
 
 static uint encrypt_iv_len = 0;
 

--- a/storage/innobase/xtrabackup/src/ds_fifo.cc
+++ b/storage/innobase/xtrabackup/src/ds_fifo.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_thread_local.h>
 #include <mysql/service_mysql_alloc.h>
 #include <mysys_err.h>
+#include <atomic>
 #include <mutex>
 #include <unordered_map>
 #include "common.h"
@@ -35,6 +36,10 @@ struct ds_fifo_ctxt_t {
   std::unordered_map<std::string, File> FIFO_list;
   /* Mutex protecting FIFO list */
   std::mutex fifo_mutex;
+  /* Tier-1 metric: total bytes written across all FIFO streams under
+  this ctxt.  Published via fifo_report_metrics(); backup_size uses
+  this to report the on-disk volume for FIFO-streamed backups. */
+  std::atomic<unsigned long long> bytes_written{0};
 
   /* Add a new pair of fullpath and fd to FIFO_list */
   void populate_list(std::string fullpath, File fd) {
@@ -82,9 +87,12 @@ static ds_file_t *fifo_open(ds_ctxt_t *ctxt, const char *path, MY_STAT *mystat);
 static int fifo_write(ds_file_t *file, const void *buf, size_t len);
 static int fifo_close(ds_file_t *file);
 static void fifo_deinit(ds_ctxt_t *ctxt);
+static void fifo_report_metrics(const ds_ctxt_t *ctxt,
+                                std::vector<ds_metric> &out);
 
-datasink_t datasink_fifo = {&fifo_init, &fifo_open,  &fifo_write,
-                            nullptr,    &fifo_close, &fifo_deinit};
+datasink_t datasink_fifo = {
+    &fifo_init,  &fifo_open,   &fifo_write,         nullptr,
+    &fifo_close, &fifo_deinit, &fifo_report_metrics};
 
 static void cleanup_on_error(const char *root, ds_fifo_ctxt_t *ctxt) {
   std::string path;
@@ -185,10 +193,19 @@ static int fifo_write(ds_file_t *file, const void *buf, size_t len) {
   if (!my_write(fd, static_cast<const uchar *>(buf), len,
                 MYF(MY_WME | MY_NABP))) {
     posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    auto fifo_context = static_cast<ds_fifo_ctxt_t *>(file->ctxt->ptr);
+    fifo_context->bytes_written.fetch_add(len, std::memory_order_relaxed);
     return 0;
   }
 
   return 1;
+}
+
+static void fifo_report_metrics(const ds_ctxt_t *ctxt,
+                                std::vector<ds_metric> &out) {
+  const auto *c = static_cast<const ds_fifo_ctxt_t *>(ctxt->ptr);
+  out.push_back(
+      {"bytes_written", c->bytes_written.load(std::memory_order_relaxed)});
 }
 
 static int fifo_close(ds_file_t *file) {

--- a/storage/innobase/xtrabackup/src/ds_local.cc
+++ b/storage/innobase/xtrabackup/src/ds_local.cc
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <mysql/service_mysql_alloc.h>
 #include <mysql_version.h>
 #include <mysys_err.h>
+#include <atomic>
 
 #ifdef HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE
 #include <linux/falloc.h>
@@ -40,6 +41,13 @@ typedef struct {
   size_t last_seek;  // to track last page sparse_file
 } ds_local_file_t;
 
+/* Per-datasink private state.  Stored in ds_ctxt_t::ptr.  bytes_written
+is the tier-1 metric exposed through local_report_metrics() and is the
+authoritative source for backup_size (final on-disk volume). */
+struct ds_local_ctxt_t {
+  std::atomic<unsigned long long> bytes_written{0};
+};
+
 static ds_ctxt_t *local_init(const char *root);
 static ds_file_t *local_open(ds_ctxt_t *ctxt, const char *path,
                              MY_STAT *mystat);
@@ -50,9 +58,12 @@ static int local_write_sparse(ds_file_t *file, const void *buf, size_t len,
                               bool punch_hole_supported);
 static int local_close(ds_file_t *file);
 static void local_deinit(ds_ctxt_t *ctxt);
+static void local_report_metrics(const ds_ctxt_t *ctxt,
+                                 std::vector<ds_metric> &out);
 
-datasink_t datasink_local = {&local_init,         &local_open,  &local_write,
-                             &local_write_sparse, &local_close, &local_deinit};
+datasink_t datasink_local = {&local_init,          &local_open,  &local_write,
+                             &local_write_sparse,  &local_close, &local_deinit,
+                             &local_report_metrics};
 
 /**
   Checks if punch hole via fallocate is supported
@@ -94,9 +105,10 @@ static ds_ctxt_t *local_init(const char *root) {
     return NULL;
   }
 
-  ctxt = static_cast<ds_ctxt_t *>(
-      my_malloc(PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t), MYF(MY_FAE)));
+  ctxt = static_cast<ds_ctxt_t *>(my_malloc(
+      PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t), MYF(MY_FAE | MY_ZEROFILL)));
 
+  ctxt->ptr = new ds_local_ctxt_t{};
   ctxt->root = my_strdup(PSI_NOT_INSTRUMENTED, root, MYF(MY_FAE));
 
   is_fallocate_punch_hole_supported(ctxt);
@@ -156,6 +168,8 @@ static int local_write(ds_file_t *file, const void *buf, size_t len) {
   if (!my_write(fd, static_cast<const uchar *>(buf), len,
                 MYF(MY_WME | MY_NABP))) {
     posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    auto local_ctxt = static_cast<ds_local_ctxt_t *>(file->ctxt->ptr);
+    local_ctxt->bytes_written.fetch_add(len, std::memory_order_relaxed);
     return 0;
   }
 
@@ -184,6 +198,12 @@ static int local_write_sparse(ds_file_t *file, const void *buf, size_t len,
     rc = my_write(fd, ptr, sparse_map[i].len, MYF(MY_WME | MY_NABP));
     if (rc != 0) {
       return 1;
+    }
+
+    {
+      auto local_ctxt = static_cast<ds_local_ctxt_t *>(file->ctxt->ptr);
+      local_ctxt->bytes_written.fetch_add(sparse_map[i].len,
+                                          std::memory_order_relaxed);
     }
 
 #ifdef HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE
@@ -221,6 +241,9 @@ static int local_close(ds_file_t *file) {
     if (rc != 0) {
       return 1;
     }
+    /* Account for the 1-byte trailing-hole write above in bytes_written. */
+    auto local_ctxt = static_cast<ds_local_ctxt_t *>(file->ctxt->ptr);
+    local_ctxt->bytes_written.fetch_add(1, std::memory_order_relaxed);
   }
 
   my_free(file);
@@ -231,6 +254,14 @@ static int local_close(ds_file_t *file) {
 }
 
 static void local_deinit(ds_ctxt_t *ctxt) {
+  delete static_cast<ds_local_ctxt_t *>(ctxt->ptr);
   my_free(ctxt->root);
   my_free(ctxt);
+}
+
+static void local_report_metrics(const ds_ctxt_t *ctxt,
+                                 std::vector<ds_metric> &out) {
+  const auto *c = static_cast<const ds_local_ctxt_t *>(ctxt->ptr);
+  out.push_back(
+      {"bytes_written", c->bytes_written.load(std::memory_order_relaxed)});
 }

--- a/storage/innobase/xtrabackup/src/ds_stdout.cc
+++ b/storage/innobase/xtrabackup/src/ds_stdout.cc
@@ -21,6 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include <my_base.h>
 #include <mysql/service_mysql_alloc.h>
 #include <mysys_err.h>
+#include <atomic>
 #include "common.h"
 #include "datasink.h"
 
@@ -28,28 +29,39 @@ typedef struct {
   File fd;
 } ds_stdout_file_t;
 
+/* Per-datasink private state.  Used to carry the bytes_written tier-1
+metric so xbstream-over-stdout backups can report backup_size the same
+way ds_local does. */
+struct ds_stdout_ctxt_t {
+  std::atomic<unsigned long long> bytes_written{0};
+};
+
 static ds_ctxt_t *stdout_init(const char *root);
 static ds_file_t *stdout_open(ds_ctxt_t *ctxt, const char *path,
                               MY_STAT *mystat);
 static int stdout_write(ds_file_t *file, const void *buf, size_t len);
 static int stdout_close(ds_file_t *file);
 static void stdout_deinit(ds_ctxt_t *ctxt);
+static void stdout_report_metrics(const ds_ctxt_t *ctxt,
+                                  std::vector<ds_metric> &out);
 
-datasink_t datasink_stdout = {&stdout_init, &stdout_open,  &stdout_write,
-                              nullptr,      &stdout_close, &stdout_deinit};
+datasink_t datasink_stdout = {
+    &stdout_init,  &stdout_open,   &stdout_write,         nullptr,
+    &stdout_close, &stdout_deinit, &stdout_report_metrics};
 
 static ds_ctxt_t *stdout_init(const char *root) {
   ds_ctxt_t *ctxt;
 
-  ctxt = static_cast<ds_ctxt_t *>(
-      my_malloc(PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t), MYF(MY_FAE)));
+  ctxt = static_cast<ds_ctxt_t *>(my_malloc(
+      PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t), MYF(MY_FAE | MY_ZEROFILL)));
 
+  ctxt->ptr = new ds_stdout_ctxt_t{};
   ctxt->root = my_strdup(PSI_NOT_INSTRUMENTED, root, MYF(MY_FAE));
 
   return ctxt;
 }
 
-static ds_file_t *stdout_open(ds_ctxt_t *ctxt __attribute__((unused)),
+static ds_file_t *stdout_open(ds_ctxt_t *ctxt [[maybe_unused]],
                               const char *path __attribute__((unused)),
                               MY_STAT *mystat __attribute__((unused))) {
   ds_stdout_file_t *stdout_file;
@@ -84,6 +96,8 @@ static int stdout_write(ds_file_t *file, const void *buf, size_t len) {
   if (!my_write(fd, static_cast<const uchar *>(buf), len,
                 MYF(MY_WME | MY_NABP))) {
     posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    auto stdout_ctxt = static_cast<ds_stdout_ctxt_t *>(file->ctxt->ptr);
+    stdout_ctxt->bytes_written.fetch_add(len, std::memory_order_relaxed);
     return 0;
   }
 
@@ -97,6 +111,14 @@ static int stdout_close(ds_file_t *file) {
 }
 
 static void stdout_deinit(ds_ctxt_t *ctxt) {
+  delete static_cast<ds_stdout_ctxt_t *>(ctxt->ptr);
   my_free(ctxt->root);
   my_free(ctxt);
+}
+
+static void stdout_report_metrics(const ds_ctxt_t *ctxt,
+                                  std::vector<ds_metric> &out) {
+  const auto *c = static_cast<const ds_stdout_ctxt_t *>(ctxt->ptr);
+  out.push_back(
+      {"bytes_written", c->bytes_written.load(std::memory_order_relaxed)});
 }

--- a/storage/innobase/xtrabackup/src/ds_tmpfile.cc
+++ b/storage/innobase/xtrabackup/src/ds_tmpfile.cc
@@ -53,7 +53,8 @@ static int tmpfile_close(ds_file_t *file);
 static void tmpfile_deinit(ds_ctxt_t *ctxt);
 
 datasink_t datasink_tmpfile = {&tmpfile_init, &tmpfile_open,  &tmpfile_write,
-                               nullptr,       &tmpfile_close, &tmpfile_deinit};
+                               nullptr,       &tmpfile_close, &tmpfile_deinit,
+                               nullptr /* report_metrics */};
 
 extern MY_TMPDIR mysql_tmpdir_list;
 
@@ -61,9 +62,9 @@ static ds_ctxt_t *tmpfile_init(const char *root) {
   ds_ctxt_t *ctxt;
   ds_tmpfile_ctxt_t *tmpfile_ctxt;
 
-  ctxt = static_cast<ds_ctxt_t *>(
-      my_malloc(PSI_NOT_INSTRUMENTED,
-                sizeof(ds_ctxt_t) + sizeof(ds_tmpfile_ctxt_t), MYF(MY_FAE)));
+  ctxt = static_cast<ds_ctxt_t *>(my_malloc(
+      PSI_NOT_INSTRUMENTED, sizeof(ds_ctxt_t) + sizeof(ds_tmpfile_ctxt_t),
+      MYF(MY_FAE | MY_ZEROFILL)));
   tmpfile_ctxt = (ds_tmpfile_ctxt_t *)(ctxt + 1);
   tmpfile_ctxt->file_list = NULL;
   ctxt->ptr = tmpfile_ctxt;

--- a/storage/innobase/xtrabackup/src/ds_xbstream.cc
+++ b/storage/innobase/xtrabackup/src/ds_xbstream.cc
@@ -60,9 +60,9 @@ static int xbstream_write_sparse(ds_file_t *file, const void *buf, size_t len,
 static int xbstream_close(ds_file_t *file);
 static void xbstream_deinit(ds_ctxt_t *ctxt);
 
-datasink_t datasink_xbstream = {&xbstream_init,  &xbstream_open,
-                                &xbstream_write, &xbstream_write_sparse,
-                                &xbstream_close, &xbstream_deinit};
+datasink_t datasink_xbstream = {
+    &xbstream_init,  &xbstream_open,   &xbstream_write, &xbstream_write_sparse,
+    &xbstream_close, &xbstream_deinit, nullptr /* report_metrics */};
 
 static ssize_t my_xbstream_write_callback(xb_wstream_file_t *f
                                           __attribute__((unused)),
@@ -90,7 +90,10 @@ static ds_ctxt_t *xbstream_init(const char *root __attribute__((unused))) {
       my_malloc(PSI_NOT_INSTRUMENTED,
                 sizeof(ds_ctxt_t) + sizeof(ds_parallel_stream_ctxt_t) +
                     (sizeof(ds_stream_ctxt_t) * (xtrabackup_fifo_streams + 1)),
-                MYF(MY_FAE)));
+                MYF(MY_FAE | MY_ZEROFILL)));
+  /* xbstream's wire format carries sparse chunks natively, so it can
+  faithfully round-trip holes regardless of the extraction filesystem. */
+  ctxt->fs_support_punch_hole = true;
 
   for (uint i = 0; i < xtrabackup_fifo_streams; i++) {
     ds_stream_ctxt_t *stream_ctxt = new ds_stream_ctxt_t;

--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -821,7 +821,8 @@ bool TablespaceKeyDumper::initialize() {
   MY_STAT stat_info;
   memset(&stat_info, 0, sizeof(MY_STAT));
 
-  m_stream = ds_open(m_ds_ctxt, XTRABACKUP_KEYS_FILE, &stat_info);
+  m_stream = ds_open_track_uncomp(m_ds_ctxt, XTRABACKUP_KEYS_FILE, &stat_info,
+                                  xb_global_track_uncomp_bytes());
   if (!m_stream) {
     xb::error() << "Error writing " << XTRABACKUP_KEYS_FILE
                 << ": failed to create file.";

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -478,7 +478,8 @@ bool Redo_Log_Writer::create_logfile(const char *name) {
   MY_STAT stat_info;
 
   memset(&stat_info, 0, sizeof(MY_STAT));
-  log_file = ds_open(ds_redo, XB_LOG_FILENAME, &stat_info);
+  log_file = ds_open_track_uncomp(ds_redo, XB_LOG_FILENAME, &stat_info,
+                                  xb_global_track_uncomp_bytes());
 
   if (log_file == NULL) {
     xb::error() << "failed to open the target stream for "

--- a/storage/innobase/xtrabackup/src/space_map.cc
+++ b/storage/innobase/xtrabackup/src/space_map.cc
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "common.h"
 #include "space_map.h"
 #include "xb0xb.h"
+#include "xtrabackup.h"
 
 Tablespace_map Tablespace_map::static_tablespace_map;
 
@@ -209,7 +210,8 @@ bool Tablespace_map::serialize(ds_ctxt_t *ds) const {
   mystat.st_mtime = time(nullptr);
 
   const char *path = XBTS_FILE_NAME;
-  ds_file_t *stream = ds_open(ds, path, &mystat);
+  ds_file_t *stream =
+      ds_open_track_uncomp(ds, path, &mystat, xb_global_track_uncomp_bytes());
   if (stream == NULL) {
     xb::error() << "cannot open output stream for " << path;
     return (false);

--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -258,5 +258,18 @@ std::string formatElapsedTime(std::chrono::nanoseconds elapsed) {
   return result.str();
 }
 
+std::string human_readable(unsigned long long bytes) {
+  char buf[64];
+  if (bytes >= 1ULL << 30)
+    snprintf(buf, sizeof(buf), "%.2f GiB", (double)bytes / (1ULL << 30));
+  else if (bytes >= 1ULL << 20)
+    snprintf(buf, sizeof(buf), "%.2f MiB", (double)bytes / (1ULL << 20));
+  else if (bytes >= 1ULL << 10)
+    snprintf(buf, sizeof(buf), "%.2f KiB", (double)bytes / (1ULL << 10));
+  else
+    snprintf(buf, sizeof(buf), "%llu bytes", bytes);
+  return buf;
+}
+
 }  // namespace utils
 }  // namespace xtrabackup

--- a/storage/innobase/xtrabackup/src/utils.h
+++ b/storage/innobase/xtrabackup/src/utils.h
@@ -74,6 +74,16 @@ constexpr HighResTimePoint INVALID_TIME = HighResTimePoint::min();
 
 std::string formatElapsedTime(std::chrono::nanoseconds elapsed);
 
+/**
+  Format a byte count as a human-readable string (e.g. "1.23 MiB",
+  "456 bytes").  Uses base-2 units (KiB / MiB / GiB) and two decimal
+  places once the magnitude is >= 1 KiB; exact byte counts are printed
+  verbatim below that threshold.
+
+  @param[in] bytes  number of bytes to format
+  @return  formatted string */
+std::string human_readable(unsigned long long bytes);
+
 // Helper to convert single values to strings
 template <typename T>
 std::string to_string(const T &value) {

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -394,6 +394,18 @@ ds_ctxt_t *ds_meta = nullptr;
 ds_ctxt_t *ds_redo = nullptr;
 ds_ctxt_t *ds_uncompressed_data = nullptr;
 
+/* Backup-run uncompressed byte aggregate.  Populated via
+ds_open_track_uncomp() at top-level open sites; read back by
+get_uncompressed_backup_size(). */
+xb_uncomp_bytes xb_uncomp_bytes_counter;
+
+/** Return the raw, hole-excluded, pre-compression backup volume.
+Only populated under --compress (xb_global_track_uncomp_bytes() is the
+gate); zero otherwise. */
+unsigned long long get_uncompressed_backup_size() {
+  return xb_uncomp_bytes_counter.get_uncompressed_backup_size();
+}
+
 /** Return the total bytes written to the physical sink (the leaf of
 ds_data).  Derived at read time by querying the leaf node directly
 with ds_find_metric(ds_leaf(ds_data), "bytes_written", ...) -- the
@@ -2774,7 +2786,8 @@ static bool xtrabackup_stream_metadata(ds_ctxt_t *ds_ctxt) {
   mystat.st_size = len;
   mystat.st_mtime = time(nullptr);
 
-  stream = ds_open(ds_ctxt, XTRABACKUP_METADATA_FILENAME, &mystat);
+  stream = ds_open_track_uncomp(ds_ctxt, XTRABACKUP_METADATA_FILENAME, &mystat,
+                                xb_global_track_uncomp_bytes());
   if (stream == NULL) {
     xb::error() << "cannot open output stream for "
                 << XTRABACKUP_METADATA_FILENAME;
@@ -2891,7 +2904,8 @@ bool xb_write_delta_metadata(const char *filename,
   mystat.st_size = len;
   mystat.st_mtime = time(nullptr);
 
-  f = ds_open(ds_meta, filename, &mystat);
+  f = ds_open_track_uncomp(ds_meta, filename, &mystat,
+                           xb_global_track_uncomp_bytes());
   if (f == NULL) {
     xb::error() << "cannot open output stream for " << filename;
     return (false);
@@ -3261,9 +3275,12 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
 
   /* do not compress encrypted tablespaces */
   if (cursor.is_encrypted) {
-    dstfile = ds_open(ds_uncompressed_data, dst_name, &cursor.statinfo);
+    dstfile =
+        ds_open_track_uncomp(ds_uncompressed_data, dst_name, &cursor.statinfo,
+                             xb_global_track_uncomp_bytes());
   } else {
-    dstfile = ds_open(ds_data, dst_name, &cursor.statinfo);
+    dstfile = ds_open_track_uncomp(ds_data, dst_name, &cursor.statinfo,
+                                   xb_global_track_uncomp_bytes());
   }
   if (dstfile == NULL) {
     xb::error() << "cannot open the destination stream for " << dst_name;

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -394,6 +394,26 @@ ds_ctxt_t *ds_meta = nullptr;
 ds_ctxt_t *ds_redo = nullptr;
 ds_ctxt_t *ds_uncompressed_data = nullptr;
 
+/** Return the total bytes written to the physical sink (the leaf of
+ds_data).  Derived at read time by querying the leaf node directly
+with ds_find_metric(ds_leaf(ds_data), "bytes_written", ...) -- the
+metric is published by ds_local / ds_stdout / ds_fifo.  Returns 0 and
+warns if the leaf did not publish the metric (e.g. on a prepare run
+where the main data pipeline was never constructed). */
+unsigned long long get_final_backup_size() {
+  if (ds_data == nullptr) {
+    return 0;
+  }
+  const ds_ctxt_t *leaf = ds_leaf(ds_data);
+  uint64_t bytes = 0;
+  if (!ds_find_metric(leaf, "bytes_written", &bytes)) {
+    xb::warn() << "Cannot determine backup size: leaf datasink "
+                  "does not publish \"bytes_written\"";
+    return 0;
+  }
+  return bytes;
+}
+
 static long innobase_log_files_in_group_save;
 static char *srv_log_group_home_dir_save;
 static longlong innobase_log_file_size_save;
@@ -4579,10 +4599,6 @@ void xtrabackup_backup_func(void) {
     exit(EXIT_FAILURE);
   }
 
-  if (!backup_finish(backup_ctxt)) {
-    exit(EXIT_FAILURE);
-  }
-
   if (xtrabackup_extra_lsndir) {
     char filename[FN_REFLEN];
 
@@ -4592,18 +4608,20 @@ void xtrabackup_backup_func(void) {
       xb::error() << "failed to write metadata to " << filename;
       exit(EXIT_FAILURE);
     }
-
-    sprintf(filename, "%s/%s", xtrabackup_extra_lsndir, XTRABACKUP_INFO);
-    if (!xtrabackup_write_info(filename)) {
-      xb::error() << "failed to write info to " << filename;
-      exit(EXIT_FAILURE);
-    }
   }
 
   if (opt_lock_ddl_per_table) {
     mdl_unlock_all();
   }
 
+  /* Tablespace_map::serialize() and the ts_key_dumper flush both
+  write additional files through ds_data, which drains down to the
+  leaf.  Run them BEFORE backup_finish() so the leaf "bytes_written"
+  counter sampled inside backup_finish() already includes those
+  bytes; otherwise the reported backup_size would be short by their
+  size.  The xtrabackup_info copy under --extra-lsndir stays AFTER
+  backup_finish() -- it is a second copy of the already-sampled
+  xtrabackup_info file and adds no ds_data bytes itself. */
   Tablespace_map::instance().serialize(ds_data);
 
   if (ts_key_dumper.is_initialized()) {
@@ -4623,6 +4641,20 @@ void xtrabackup_backup_func(void) {
   }
 
   ts_key_dumper.finalize();
+
+  if (!backup_finish(backup_ctxt)) {
+    exit(EXIT_FAILURE);
+  }
+
+  if (xtrabackup_extra_lsndir) {
+    char filename[FN_REFLEN];
+
+    sprintf(filename, "%s/%s", xtrabackup_extra_lsndir, XTRABACKUP_INFO);
+    if (!xtrabackup_write_info(filename)) {
+      xb::error() << "failed to write info to " << filename;
+      exit(EXIT_FAILURE);
+    }
+  }
 
   xtrabackup_destroy_datasinks();
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -78,7 +78,13 @@ extern char *innobase_data_home_dir;
 extern char *innobase_buffer_pool_filename;
 extern ds_ctxt_t *ds_meta;
 extern ds_ctxt_t *ds_data;
+extern ds_ctxt_t *ds_redo;
 extern ds_ctxt_t *ds_uncompressed_data;
+
+/** @return total bytes written by the leaf of the main data pipeline.
+Derived at read time by querying the leaf of ds_data via
+ds_find_metric(ds_leaf(ds_data), "bytes_written", ...). */
+unsigned long long get_final_backup_size();
 
 extern pagetracking::xb_space_map *changed_page_tracking;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -81,9 +81,25 @@ extern ds_ctxt_t *ds_data;
 extern ds_ctxt_t *ds_redo;
 extern ds_ctxt_t *ds_uncompressed_data;
 
+/** Global uncompressed-byte counter for the current backup run (type
+is defined in datasink.h to keep that header self-contained for
+standalone tools).  Only enabled on top-level ds_file_t handles via
+ds_open_track_uncomp(xb_global_track_uncomp_bytes()); internal wrapper
+opens do not contribute, so every logical byte is counted exactly
+once. */
+extern xb_uncomp_bytes xb_uncomp_bytes_counter;
+
+/** @return total raw (pre-compression, hole-excluded) bytes
+accumulated by xb_uncomp_bytes_counter across all top-level tracked
+opens this run.  Only meaningful when --compress is used; returns 0
+otherwise. */
+unsigned long long get_uncompressed_backup_size();
+
 /** @return total bytes written by the leaf of the main data pipeline.
-Derived at read time by querying the leaf of ds_data via
-ds_find_metric(ds_leaf(ds_data), "bytes_written", ...). */
+Equals the post-compression size under --compress and equals the
+uncompressed size otherwise.  Derived at read time by querying the
+leaf of ds_data via ds_find_metric(ds_leaf(ds_data), "bytes_written",
+...). */
 unsigned long long get_final_backup_size();
 
 extern pagetracking::xb_space_map *changed_page_tracking;
@@ -109,6 +125,20 @@ extern char *xtrabackup_databases_exclude;
 
 extern xtrabackup_compress_t xtrabackup_compress;
 extern bool xtrabackup_encrypt;
+
+/** Counter pointer passed to ds_open_track_uncomp() for top-level
+backup files.  Tracking is only useful when --compress is active:
+without compression the logical bytes equal what the leaf writes
+anyway, and get_final_backup_size() already returns the same number
+from the leaf counter.  Returning nullptr outside --compress keeps
+the hot write path free of any extra work in the common case.
+@return &xb_uncomp_bytes_counter when --compress is active, nullptr
+        otherwise. */
+inline xb_uncomp_bytes *xb_global_track_uncomp_bytes() {
+  return xtrabackup_compress != XTRABACKUP_COMPRESS_NONE
+             ? &xb_uncomp_bytes_counter
+             : nullptr;
+}
 
 extern bool xtrabackup_backup;
 extern bool xtrabackup_prepare;

--- a/storage/innobase/xtrabackup/test/inc/common.sh
+++ b/storage/innobase/xtrabackup/test/inc/common.sh
@@ -87,6 +87,129 @@ function die()
   exit 1
 }
 
+########################################################################
+# xtrabackup_info / backup_size helpers
+#
+# Shared across tests that validate backup_size / uncompressed_backup_size.
+# Kept here so suites do not duplicate (and drift) their own copies.
+########################################################################
+
+# get_field <info_file> <field>
+#   Read one "<field> = <value>" line from an xtrabackup_info file and
+#   echo the value (third whitespace-separated token).  Empty output if
+#   the field is not present.
+#   $1 info_file - path to xtrabackup_info
+#   $2 field     - name of the field to look up
+get_field() { grep "^$2 = " "$1" | awk '{print $3}'; }
+
+# file_size <path>
+#   Echo the size in bytes of a single regular file.
+file_size() { stat -c '%s' "$1"; }
+
+# sum_file_bytes <dir>
+#   Echo the sum of the sizes of every regular file under <dir>
+#   (recursive).  0 if the directory is empty or does not exist.
+#   The explicit -d guard keeps find from spraying a "No such file"
+#   message to stderr when callers probe a path that may be absent.
+sum_file_bytes() {
+  [ -d "$1" ] || { echo 0; return; }
+  find "$1" -type f -printf '%s\n' | awk '{s+=$1} END{print s+0}'
+}
+
+# find_info_file <dir>
+#   Locate xtrabackup_info (or one of its compressed/encrypted variants)
+#   under <dir>, echo the path, and return 0.  die()s if none found.
+#   Understands the extensions produced by --compress (.lz4, .zst, .qp)
+#   and --encrypt (.xbcrypt, combined with compression).
+find_info_file() {
+  local dir=$1 ext f
+  for ext in "" .lz4 .zst .qp .xbcrypt .lz4.xbcrypt .zst.xbcrypt .qp.xbcrypt ; do
+    f="$dir/xtrabackup_info$ext"
+    if [ -f "$f" ]; then echo "$f"; return 0; fi
+  done
+  die "no xtrabackup_info* found under $dir"
+}
+
+# assert_positive <val> <label>
+#   die() unless <val> is a non-empty decimal integer > 0.
+assert_positive() {
+  local val=$1 label=$2
+  if ! [[ "$val" =~ ^[0-9]+$ ]] || [ "$val" -le 0 ]; then
+    die "$label: expected positive integer, got '$val'"
+  fi
+}
+
+# assert_no_field <info_file> <field>
+#   die() if <field> is present as an "<field> = ..." line in <info_file>.
+assert_no_field() {
+  local file=$1 field=$2
+  if grep -q "^$field = " "$file" ; then
+    die "$field should not be present in $file"
+  fi
+}
+
+# assert_eq <actual> <expected> <label>
+#   Byte-perfect equality check with a readable diff on failure.
+assert_eq() {
+  local actual=$1 expected=$2 label=$3
+  if [ -z "$actual" ];   then die "$label: actual is empty";   fi
+  if [ -z "$expected" ]; then die "$label: expected is empty"; fi
+  if [ "$actual" -ne "$expected" ]; then
+    die "$label: actual=$actual expected=$expected diff=$((actual - expected))"
+  fi
+  vlog "$label: $actual (EXACT)"
+}
+
+# assert_target_strict <dir> <bs> <label>
+#   backup_size (bs) read from extra-lsndir/xtrabackup_info must equal
+#   the sum of file sizes under <dir>.  Uses the extra-lsndir copy
+#   because it is sampled AFTER the target's xtrabackup_info has flowed
+#   through the leaf, so bs already includes that file.
+assert_target_strict() {
+  local dir=$1 bs=$2 label=$3
+  local total=$(sum_file_bytes "$dir")
+  assert_eq "$bs" "$total" \
+    "$label A: backup_size($bs) == sum_file_bytes($dir)"
+}
+
+# assert_stream_strict <xbs> <bs> <label>
+#   Strict invariant for --stream=xbstream backups.  The .xbs is the
+#   complete stdout of the leaf (xbstream wrapping included for every
+#   file, xtrabackup_info included).  bs from extra-lsndir is the
+#   post-write sample, so bs == size of the .xbs file.
+assert_stream_strict() {
+  local xbs=$1 bs=$2 label=$3
+  local xbs_size=$(file_size "$xbs")
+  assert_eq "$bs" "$xbs_size" \
+    "$label A': backup_size($bs) == size of $(basename $xbs) ($xbs_size)"
+}
+
+# assert_decompressed_strict <dir> <us> <label> [enc_key]
+#   Strict invariant used with --compress (and optionally --encrypt).
+#   Decrypts in-place if enc_key is passed, --decompresses in-place,
+#   drops the original .xbcrypt/.lz4/.zst leftovers, then asserts that
+#   uncompressed_backup_size (us) equals the sum of file sizes under
+#   the now-plaintext <dir>.  Requires the extra-lsndir copy of
+#   xtrabackup_info (sampled AFTER the plaintext info has flowed
+#   through the metric-bound top-level ds_data).
+assert_decompressed_strict() {
+  local dir=$1 us=$2 label=$3 enc_key=$4
+  if [ -n "$enc_key" ]; then
+    xtrabackup --decrypt=AES256 --encrypt-key="$enc_key" --target-dir="$dir" \
+        2>/dev/null || die "$label: --decrypt failed"
+    find "$dir" -name '*.xbcrypt' -delete
+  fi
+  xtrabackup --decompress --target-dir="$dir" 2>/dev/null \
+      || die "$label: --decompress failed"
+  find "$dir" -name '*.lz4' -delete
+  find "$dir" -name '*.zst' -delete
+  find "$dir" -name '*.qp'  -delete
+
+  local total=$(sum_file_bytes "$dir")
+  assert_eq "$us" "$total" \
+    "$label B: uncompressed_backup_size($us) == sum_file_bytes(decompressed $dir)"
+}
+
 function call_mysql_install_db()
 {
         vlog "Calling mysql_install_db"

--- a/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
@@ -1,0 +1,239 @@
+############################################################################
+# Test backup_size reporting in xtrabackup_info and the error log.
+#
+# Validates byte-perfect invariants across non-compress transport /
+# format combinations (target-dir, xbstream, encrypt, incremental chain,
+# full restore, sparse InnoDB page-compressed tablespaces).
+#
+# Sampling note: backup_size is sampled inside get_xtrabackup_info() and
+# embedded in the file content.  That sample is taken AGAIN when
+# --extra-lsndir's xtrabackup_info is written by xtrabackup_write_info(),
+# which happens AFTER backup_finish() has already written the target's
+# xtrabackup_info through ds_data.  So the value read from the extra-
+# lsndir copy reflects the FINAL leaf bytes_written -- it already counts
+# every byte that ends up on disk, including the target's own
+# xtrabackup_info[.xbcrypt|...].  Therefore:
+#
+#   Invariant A  (target-dir):  backup_size == sum_file_bytes(target)
+#   Invariant A' (stream     ):  backup_size == size of .xbs file
+#
+# Both are byte-exact; zero tolerance.
+#
+# Sparse scenarios are LOOSE for backup_size because:
+#   - backup_size counts packed data bytes only (no holes).
+#   - Apparent on-disk size INCLUDES the punched holes.
+#   - Allocated bytes (%b * 512) round to FS-block boundaries and the
+#     +1-byte trailing-hole fix in local_close() allocates one whole FS
+#     block (~4 KiB) which the counter records as 1 byte.
+#   Neither apparent nor allocated equals backup_size to the byte for
+#   sparse files.
+############################################################################
+
+. inc/common.sh
+
+############################################################################
+# Helpers (get_field, file_size, sum_file_bytes, find_info_file,
+# assert_positive, assert_no_field, assert_eq, assert_target_strict,
+# assert_stream_strict) are sourced from inc/common.sh above.
+############################################################################
+
+start_server --innodb_file_per_table
+
+load_sakila
+
+ENCKEY="percona_xtrabackup_is_awesome___"
+
+############################################################################
+# Scenario 1: Plain --target-dir
+############################################################################
+vlog "=== Scenario 1: Plain --target-dir ==="
+
+mkdir -p $topdir/lsn1
+xtrabackup --backup --target-dir=$topdir/backup1 --extra-lsndir=$topdir/lsn1 \
+    2> >(tee $topdir/log1 >&2)
+
+bs1=$(get_field "$topdir/lsn1/xtrabackup_info" backup_size)
+assert_positive "$bs1" "scen1 backup_size"
+assert_no_field "$topdir/lsn1/xtrabackup_info" uncompressed_backup_size
+grep -q "Backup size:" $topdir/log1 || die "scen1: missing 'Backup size:' in log"
+
+assert_target_strict "$topdir/backup1" "$bs1" "scen1 (plain target)"
+
+rm -rf $topdir/backup1 $topdir/lsn1 $topdir/log1
+
+############################################################################
+# Scenario 2: Plain --stream=xbstream
+############################################################################
+vlog "=== Scenario 2: Plain --stream=xbstream ==="
+
+mkdir -p $topdir/lsn2
+xtrabackup --backup --stream=xbstream --extra-lsndir=$topdir/lsn2 \
+    > $topdir/backup2.xbs 2> >(tee $topdir/log2 >&2)
+
+bs2=$(get_field "$topdir/lsn2/xtrabackup_info" backup_size)
+assert_positive "$bs2" "scen2 backup_size"
+assert_no_field "$topdir/lsn2/xtrabackup_info" uncompressed_backup_size
+
+assert_stream_strict "$topdir/backup2.xbs" "$bs2" "scen2 (plain stream)"
+
+rm -rf $topdir/backup2.xbs $topdir/lsn2 $topdir/log2
+
+############################################################################
+# Scenario 3: Encrypted (no compress) --target-dir
+############################################################################
+vlog "=== Scenario 3: Encrypted --target-dir ==="
+
+mkdir -p $topdir/lsn3
+xtrabackup --backup --encrypt=AES256 --encrypt-key="$ENCKEY" \
+    --target-dir=$topdir/backup3 --extra-lsndir=$topdir/lsn3 \
+    2> >(tee $topdir/log3 >&2)
+
+bs3=$(get_field "$topdir/lsn3/xtrabackup_info" backup_size)
+assert_positive "$bs3" "scen3 backup_size"
+assert_no_field "$topdir/lsn3/xtrabackup_info" uncompressed_backup_size
+
+assert_target_strict "$topdir/backup3" "$bs3" "scen3 (encrypt target)"
+
+rm -rf $topdir/backup3 $topdir/lsn3 $topdir/log3
+
+############################################################################
+# Scenario 4: Encrypted + xbstream (no compress)
+############################################################################
+vlog "=== Scenario 4: --encrypt + --stream=xbstream ==="
+
+mkdir -p $topdir/lsn4
+xtrabackup --backup --stream=xbstream --encrypt=AES256 --encrypt-key="$ENCKEY" \
+    --extra-lsndir=$topdir/lsn4 \
+    > $topdir/backup4.xbs 2> >(tee $topdir/log4 >&2)
+
+bs4=$(get_field "$topdir/lsn4/xtrabackup_info" backup_size)
+assert_positive "$bs4" "scen4 backup_size"
+assert_no_field "$topdir/lsn4/xtrabackup_info" uncompressed_backup_size
+
+assert_stream_strict "$topdir/backup4.xbs" "$bs4" "scen4 (encrypt stream)"
+
+rm -rf $topdir/backup4.xbs $topdir/lsn4 $topdir/log4
+
+############################################################################
+# Scenario 5: Restore validation (plain backup, full prepare + copy-back)
+############################################################################
+vlog "=== Scenario 5: Restore validation ==="
+
+xtrabackup --backup --target-dir=$topdir/backup5
+record_db_state sakila
+xtrabackup --prepare --target-dir=$topdir/backup5
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup5
+start_server
+verify_db_state sakila
+rm -rf $topdir/backup5
+
+############################################################################
+# Scenario 6: Incremental chain (no compress)
+############################################################################
+vlog "=== Scenario 6: Incremental chain (no compress) ==="
+
+mysql -e "CREATE TABLE t_inc (a INT PRIMARY KEY AUTO_INCREMENT, b TEXT) ENGINE=InnoDB;" test
+for i in $(seq 1 500) ; do
+  echo "INSERT INTO t_inc (b) VALUES (REPEAT(UUID(), 20));"
+done | mysql test
+
+mkdir -p $topdir/lsn6full
+xtrabackup --backup --target-dir=$topdir/backup6full \
+    --extra-lsndir=$topdir/lsn6full
+
+bs6full=$(get_field "$topdir/lsn6full/xtrabackup_info" backup_size)
+assert_target_strict "$topdir/backup6full" "$bs6full" "scen6 (inc full)"
+
+for i in $(seq 1 100) ; do
+  echo "INSERT INTO t_inc (b) VALUES (REPEAT(UUID(), 20));"
+done | mysql test
+
+mkdir -p $topdir/lsn6inc1
+xtrabackup --backup --incremental-basedir=$topdir/backup6full \
+    --target-dir=$topdir/backup6inc1 --extra-lsndir=$topdir/lsn6inc1
+
+bs6inc1=$(get_field "$topdir/lsn6inc1/xtrabackup_info" backup_size)
+assert_target_strict "$topdir/backup6inc1" "$bs6inc1" "scen6 (inc1)"
+[ "$bs6inc1" -lt "$bs6full" ] || die "scen6: inc1 ($bs6inc1) should be < full ($bs6full)"
+
+ls $topdir/backup6inc1/test/*.delta > /dev/null 2>&1 || die "scen6: missing .delta in inc1"
+ls $topdir/backup6inc1/test/*.meta  > /dev/null 2>&1 || die "scen6: missing .meta  in inc1"
+
+for i in $(seq 1 50) ; do
+  echo "INSERT INTO t_inc (b) VALUES (REPEAT(UUID(), 20));"
+done | mysql test
+
+mkdir -p $topdir/lsn6inc2
+xtrabackup --backup --incremental-basedir=$topdir/backup6inc1 \
+    --target-dir=$topdir/backup6inc2 --extra-lsndir=$topdir/lsn6inc2
+
+bs6inc2=$(get_field "$topdir/lsn6inc2/xtrabackup_info" backup_size)
+assert_target_strict "$topdir/backup6inc2" "$bs6inc2" "scen6 (inc2)"
+
+# Restore the chain end-to-end.
+record_db_state test
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup6full
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup6inc1 \
+    --target-dir=$topdir/backup6full
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup6inc2 \
+    --target-dir=$topdir/backup6full
+xtrabackup --prepare --target-dir=$topdir/backup6full
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup6full
+start_server
+verify_db_state test
+
+rm -rf $topdir/backup6full $topdir/backup6inc1 $topdir/backup6inc2 \
+       $topdir/lsn6full   $topdir/lsn6inc1   $topdir/lsn6inc2
+
+############################################################################
+# Scenario 7: Sparse files, no compress.  See header comment for why
+# backup_size cannot be byte-perfectly compared on disk for sparse files.
+############################################################################
+if grep -q 'PUNCH HOLE support not available' $MYSQLD_ERRFILE ; then
+  vlog "=== Scenario 7: SKIPPED (no PUNCH HOLE support) ==="
+else
+  vlog "=== Scenario 7: Sparse files, no compress ==="
+
+  mysql -e "CREATE TABLE t_sparse (c1 INT AUTO_INCREMENT PRIMARY KEY, c2 BLOB) COMPRESSION='zlib' ENGINE=InnoDB;" test
+  mysql -e "INSERT INTO t_sparse (c2) VALUES (REPEAT('x', 5000));" test
+  for i in $(seq 1 10) ; do
+    mysql -e "INSERT INTO t_sparse (c2) SELECT c2 FROM t_sparse;" test
+  done
+  innodb_wait_for_flush_all
+
+  if ! is_sparse_file $mysql_datadir/test/t_sparse.ibd ; then
+    die "t_sparse.ibd is expected to be sparse but is NOT"
+  fi
+  record_db_state test
+
+  mkdir -p $topdir/lsn7
+  xtrabackup --backup --target-dir=$topdir/backup7 --extra-lsndir=$topdir/lsn7
+
+  bs7=$(get_field "$topdir/lsn7/xtrabackup_info" backup_size)
+  assert_positive "$bs7" "scen7 backup_size"
+  assert_no_field "$topdir/lsn7/xtrabackup_info" uncompressed_backup_size
+
+  is_sparse_file $topdir/backup7/test/t_sparse.ibd \
+      || die "scen7: backed-up t_sparse.ibd is not sparse"
+
+  # Sanity: backup_size must be smaller than apparent on-disk total because
+  # apparent includes the holes that backup_size omits.
+  apparent7=$(sum_file_bytes "$topdir/backup7")
+  [ "$bs7" -lt "$apparent7" ] \
+      || die "scen7: backup_size ($bs7) should be < apparent total ($apparent7) due to holes"
+
+  xtrabackup --prepare --target-dir=$topdir/backup7
+  stop_server
+  rm -rf $mysql_datadir/*
+  xtrabackup --copy-back --target-dir=$topdir/backup7
+  start_server
+  verify_db_state test
+
+  rm -rf $topdir/backup7 $topdir/lsn7
+fi
+
+vlog "All non-compress backup_size scenarios passed (byte-perfect where strict)."

--- a/storage/innobase/xtrabackup/test/t/backup_size_compress.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_size_compress.sh
@@ -1,0 +1,300 @@
+############################################################################
+# Test uncompressed_backup_size reporting in xtrabackup_info and the error
+# log when --compress is used.
+#
+# Validates byte-perfect invariants for every --compress transport /
+# format combination (target-dir, xbstream, encrypt, incremental chain,
+# RocksDB bypass, server-encrypted InnoDB, redo log encryption, sparse).
+#
+# Sampling note: uncompressed_backup_size is sampled inside
+# get_xtrabackup_info() and embedded in the file content.  That sample
+# is taken AGAIN when --extra-lsndir's xtrabackup_info is written by
+# xtrabackup_write_info(), which happens AFTER backup_finish() has
+# already written the target's xtrabackup_info through ds_data.  So the
+# value we read from the extra-lsndir copy reflects every raw byte that
+# flowed through ds_data before compression, including xtrabackup_info
+# itself.  Therefore:
+#
+#   Invariant A  (target-dir):  backup_size == sum_file_bytes(target)
+#   Invariant A' (stream     ):  backup_size == size of .xbs file
+#   Invariant B  (--compress ):  uncompressed_backup_size ==
+#                                sum_file_bytes(decompressed)
+#
+# All three are exact: zero tolerance.
+#
+# Sparse + --compress (scen15): Invariant A cannot be byte-perfectly
+# compared on disk because backup_size on the compressed target counts
+# packed compressed payload while the apparent file layout may round to
+# filesystem-block boundaries.  Invariant B is still byte-perfect
+# because the decompressor writes the data dense (no holes) and
+# uncompressed_backup_size counts only packed payload bytes.
+############################################################################
+
+. inc/common.sh
+
+require_zstd
+require_lz4
+
+############################################################################
+# Helpers (get_field, file_size, sum_file_bytes, find_info_file,
+# assert_positive, assert_no_field, assert_eq, assert_target_strict,
+# assert_stream_strict, assert_decompressed_strict) are sourced from
+# inc/common.sh above.
+############################################################################
+
+start_server --innodb_file_per_table
+
+load_sakila
+
+ENCKEY="percona_xtrabackup_is_awesome___"
+
+############################################################################
+# Scenario 1: Compressed (lz4) --target-dir
+############################################################################
+vlog "=== Scenario 1: Compressed (lz4) --target-dir ==="
+
+mkdir -p $topdir/lsn1
+xtrabackup --backup --compress=lz4 --target-dir=$topdir/backup1 \
+    --extra-lsndir=$topdir/lsn1 \
+    2> >(tee $topdir/log1 >&2)
+
+bs1=$(get_field "$topdir/lsn1/xtrabackup_info" backup_size)
+us1=$(get_field "$topdir/lsn1/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$bs1" "scen1 backup_size"
+assert_positive "$us1" "scen1 uncompressed_backup_size"
+grep -q "Backup size:"              $topdir/log1 || die "scen1: missing 'Backup size:' in log"
+grep -q "Uncompressed backup size:" $topdir/log1 || die "scen1: missing 'Uncompressed backup size:' in log"
+grep -q "Compression ratio:"        $topdir/log1 || die "scen1: missing 'Compression ratio:' in log"
+
+assert_target_strict       "$topdir/backup1" "$bs1" "scen1 (compress target)"
+assert_decompressed_strict "$topdir/backup1" "$us1" "scen1 (compress target)" ""
+
+rm -rf $topdir/backup1 $topdir/lsn1 $topdir/log1
+
+############################################################################
+# Scenario 2: Compressed + xbstream
+############################################################################
+vlog "=== Scenario 2: --compress=lz4 --stream=xbstream ==="
+
+mkdir -p $topdir/lsn2
+xtrabackup --backup --stream=xbstream --compress=lz4 \
+    --extra-lsndir=$topdir/lsn2 \
+    > $topdir/backup2.xbs 2> >(tee $topdir/log2 >&2)
+
+bs2=$(get_field "$topdir/lsn2/xtrabackup_info" backup_size)
+us2=$(get_field "$topdir/lsn2/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$bs2" "scen2 backup_size"
+assert_positive "$us2" "scen2 uncompressed_backup_size"
+
+assert_stream_strict "$topdir/backup2.xbs" "$bs2" "scen2 (compress stream)"
+
+mkdir -p $topdir/extract2
+xbstream -x -C $topdir/extract2 < $topdir/backup2.xbs
+assert_decompressed_strict "$topdir/extract2" "$us2" "scen2 (compress stream)" ""
+
+rm -rf $topdir/backup2.xbs $topdir/extract2 $topdir/lsn2 $topdir/log2
+
+############################################################################
+# Scenario 3: Compressed + Encrypted + xbstream (the kitchen sink)
+############################################################################
+vlog "=== Scenario 3: --compress + --encrypt + --stream=xbstream ==="
+
+mkdir -p $topdir/lsn3
+xtrabackup --backup --compress=lz4 --encrypt=AES256 --encrypt-key="$ENCKEY" \
+    --stream=xbstream --extra-lsndir=$topdir/lsn3 \
+    > $topdir/backup3.xbs 2> >(tee $topdir/log3 >&2)
+
+bs3=$(get_field "$topdir/lsn3/xtrabackup_info" backup_size)
+us3=$(get_field "$topdir/lsn3/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$bs3" "scen3 backup_size"
+assert_positive "$us3" "scen3 uncompressed_backup_size"
+
+assert_stream_strict "$topdir/backup3.xbs" "$bs3" "scen3 (compress+encrypt stream)"
+
+mkdir -p $topdir/extract3
+xbstream -x -C $topdir/extract3 < $topdir/backup3.xbs
+assert_decompressed_strict "$topdir/extract3" "$us3" "scen3 (compress+encrypt stream)" "$ENCKEY"
+
+rm -rf $topdir/backup3.xbs $topdir/extract3 $topdir/lsn3 $topdir/log3
+
+############################################################################
+# Scenario 4: Incremental chain with --compress=lz4
+############################################################################
+vlog "=== Scenario 4: Incremental chain (compress=lz4) ==="
+
+mysql -e "CREATE TABLE t_inc (a INT PRIMARY KEY AUTO_INCREMENT, b TEXT) ENGINE=InnoDB;" test
+for i in $(seq 1 500) ; do
+  echo "INSERT INTO t_inc (b) VALUES (REPEAT(UUID(), 20));"
+done | mysql test
+
+mkdir -p $topdir/lsn4full
+xtrabackup --backup --compress=lz4 --target-dir=$topdir/backup4full \
+    --extra-lsndir=$topdir/lsn4full
+
+bs4full=$(get_field "$topdir/lsn4full/xtrabackup_info" backup_size)
+us4full=$(get_field "$topdir/lsn4full/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$us4full" "scen4 full uncompressed_backup_size"
+
+assert_target_strict       "$topdir/backup4full" "$bs4full" "scen4 (full compress target)"
+assert_decompressed_strict "$topdir/backup4full" "$us4full" "scen4 (full compress target)" ""
+
+for i in $(seq 1 100) ; do
+  echo "INSERT INTO t_inc (b) VALUES (REPEAT(UUID(), 20));"
+done | mysql test
+
+mkdir -p $topdir/lsn4inc1
+xtrabackup --backup --compress=lz4 \
+    --incremental-basedir=$topdir/lsn4full \
+    --target-dir=$topdir/backup4inc1 --extra-lsndir=$topdir/lsn4inc1
+
+bs4inc1=$(get_field "$topdir/lsn4inc1/xtrabackup_info" backup_size)
+us4inc1=$(get_field "$topdir/lsn4inc1/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$us4inc1" "scen4 inc1 uncompressed_backup_size"
+
+assert_target_strict       "$topdir/backup4inc1" "$bs4inc1" "scen4 (inc1 compress target)"
+assert_decompressed_strict "$topdir/backup4inc1" "$us4inc1" "scen4 (inc1 compress target)" ""
+
+[ "$bs4inc1" -lt "$bs4full" ] || die "scen4: inc1 ($bs4inc1) should be < full ($bs4full)"
+
+rm -rf $topdir/backup4full $topdir/backup4inc1 $topdir/lsn4full $topdir/lsn4inc1
+
+############################################################################
+# Scenario 5: --compress + RocksDB (bypass via ds_uncompressed_data)
+############################################################################
+if test -f $(dirname ${MYSQLD})/../lib/plugin/ha_rocksdb.so ; then
+  vlog "=== Scenario 5: --compress + RocksDB ==="
+
+  stop_server
+  rm -rf $mysql_datadir
+  start_server --innodb_file_per_table
+
+  init_rocksdb
+
+  mysql -e "CREATE TABLE t_rocks (a INT PRIMARY KEY AUTO_INCREMENT, b INT, c VARCHAR(200)) ENGINE=ROCKSDB;" test
+  for i in $(seq 1 500) ; do
+    echo "INSERT INTO t_rocks (b, c) VALUES (FLOOR(RAND() * 1000000), UUID());"
+  done | mysql test
+
+  mkdir -p $topdir/lsn5
+  xtrabackup --backup --compress=lz4 --target-dir=$topdir/backup5 \
+      --extra-lsndir=$topdir/lsn5
+
+  bs5=$(get_field "$topdir/lsn5/xtrabackup_info" backup_size)
+  us5=$(get_field "$topdir/lsn5/xtrabackup_info" uncompressed_backup_size)
+  assert_positive "$us5" "scen5 uncompressed_backup_size"
+
+  assert_target_strict       "$topdir/backup5" "$bs5" "scen5 (rocksdb+compress target)"
+  assert_decompressed_strict "$topdir/backup5" "$us5" "scen5 (rocksdb+compress target)" ""
+
+  rm -rf $topdir/backup5 $topdir/lsn5
+else
+  vlog "=== Scenario 5: SKIPPED (RocksDB not available) ==="
+fi
+
+############################################################################
+# Scenario 6: --compress + server-encrypted InnoDB tablespaces
+############################################################################
+vlog "=== Scenario 6: --compress + server-encrypted InnoDB ==="
+
+stop_server
+
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+configure_server_with_component
+
+mysql -e "CREATE TABLE t_enc (a INT PRIMARY KEY AUTO_INCREMENT, b TEXT) ENCRYPTION='y' ENGINE=InnoDB;" test
+for i in $(seq 1 500) ; do
+  echo "INSERT INTO t_enc (b) VALUES (REPEAT(UUID(), 10));"
+done | mysql test
+
+mkdir -p $topdir/lsn6
+xtrabackup --backup --compress=lz4 --target-dir=$topdir/backup6 \
+    --extra-lsndir=$topdir/lsn6 ${keyring_args}
+
+bs6=$(get_field "$topdir/lsn6/xtrabackup_info" backup_size)
+us6=$(get_field "$topdir/lsn6/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$us6" "scen6 uncompressed_backup_size"
+
+assert_target_strict       "$topdir/backup6" "$bs6" "scen6 (enc-innodb+compress target)"
+assert_decompressed_strict "$topdir/backup6" "$us6" "scen6 (enc-innodb+compress target)" ""
+
+rm -rf $topdir/backup6 $topdir/lsn6
+cleanup_keyring
+
+############################################################################
+# Scenario 7: --compress + server redo log encryption
+############################################################################
+vlog "=== Scenario 7: --compress + redo log encryption ==="
+
+stop_server
+
+MYSQLD_EXTRA_MY_CNF_OPTS="
+innodb_redo_log_encrypt=ON
+innodb_undo_log_encrypt=ON
+"
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+configure_server_with_component
+
+mysql -e "CREATE TABLE t_redo_enc (a INT PRIMARY KEY AUTO_INCREMENT, b TEXT) ENGINE=InnoDB;" test
+for i in $(seq 1 500) ; do
+  echo "INSERT INTO t_redo_enc (b) VALUES (REPEAT(UUID(), 10));"
+done | mysql test
+
+mkdir -p $topdir/lsn7
+xtrabackup --backup --compress=lz4 --target-dir=$topdir/backup7 \
+    --extra-lsndir=$topdir/lsn7 ${keyring_args}
+
+bs7=$(get_field "$topdir/lsn7/xtrabackup_info" backup_size)
+us7=$(get_field "$topdir/lsn7/xtrabackup_info" uncompressed_backup_size)
+assert_positive "$us7" "scen7 uncompressed_backup_size"
+
+assert_target_strict       "$topdir/backup7" "$bs7" "scen7 (redo-enc+compress target)"
+assert_decompressed_strict "$topdir/backup7" "$us7" "scen7 (redo-enc+compress target)" ""
+
+rm -rf $topdir/backup7 $topdir/lsn7
+cleanup_keyring
+
+############################################################################
+# Scenario 8: Sparse files + --compress=zstd.  Invariant B (decompress)
+# gives a byte-perfect check because the decompressor writes the data
+# dense (no holes) and uncompressed_backup_size counts only the packed
+# payload bytes.
+############################################################################
+stop_server
+rm -rf $mysql_datadir
+MYSQLD_EXTRA_MY_CNF_OPTS=""
+start_server
+
+if grep -q 'PUNCH HOLE support not available' $MYSQLD_ERRFILE ; then
+  vlog "=== Scenario 8: SKIPPED (no PUNCH HOLE support) ==="
+else
+  vlog "=== Scenario 8: Sparse files + --compress=zstd ==="
+
+  mysql -e "CREATE TABLE t_sparse (c1 INT AUTO_INCREMENT PRIMARY KEY, c2 BLOB) COMPRESSION='zlib' ENGINE=InnoDB;" test
+  mysql -e "INSERT INTO t_sparse (c2) VALUES (REPEAT('x', 5000));" test
+  for i in $(seq 1 10) ; do
+    mysql -e "INSERT INTO t_sparse (c2) SELECT c2 FROM t_sparse;" test
+  done
+  innodb_wait_for_flush_all
+
+  if ! is_sparse_file $mysql_datadir/test/t_sparse.ibd ; then
+    die "t_sparse.ibd is expected to be sparse but is NOT"
+  fi
+
+  mkdir -p $topdir/lsn8
+  xtrabackup --backup --compress=zstd --target-dir=$topdir/backup8 \
+      --extra-lsndir=$topdir/lsn8
+
+  bs8=$(get_field "$topdir/lsn8/xtrabackup_info" backup_size)
+  us8=$(get_field "$topdir/lsn8/xtrabackup_info" uncompressed_backup_size)
+  assert_positive "$us8" "scen8 uncompressed_backup_size"
+
+  assert_decompressed_strict "$topdir/backup8" "$us8" "scen8 (sparse+compress target)" ""
+
+  rm -rf $topdir/backup8 $topdir/lsn8
+fi
+
+vlog "All --compress backup_size scenarios passed (byte-perfect)."


### PR DESCRIPTION
## Summary

xtrabackup now embeds two byte-accurate size fields in `xtrabackup_info`
and mirrors them to the error log:

- **`backup_size`** (bytes) — final bytes the backup wrote to disk
  (or to the stream). Always reported.
- **`uncompressed_backup_size`** (bytes) — logical pre-compression
  bytes (data + redo + metadata + server-encrypted InnoDB files +
  RocksDB SSTs that skip the compressor). Reported only when
  `--compress` is used.

Both values are byte-perfect against the actual on-disk artifact for
every combination of `--compress{,-lz4,-zstd}` / `--encrypt` /
`--stream=xbstream` / `--extra-lsndir` / incremental / sparse.
Strict-equality asserts in `t/backup_size_basic.sh` and
`t/backup_size_compress.sh` cover 15+ scenarios end-to-end.

JIRA: https://perconadev.atlassian.net/browse/PXB-3747

## How to use this feature

No new flags or options — the behavior is enabled for every backup.

1. **Final backup size (`backup_size`)** — always present in
   `xtrabackup_info`, e.g.:

       backup_size = 129456789

   and logged:

       Backup size: 123.45 MiB (129456789 bytes)

2. **Uncompressed size under `--compress` (`uncompressed_backup_size`)** —
   added only when `--compress{,-lz4,-zstd}` is used:

       uncompressed_backup_size = 479123456

   along with two extra log lines:

       Uncompressed backup size: 456.78 MiB (479123456 bytes)
       Compression ratio: 3.70x

   This helps operators estimate the disk space required to extract
   a compressed backup before running `xbstream -x` /
   `xtrabackup --decompress`, and makes backups taken at different
   dates comparable regardless of compressibility.

3. **Where `xtrabackup_info` lives** — the copy inside the backup
   directory follows the transport the user picked: it is compressed
   under `--compress`, encrypted under `--encrypt`, and wrapped in
   the xbstream under `--stream=xbstream`. To always obtain an
   unencrypted, uncompressed copy of `xtrabackup_info`, pass
   `--extra-lsndir=<dir>` — the file written there is plaintext
   regardless of `--compress` / `--encrypt`.

4. **Error-log output** — the two (or three, under `--compress`)
   lines above appear at the end of the backup, just before the
   "completed OK!" banner.

## Commits

Split into two focused, bisect-friendly commits:

1. **`PXB-3747 : Report final on-disk backup_size in xtrabackup_info`**
   — adds `backup_size` with zero `--compress` awareness; includes
   the shared strict-size test infrastructure.
2. **`PXB-3747 : Report uncompressed_backup_size for --compress backups`**
   — adds `uncompressed_backup_size`, the "Uncompressed backup size"
   log line, and the "Compression ratio" log line, wired up only
   for `--compress` runs.

## Commit 1 design — `backup_size`

The datasink pipeline has exactly one authoritative component: the
**leaf**. Every byte that lands in the backup artifact passes
through `ds_local` / `ds_stdout` / `ds_fifo`. Wrapper datasinks
(encrypt, xbstream, buffer, tmpfile, compress) only transform and
forward bytes.

```
    ds_data (head)
         |  ds_write()
         v
    [ wrappers: xbstream / encrypt / compress / ... ]
         |  pipe_ctxt
         v
    leaf (ds_local | ds_stdout | ds_fifo)   authoritative byte count
         |
         v
    my_write() / fwrite()
```

Rather than adding one-off `get_foo()` vtable slots per metric, the
patch introduces a tiny per-datasink metrics API: each datasink
can publish named `{name, value}` pairs via an optional
`report_metrics` slot, and callers read one off a specific node
with `ds_find_metric`. The three leaves publish an atomic
`bytes_written` counter bumped on every successful write.
`get_final_backup_size()` walks to the leaf and reads it;
`backup_size = N` is written to `xtrabackup_info` and logged.

`Tablespace_map::serialize()` and the transition-key dumper are
moved ahead of `backup_finish()` so their bytes are included in
the reported `backup_size`.

## Commit 2 design — `uncompressed_backup_size`

### Why two data pipelines exist

xtrabackup maintains two top-level data pipelines because not
every file benefits from compression:

- **`ds_data`** — normal InnoDB tablespaces, redo, metadata.
  Compressed when `--compress` is on.
- **`ds_uncompressed_data`** — server-encrypted InnoDB tablespaces
  (re-compressing ciphertext is wasteful) and RocksDB SST files
  (already compressed internally). Bypasses the compress wrapper.

Both pipelines share their encrypt / xbstream / leaf tail as an
init-time context-sharing optimization:

```
    ds_data              --> buffer --> compress --> encrypt --> leaf
                                                                  ^
                                                                  |
    ds_uncompressed_data -----------------------> encrypt --------+
```

### Why the counter cannot live on any `ds_ctxt_t`

The shared tail makes "attach a counter to the ctxt" broken no
matter which ctxt is picked:

- **Leaf ctxt.** Under `--stream=xbstream`, `ds_data`, `ds_redo`,
  `ds_meta`, and `ds_uncompressed_data` all terminate at the same
  leaf. A leaf-ctxt counter would sum bytes from every pipeline,
  and for the compressed pipeline those bytes are post-compression
  — neither the logical total nor the on-disk total.
- **Encrypt / xbstream / buffer ctxts.** `ds_data` and
  `ds_uncompressed_data` share these too. Counting there mixes
  post-compression bytes (from `ds_data`) with raw bytes (from
  `ds_uncompressed_data`); the sum is meaningless.

### Per-file `ds_file_t` handle is the right anchor

The counter attaches where a single logical write unambiguously
enters exactly one pipeline — on the per-file handle returned by
the top-level `ds_open()`. Each top-level open creates a fresh
`ds_file_t`, the caller decides whether that file's bytes count,
and `ds_write` / `ds_write_sparse` bump the counter with the
length supplied at the entry, before any wrapper transforms it:

```
    xtrabackup top-level open
         |  ds_open_track_uncomp(..., xb_global_track_uncomp_bytes())
         |                             |
         |                             +-- nullptr when !--compress
         v
    ds_file_t { uncomp_bytes -> xb_uncomp_bytes_counter }
         |  ds_write(len) / ds_write_sparse(packed_len)
         |     if (file->uncomp_bytes) uncomp_bytes->add_uncompressed(len)
         v
    [ compress / encrypt / buffer / xbstream wrappers ]
         |
         v
    leaf  (already counted as backup_size by commit 1)

    xb_uncomp_bytes_counter.get_uncompressed_backup_size()
         |
         v
    uncompressed_backup_size  (xtrabackup_info + error log)
```

Tracking is opt-in and scoped to the top-level opens on `ds_data`
/ `ds_redo` / `ds_meta` / `ds_uncompressed_data`, so the hot-path
cost is one atomic add per write on `--compress` runs; non-compress
runs skip even that. The same counter aggregates both pipelines,
so server-encrypted IBDs and RocksDB SSTs are counted exactly
once, at their logical size.

`xb_global_track_uncomp_bytes()` returns a real counter only when
`--compress` is active, so non-compress runs emit neither the
field nor the log lines.

## Test plan

- **`t/backup_size_basic.sh`** — `--target-dir`, `--stream=xbstream`,
  `--encrypt` on both, incremental chains, sparse tablespaces, full
  restore round-trip. Every scenario asserts `backup_size` matches
  the on-disk / on-stream byte count exactly; `uncompressed_backup_size`
  must **not** be present.
- **`t/backup_size_compress.sh`** — `--compress` target-dir,
  `--compress` xbstream, `--compress` + `--encrypt`, incremental
  chains with compression, RocksDB, server-encrypted InnoDB,
  redo-log encryption, sparse + `--compress`, and `--extra-lsndir`.
  Every scenario asserts `backup_size` matches the compressed
  on-disk size and, after decompression, `uncompressed_backup_size`
  matches the decompressed tree size byte-for-byte.
- **`suites/reducedlock/backup_size_reduced.sh`** — reduced-lock
  + concurrent TRUNCATE edge case (zero-size tablespace).
- **`-s compression`** — 12/12 runnable tests pass; shared
  strict-size helpers live in `inc/common.sh`.
