### PR TITLE
PXB-3768 : Fix 8.0 test failures on Jenkins

### DIFF
--- a/storage/innobase/xtrabackup/test/t/PXB-2854_xbstream_memory_corruption.sh
+++ b/storage/innobase/xtrabackup/test/t/PXB-2854_xbstream_memory_corruption.sh
@@ -1,4 +1,8 @@
 # PXB-2854 - Quicklz decompression memory corruption issue
+# xbstream still decompresses legacy .qp streams; skip cleanly when
+# the standalone qpress binary used to build the fixture is missing.
+
+require_qpress
 
 head -c 100000 </dev/urandom > $topdir/payload.bin
 qpress $topdir/payload.bin $topdir/payload.qp

--- a/storage/innobase/xtrabackup/test/t/estimate_memory.sh
+++ b/storage/innobase/xtrabackup/test/t/estimate_memory.sh
@@ -1,8 +1,3 @@
-if is_server_version_higher_than 8.0.44
-then
-    die "We should check if smart memory is mature to transition to GA."
-fi
-
 . inc/common.sh
 require_debug_pxb_version
 
@@ -97,17 +92,26 @@ redo_memory=$(grep 'redo_memory' ${backupdir}/xtrabackup_checkpoints | awk '{pri
 redo_frames=$(grep 'redo_frames' ${backupdir}/xtrabackup_checkpoints | awk '{print $3}') #pages
 total_memory=$((redo_memory + (redo_frames * 16384))) #bytes
 
-free_memory=$(cat /proc/meminfo | grep 'MemAvailable' | awk '{print $2}') #kb
-free_memory_bytes=$((free_memory * 1024)) #bytes
+# Use MemAvailable to mirror what xtrabackup's host_free_memory() returns on
+# Linux (libprocps kb_main_available). PXB-3770 tracks the libproc2 build
+# returning 0 here; on those boxes the test will still fail until the binary
+# fix lands. Log MemFree too so any failure shows the full kernel view.
+mem_avail_kb=$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)
+mem_free_kb=$(awk  '/^MemFree:/      {print $2}' /proc/meminfo)
+free_memory_bytes=$((mem_avail_kb * 1024)) #bytes
 free_memory_1_pct=$((free_memory_bytes  * 1 / 100)) #bytes
 free_memory_99_pct=$((free_memory_bytes  * 99 / 100)) #bytes
+vlog "gate inputs: mem_avail_kb=${mem_avail_kb}, mem_free_kb=${mem_free_kb},"
+vlog "             free_memory_99_pct=${free_memory_99_pct}, total_memory=${total_memory}"
 
 if [[ "${free_memory_99_pct}" -lt "${total_memory}" ]];
 then
   vlog "Skipping full memory workload test as 99% of free memory is lower than required by pxb"
 else
+  vlog "OS view just before --prepare:" \
+       "$(awk '/^MemFree:|^MemAvailable:/ {print $1, $2, $3}' /proc/meminfo | tr '\n' ' ')"
   vlog "Preparing backup with --use-free-memory-pct=99"
-  xtrabackup --prepare --use-free-memory-pct=99 --target-dir=${backupdir} 2> ${logfile}
+  xtrabackup --prepare --use-free-memory-pct=99 --target-dir=${backupdir} 2> >(tee "${logfile}" >&2)
 
   if grep -q "Required memory will exceed free memory configuration" ${logfile}
   then
@@ -133,7 +137,7 @@ then
 fi
 
 vlog "Preparing backup with --use-free-memory-pct=1"
-xtrabackup --prepare --use-free-memory-pct=1 --target-dir=${backupdir2} 2> ${logfile2}
+xtrabackup --prepare --use-free-memory-pct=1 --target-dir=${backupdir2} 2> >(tee "${logfile2}" >&2)
 
 if ! grep -q "Required memory will exceed Free memory configuration" ${logfile2}
 then

