### PR TITLE
PXB-3568 : xtrabackup crashes on RHEL9 with --compress=lz4

### DIFF
--- a/storage/innobase/xtrabackup/src/ds_compress.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress.cc
@@ -41,21 +41,21 @@ typedef struct {
   size_t to_size;
   uint32_t adler;
   qlz_state_compress state;
-} comp_thread_ctxt_t;
+} qpress_thread_ctxt_t;
 
 typedef struct {
   Thread_pool *thread_pool;
-} ds_compress_ctxt_t;
+} qpress_compress_ctxt_t;
 
 typedef struct {
   ds_file_t *dest_file;
-  ds_compress_ctxt_t *comp_ctxt;
+  qpress_compress_ctxt_t *comp_ctxt;
   size_t bytes_processed;
   char *comp_buf;
   size_t comp_buf_size;
   std::vector<std::future<void>> tasks;
-  std::vector<comp_thread_ctxt_t> contexts;
-} ds_compress_file_t;
+  std::vector<qpress_thread_ctxt_t> contexts;
+} qpress_compress_file_t;
 
 /* Compression options */
 extern char *xtrabackup_compress_alg;
@@ -77,7 +77,7 @@ static inline int write_uint32_le(ds_file_t *file, uint32_t n);
 static inline int write_uint64_le(ds_file_t *file, ulonglong n);
 
 static ds_ctxt_t *compress_init(const char *root) {
-  ds_compress_ctxt_t *compress_ctxt = new ds_compress_ctxt_t;
+  qpress_compress_ctxt_t *compress_ctxt = new qpress_compress_ctxt_t;
   compress_ctxt->thread_pool = new Thread_pool(xtrabackup_compress_threads);
 
   ds_ctxt_t *ctxt = new ds_ctxt_t;
@@ -92,7 +92,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
   xb_ad(ctxt->pipe_ctxt != nullptr);
   ds_ctxt_t *dest_ctxt = ctxt->pipe_ctxt;
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  qpress_compress_ctxt_t *comp_ctxt = (qpress_compress_ctxt_t *)ctxt->ptr;
 
   /* Append the .qp extension to the filename */
   char new_name[FN_REFLEN];
@@ -103,7 +103,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
     return nullptr;
   }
 
-  ds_compress_file_t *comp_file = new ds_compress_file_t;
+  qpress_compress_file_t *comp_file = new qpress_compress_file_t;
   comp_file->dest_file = dest_file;
   comp_file->comp_ctxt = comp_ctxt;
   comp_file->bytes_processed = 0;
@@ -139,8 +139,8 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
 }
 
 static int compress_write(ds_file_t *file, const void *buf, size_t len) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
-  ds_compress_ctxt_t *comp_ctxt = comp_file->comp_ctxt;
+  qpress_compress_file_t *comp_file = (qpress_compress_file_t *)file->ptr;
+  qpress_compress_ctxt_t *comp_ctxt = comp_file->comp_ctxt;
   ds_file_t *dest_file = comp_file->dest_file;
 
   /* make sure we have enough memory for compression */
@@ -229,7 +229,7 @@ err:
 }
 
 static int compress_close(ds_file_t *file) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
+  qpress_compress_file_t *comp_file = (qpress_compress_file_t *)file->ptr;
   ds_file_t *dest_file = comp_file->dest_file;
 
   /* Write the qpress file trailer */
@@ -253,7 +253,7 @@ static int compress_close(ds_file_t *file) {
 static void compress_deinit(ds_ctxt_t *ctxt) {
   xb_ad(ctxt->pipe_ctxt != nullptr);
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  qpress_compress_ctxt_t *comp_ctxt = (qpress_compress_ctxt_t *)ctxt->ptr;
 
   delete comp_ctxt->thread_pool;
   delete comp_ctxt;

--- a/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_lz4.cc
@@ -41,21 +41,21 @@ typedef struct {
   char *to;
   size_t to_len;
   size_t to_size;
-} comp_thread_ctxt_t;
+} lz4_thread_ctxt_t;
 
 typedef struct {
   Thread_pool *thread_pool;
-} ds_compress_ctxt_t;
+} lz4_compress_ctxt_t;
 
 typedef struct {
   ds_file_t *dest_file;
-  ds_compress_ctxt_t *comp_ctxt;
+  lz4_compress_ctxt_t *comp_ctxt;
   size_t bytes_processed;
   char *comp_buf;
   size_t comp_buf_size;
   std::vector<std::future<void>> tasks;
-  std::vector<comp_thread_ctxt_t> contexts;
-} ds_compress_file_t;
+  std::vector<lz4_thread_ctxt_t> contexts;
+} lz4_compress_file_t;
 
 /* Compression options */
 extern char *xtrabackup_compress_alg;
