### PR TITLE
PXB-3759 : xtrabackup crashes if server uses redo log encryption and

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -698,7 +698,7 @@ bool Redo_Log_Parser::parse_log(const byte *buf, size_t len, lsn_t start_lsn) {
 
 Redo_Log_Writer::Redo_Log_Writer() {
   scratch_buf.alloc_withkey(UT_NEW_THIS_FILE_PSI_KEY,
-                            ut::Count{16 * 1024 * 1024});
+                            ut::Count{redo_log_read_buffer_size});
 }
 
 bool Redo_Log_Writer::create_logfile(const char *name) {
@@ -745,6 +745,11 @@ bool Redo_Log_Writer::write_buffer(byte *buf, size_t len) {
   byte *write_buf = buf;
 
   if (srv_redo_log_encrypt) {
+    /* encrypt_log writes len bytes into scratch_buf with no
+    release-build bounds check on dst. Guard against any future drift
+    between the read buffer size and the scratch buffer size. */
+    ut_a(len <= redo_log_read_buffer_size);
+
     IORequest req_type(IORequest::WRITE);
     req_type.get_encryption_info().set(log_sys->m_encryption_metadata);
     ut_ad(req_type.is_encrypted());

--- a/storage/innobase/xtrabackup/test/suites/keyring/pxb-3759.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/pxb-3759.sh
@@ -1,0 +1,91 @@
+#
+# PXB-3759: xtrabackup crashes with SIGSEGV at end of backup when server-side
+# redo log encryption is enabled and innodb_log_buffer_size > 32 MiB.
+#
+# Root cause: Redo_Log_Writer::scratch_buf is hardcoded to 16 MiB while the
+# source buffer scales with innodb_log_buffer_size / 2. When the log copy
+# thread reads more than 16 MiB of redo and the encrypt branch is taken,
+# Encryption::encrypt_log writes past scratch_buf, clobbering adjacent heap
+# allocations. The crash typically surfaces during destructor cleanup of
+# Redo_Log_Reader's aligned buffers whose PFS metadata was overwritten.
+#
+# Trigger: keyring + innodb_redo_log_encrypt=ON + innodb_log_buffer_size=64M
+# plus enough pending redo at backup time to push a single read_logfile()
+# call above 16 MiB.
+#
+
+require_debug_pxb_version
+
+KEYRING_TYPE="component"
+. inc/keyring_common.sh
+. inc/keyring_file.sh
+
+# keyring_common.sh sets MYSQLD_EXTRA_MY_CNF_OPTS at source time, overwriting
+# anything set above. Append our options after sourcing so they survive.
+MYSQLD_EXTRA_MY_CNF_OPTS="${MYSQLD_EXTRA_MY_CNF_OPTS}
+innodb_log_buffer_size=64M
+"
+
+configure_server_with_component
+
+mysql -e "CREATE TABLE pxb_3759 (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  payload LONGBLOB
+) ENGINE=InnoDB" test
+
+mysql test <<'EOF'
+DROP PROCEDURE IF EXISTS pxb_3759_load;
+DELIMITER //
+CREATE PROCEDURE pxb_3759_load(IN n INT)
+BEGIN
+  DECLARE i INT DEFAULT 0;
+  WHILE i < n DO
+    INSERT INTO pxb_3759 (payload) VALUES (REPEAT('a', 1024 * 1024));
+    SET i = i + 1;
+  END WHILE;
+END//
+DELIMITER ;
+EOF
+
+innodb_wait_for_flush_all
+
+mkdir $topdir/backup
+
+vlog "starting backup paused after redo catchup"
+xtrabackup --backup --target-dir=$topdir/backup \
+           --debug-sync="xtrabackup_pause_after_redo_catchup" \
+           2> >(tee $topdir/backup.log) &
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+vlog "piling up >16 MiB of redo while xtrabackup is paused"
+mysql -e "CALL pxb_3759_load(64)" test
+
+vlog "resuming xtrabackup"
+kill -SIGCONT $xb_pid
+
+run_cmd wait $job_pid
+
+if grep -qE "signal 11|SIGSEGV|signal 6|SIGABRT|Assertion failure" $topdir/backup.log ; then
+    die "xtrabackup crashed (PXB-3759 reproduced)"
+fi
+
+record_db_state test
+
+xtrabackup --prepare --target-dir=$topdir/backup \
+  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+
+stop_server
+
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+
+cp ${instance_local_manifest} $mysql_datadir
+cp ${keyring_component_cnf} $mysql_datadir
+
+start_server
+
+verify_db_state test


### PR DESCRIPTION
innodb_log_buffer_size > 16MB

https://perconadev.atlassian.net/browse/PXB-3759

Problem
=======

xtrabackup crashes with SIGSEGV at end of backup when the source server has innodb_redo_log_encrypt=ON and innodb_log_buffer_size
> 32 MiB.

Analysis
========

Redo_Log_Writer::scratch_buf is hardcoded to 16 MiB, while the matching source buffer scales with srv_log_buffer_size / 2. With innodb_log_buffer_size=64M a single write_buffer() call may pass 32 MiB to Encryption::encrypt_log(), which copies that many bytes into scratch_buf without bounds-checking the destination. The overflow corrupts adjacent heap allocations; the crash typically surfaces later when freeing an allocation whose PFS metadata header was corrupted.

Fix
===

Size scratch_buf to redo_log_read_buffer_size so it always matches the largest len write_buffer() can receive. Add a release-build assertion against the same bound to prevent future drift between the two sizes.

Add suites/keyring/pxb-3759.sh as a regression test. It uses the xtrabackup_pause_after_redo_catchup debug-sync to deterministically build up >16 MiB of pending redo before resuming the backup.