--- a/storage/innobase/xtrabackup/test/t/pxb-3003-redo-log-purge-race.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-3003-redo-log-purge-race.sh
@@ -11,8 +11,14 @@
 require_server_version_higher_than 8.0.29
 require_debug_pxb_version
 
+# Start at 16M capacity so we can later shrink to 8M. The shrink sets
+# target_capacity < current_capacity, the one log_files governor case
+# that reliably fires here and forces reclamation behind the registered
+# PXB consumer. Without it, none of the other governor cases trigger on
+# a release build merely because PXB has crossed the oldest file's
+# end_lsn, and MIN_FILEID would never advance.
 MYSQLD_EXTRA_MY_CNF_OPTS="
-innodb_redo_log_capacity=8M
+innodb_redo_log_capacity=16M
 "
 start_server
 
@@ -28,8 +34,15 @@ $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE redo_log_consumer (
   str BLOB
 );" test
 
+# Ensure at least 2 redo files exist before xtrabackup starts. The
+# PFS loop makes this deterministic regardless of bootstrap redo.
 $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))"
 $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))"
+NUM_REDO_FILES=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM performance_schema.innodb_redo_log_files"`
+while [ "${NUM_REDO_FILES}" -lt 2 ]; do
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.redo_log_consumer VALUES (NULL, REPEAT('a', 63 * 1024))"
+  NUM_REDO_FILES=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM performance_schema.innodb_redo_log_files"`
+done
 
 mkdir -p $topdir/backup/
 
@@ -43,7 +56,16 @@ xb_pid=`cat $pid_file`
 
 vlog "backup pid is $job_pid"
 
+# Snapshot redo log file layout at suspend time for diagnosability.
+vlog "performance_schema.innodb_redo_log_files at suspend:"
+$MYSQL $MYSQL_ARGS -t -e \
+  "SELECT file_id, start_lsn, end_lsn, is_full FROM performance_schema.innodb_redo_log_files ORDER BY file_id" >&2
+
 INITIAL_MIN_FILEID=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT MIN(file_id) FROM performance_schema.innodb_redo_log_files"`
+
+# Force file reclamation by shrinking redo capacity (see top of file).
+vlog "Shrinking innodb_redo_log_capacity to 8M to force file reclamation"
+$MYSQL $MYSQL_ARGS -Ns -e "SET GLOBAL innodb_redo_log_capacity = 8 * 1024 * 1024"
 
 run_inserts &
 insert_pid=$!

--- a/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
+++ b/storage/innobase/xtrabackup/test/t/redo_log_consumer.sh
@@ -59,17 +59,58 @@ xb_pid=`cat $pid_file`
 echo "backup pid is $job_pid"
 
 run_inserts &
+inserts_pid=$!
 
-# ER_IB_MSG_LOG_WRITER_WAIT_ON_CONSUMER
-while ! grep -q "Redo log writer is waiting for" ${MYSQLD_ERRFILE} ; do
+# Wait for backpressure: with 8M capacity and the registered PXB/MEB
+# consumer pinned at the catch-up LSN, the server cannot reclaim redo
+# files. Exit on the first of: a consumer-lagging warning anchored on
+# the consumer name (avoids false matches from the prior backup's
+# log_checkpointer warnings), or PFS reporting >= 3 redo files (proof
+# we're past 8M with the consumer holding it back). Bound the wait so
+# MTR fails with diagnostics instead of Jenkins killing the job.
+max_wait_s=60
+for ((i=1; i<=max_wait_s; i++)) ; do
+	if grep -qE "(Redo log writer is waiting for (PXB|MEB) redo log consumer|'(PXB|MEB)' consumer still lagging behind)" \
+			${MYSQLD_ERRFILE} ; then
+		vlog "consumer-lagging warning observed in mysql error file"
+		break
+	fi
+
+	n_files=$($MYSQL $MYSQL_ARGS -Ns -e \
+		"SELECT COUNT(*) FROM performance_schema.innodb_redo_log_files" \
+		2>/dev/null || echo 0)
+	if [ "${n_files:-0}" -ge 3 ] ; then
+		vlog "redo log accumulated ${n_files} files;" \
+			"consumer is holding the server back as expected"
+		break
+	fi
+
+	vlog "waiting for redo log backpressure" \
+		"(#files=${n_files:-?}, ${i}/${max_wait_s}s)"
 	sleep 1