@@ -76,7 +76,7 @@ datasink_t datasink_compress_lz4 = {&compress_init,  &compress_open,
 static inline int write_uint32_le(ds_file_t *file, uint32_t n);
 
 static ds_ctxt_t *compress_init(const char *root) {
-  ds_compress_ctxt_t *compress_ctxt = new ds_compress_ctxt_t;
+  lz4_compress_ctxt_t *compress_ctxt = new lz4_compress_ctxt_t;
   compress_ctxt->thread_pool = new Thread_pool(xtrabackup_compress_threads);
 
   ds_ctxt_t *ctxt = new ds_ctxt_t;
@@ -93,7 +93,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
   xb_ad(ctxt->pipe_ctxt != nullptr);
   ds_ctxt_t *dest_ctxt = ctxt->pipe_ctxt;
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  lz4_compress_ctxt_t *comp_ctxt = (lz4_compress_ctxt_t *)ctxt->ptr;
 
   /* Append the .lz4 extension to the filename */
   fn_format(new_name, path, "", ".lz4", MYF(MY_APPEND_EXT));
@@ -103,7 +103,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
     return nullptr;
   }
 
-  ds_compress_file_t *comp_file = new ds_compress_file_t;
+  lz4_compress_file_t *comp_file = new lz4_compress_file_t;
   comp_file->dest_file = dest_file;
   comp_file->comp_ctxt = comp_ctxt;
   comp_file->bytes_processed = 0;
@@ -118,8 +118,8 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
 }
 
 static int compress_write(ds_file_t *file, const void *buf, size_t len) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
-  ds_compress_ctxt_t *comp_ctxt = comp_file->comp_ctxt;
+  lz4_compress_file_t *comp_file = (lz4_compress_file_t *)file->ptr;
+  lz4_compress_ctxt_t *comp_ctxt = comp_file->comp_ctxt;
   ds_file_t *dest_file = comp_file->dest_file;
 
   /* make sure we have enough memory for compression */
@@ -275,7 +275,7 @@ err:
 }
 
 static int compress_close(ds_file_t *file) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
+  lz4_compress_file_t *comp_file = (lz4_compress_file_t *)file->ptr;
   ds_file_t *dest_file = comp_file->dest_file;
 
   int rc = ds_close(dest_file);
