### PR TITLE
PXB-3762: xtrabackup --backup --transition-key crashes when undo tablespace key exists in redo only

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -392,7 +392,7 @@ static dberr_t srv_undo_tablespace_read_encryption(pfs_os_file_t fh,
 
   if (found && recv_key->lsn >= page_lsn) {
     // Condition 1: Use key from redo if available and appropriate
-    encryption_success = use_dumped_tablespace_keys
+    encryption_success = (use_dumped_tablespace_keys && !srv_backup_mode)
                              ? load_key_from_dump()
                              : set_encryption(recv_key->ptr, recv_key->iv);
   } else if (is_enc) {


### PR DESCRIPTION
## Summary

Fix assertion `ut_a(found)` in `xb_set_encryption()` during
`xtrabackup --backup --transition-key=...`.

JIRA URL: https://perconadev.atlassian.net/browse/PXB-3762

## Background: what the keys map is for

xtrabackup uses one in-memory map (`encryption_info`) in two phases:

* **`--backup` - producer.** Keys seen in redo are *inserted* into the
  map and written out to `xtrabackup_keys` at end-of-backup.
* **`--prepare` - consumer.** `xtrabackup_keys` is *loaded* back into
  the map and looked up via `xb_fetch_tablespace_key()` to install
  encryption on each tablespace.

`xb_set_encryption()` is therefore a prepare-only helper. Calling it
during backup is wrong by design,  the map is still being filled, so
the lookup must fail.

## Root cause

`srv_undo_tablespace_read_encryption()` has three branches for loading
the undo tablespace key. Condition 2 correctly gates the prepare-only
path with `(use_dumped_tablespace_keys && !srv_backup_mode)`.
Condition 1 (redo holds a key newer than the on-disk undo page) is
missing the `!srv_backup_mode` half of that guard.

`--transition-key` sets `use_dumped_tablespace_keys = true` in both
backup and prepare. So during `--backup`, when redo contains a recent
master-key-rotation entry for the undo space, Condition 1 takes the
prepare-only path, the lookup finds nothing, and `ut_a(found)` fires.

## Fix

Mirror Condition 2's guard in Condition 1: only take the dump-load
path when `!srv_backup_mode`. During backup we now use the key we
already have right there in `recv_key` — which is also exactly what
we want, because backup's job is just to collect that key into the
map for later dumping.