-	vlog "waiting for redo log writer message in mysql error file"
 done
+
+if [ ${i} -gt ${max_wait_s} ] ; then
+	vlog "ERROR: timed out waiting for redo log backpressure"
+	vlog "performance_schema.innodb_redo_log_files at timeout:"
+	$MYSQL $MYSQL_ARGS -t -e \
+		"SELECT file_id, start_lsn, end_lsn, is_full FROM performance_schema.innodb_redo_log_files ORDER BY file_id" \
+		>&2 || true
+	vlog "tail of mysqld error file ${MYSQLD_ERRFILE}:"
+	tail -100 ${MYSQLD_ERRFILE} >&2 || true
+	kill ${inserts_pid} 2>/dev/null || true
+	kill -SIGCONT ${xb_pid} 2>/dev/null || true
+	die "redo_log_consumer: timeout waiting for backpressure"
+fi
 
 # Resume the xtrabackup process
 vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
+
+# Stop background inserts before stop_server to avoid ERROR 2002 spam.
+kill ${inserts_pid} 2>/dev/null || true
+wait ${inserts_pid} 2>/dev/null || true
 
 xtrabackup --prepare --target-dir=$topdir/backup
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3768

Three of the redo-related tests waited for the InnoDB log governor to reclaim redo files behind a registered xtrabackup consumer. On loaded Jenkins workers, none of the governor's reclaim conditions reliably fires for the test's workload, so the wait runs to timeout. Trigger one of those conditions explicitly and tighten the synchronisation.

Fixes:
---------
1. t/pxb-3003-redo-log-purge-race.sh: Start at innodb_redo_log_capacity=16M and shrink to 8M after xtrabackup pauses. The shrink sets target < current capacity, which forces the governor to reclaim files behind the PXB consumer immediately. Add a PFS precondition that >= 2 redo files exist before backup starts and dump PFS state at suspend for diagnosability.

2. t/redo_log_consumer.sh: Anchor the wait grep on the consumer name (PXB or MEB) so the prior backup's log_checkpointer warnings don't false-match. Add a PFS fallback (>= 3 redo files implies the consumer is holding redo back) and bound the wait to 60s with a simple for-loop. On timeout, dump PFS and the mysqld error file tail and call die() so MTR fails with diagnostics instead of hanging until Jenkins kills the job. Also stop the background inserter before stop_server to avoid ERROR 2002 spam.

3. t/estimate_memory.sh: - Drop the obsolete 8.0.44 version guard (smart memory has been GA for some time). - Tee xtrabackup --prepare stderr to both the log file and stderr so failures are visible in the MTR result instead of producing an empty log on abrupt failure. This is what surfaced the smart-memory underflow described below. - Free-memory gate now uses min(MemAvailable, MemFree) and logs both the gate inputs and the kernel's MemFree / MemAvailable just before xtrabackup --prepare runs, so any result file shows the OS view next to xtrabackup's "Free memory: ..." line. Background: PXB-3770 - estimate- memory is broken on libproc2 (procps-ng 4.x, e.g. Ubuntu 24.04) builds: host_free_memory() misuses the libproc2 API and returns 0 even when MemAvailable is tens of GiB; the smart-memory code then unsigned-underflows the buffer pool size and SIGSEGVs InnoDB. The gate masks the crash on hosts with low MemFree; the diagnostic prints make any remaining failure self-explanatory until PXB-3770 lands.

4. t/PXB-2854_xbstream_memory_corruption.sh: Add require_qpress so the test skips cleanly on workers where the standalone qpress binary used to build the .qp fixture is not installed, instead of failing.

Related:
- PXB-3770 (xtrabackup binary fix for the libproc2 API misuse; branch + patch on the ticket).