@@ -290,7 +290,7 @@ static int compress_close(ds_file_t *file) {
 static void compress_deinit(ds_ctxt_t *ctxt) {
   xb_ad(ctxt->pipe_ctxt != nullptr);
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  lz4_compress_ctxt_t *comp_ctxt = (lz4_compress_ctxt_t *)ctxt->ptr;
 
   delete comp_ctxt->thread_pool;
   delete comp_ctxt;

--- a/storage/innobase/xtrabackup/src/ds_compress_zstd.cc
+++ b/storage/innobase/xtrabackup/src/ds_compress_zstd.cc
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 
 typedef struct {
   ZSTD_threadPool *thread_pool;
-} ds_compress_ctxt_t;
+} zstd_compress_ctxt_t;
 
 typedef struct {
   ds_file_t *dest_file;
@@ -38,7 +38,7 @@ typedef struct {
   size_t raw_bytes;
   size_t comp_bytes;
   ZSTD_CCtx *cctx;
-} ds_compress_file_t;
+} zstd_compress_file_t;
 
 /* Compression options */
 extern char *xtrabackup_compress_alg;
@@ -57,7 +57,7 @@ datasink_t datasink_compress_zstd = {&compress_init,  &compress_open,
                                      &compress_close, &compress_deinit};
 
 static ds_ctxt_t *compress_init(const char *root) {
-  ds_compress_ctxt_t *compress_ctxt = new ds_compress_ctxt_t;
+  zstd_compress_ctxt_t *compress_ctxt = new zstd_compress_ctxt_t;
   compress_ctxt->thread_pool =
       ZSTD_createThreadPool(xtrabackup_compress_threads);
 
@@ -75,7 +75,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
   xb_ad(ctxt->pipe_ctxt != nullptr);
   ds_ctxt_t *dest_ctxt = ctxt->pipe_ctxt;
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  zstd_compress_ctxt_t *comp_ctxt = (zstd_compress_ctxt_t *)ctxt->ptr;
 
   /* Append the .zst extension to the filename */
   fn_format(new_name, path, "", ".zst", MYF(MY_APPEND_EXT));
@@ -85,7 +85,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
     return nullptr;
   }
 
-  ds_compress_file_t *comp_file = new ds_compress_file_t;
+  zstd_compress_file_t *comp_file = new zstd_compress_file_t;
   comp_file->dest_file = dest_file;
   comp_file->comp_buf = nullptr;
   comp_file->comp_buf_size = 0;
@@ -108,7 +108,7 @@ static ds_file_t *compress_open(ds_ctxt_t *ctxt, const char *path,
 }
 
 static int compress_write(ds_file_t *file, const void *buf, size_t len) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
+  zstd_compress_file_t *comp_file = (zstd_compress_file_t *)file->ptr;
   ds_file_t *dest_file = comp_file->dest_file;
 
   /* make sure we have enough memory for compression */
@@ -174,7 +174,7 @@ err:
 }
 
 static int compress_close(ds_file_t *file) {
-  ds_compress_file_t *comp_file = (ds_compress_file_t *)file->ptr;
+  zstd_compress_file_t *comp_file = (zstd_compress_file_t *)file->ptr;
   ds_file_t *dest_file = comp_file->dest_file;
 
   ZSTD_freeCCtx(comp_file->cctx);
@@ -191,7 +191,7 @@ static int compress_close(ds_file_t *file) {
 static void compress_deinit(ds_ctxt_t *ctxt) {
   xb_ad(ctxt->pipe_ctxt != nullptr);
 
-  ds_compress_ctxt_t *comp_ctxt = (ds_compress_ctxt_t *)ctxt->ptr;
+  zstd_compress_ctxt_t *comp_ctxt = (zstd_compress_ctxt_t *)ctxt->ptr;
 
   ZSTD_freeThreadPool(comp_ctxt->thread_pool);
   delete comp_ctxt;


### PR DESCRIPTION
JIRA URL: https://perconadev.atlassian.net/browse/PXB-3568

Problem:
xtrabackup crashes with SIGABRT (Signal 6) during a backup with --compress=lz4 on EL9-based images (RHEL 9, OracleLinux 9, Rocky 9) when the database is under concurrent write load. The crash also manifests as an SST failure in PXC clusters running PXC 8.0.42 and 8.0.45 Docker images. Without _GLIBCXX_ASSERTIONS the same condition silently corrupts heap memory instead of aborting.

Analysis:
The three compression datasinks - ds_compress.cc (qpress), ds_compress_lz4.cc, and ds_compress_zstd.cc - each defined structs named comp_thread_ctxt_t, ds_compress_ctxt_t, and ds_compress_file_t with different layouts. This violates the C++ One Definition Rule (ODR), which says a named type must have the same definition in every translation unit that references it.

Without LTO, every translation unit was compiled independently and saw only its own local definition, so no conflict surfaced at runtime. With LTO, GCC merges all translation units into a single intermediate representation at link time, detects the same-named structs with different layouts, picks one as canonical, and uses it for code generation across all callers.

GCC picked the qpress version of comp_thread_ctxt_t, which embeds a qlz_state_compress hash table and is 36920 bytes (0x9038). The LZ4 version is 40 bytes (0x28). As a result, the LZ4 compress_write() emitted the qpress 36920-byte stride when indexing its std::vector<comp_thread_ctxt_t>:

  imul $0x9038, %r12, %rax   ; per-element stride: WRONG (should be 0x28)

On the second iteration of the loop, the wrong stride produced an out-of-bounds offset, which tripped the std::vector::operator[] bounds-check assertion enabled by _GLIBCXX_ASSERTIONS (default on EL9 via redhat-rpm-config) and aborted.

GCC was already emitting -Wodr warnings flagging these exact structs in every build, but they were missed amid the build log noise.

Fix:
Rename the file-local types in each compression datasink with a compressor-specific prefix so every translation unit has a unique type identity, eliminating the ODR violation:

  ds_compress.cc (qpress): comp_thread_ctxt_t -> qpress_thread_ctxt_t
                           ds_compress_ctxt_t -> qpress_compress_ctxt_t
                           ds_compress_file_t -> qpress_compress_file_t
  ds_compress_lz4.cc     : comp_thread_ctxt_t -> lz4_thread_ctxt_t
                           ds_compress_ctxt_t -> lz4_compress_ctxt_t
                           ds_compress_file_t -> lz4_compress_file_t
  ds_compress_zstd.cc    : ds_compress_ctxt_t -> zstd_compress_ctxt_t
                           ds_compress_file_t -> zstd_compress_file_t

After the rename:
 * The three -Wodr warnings for these types are gone from the build.
 * LZ4 compress_write uses the correct $0x28 (40) stride.
 * qpress compress_write uses $0x9038 (36920), which is also correct because qpress's struct really is that size.
 * Full backup + decompress + --prepare + --copy-back + live SELECT round-trip passes on Ubuntu 22.04 and OracleLinux 9 with GCC 12.3
   + LTO + _GLIBCXX_ASSERTIONS.