### PR TITLE
PXB-3818: Fix reduced-lock DDL handling

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -11254,6 +11254,11 @@ const byte *fil_tablespace_redo_encryption(const byte *ptr, const byte *end,
   to pupulate space encryption info once it is loaded. */
   DBUG_EXECUTE_IF("dont_update_key_found_during_REDO_scan", return ptr;);
 
+  /* recv_sys->keys is read by other threads (e.g. recv_find_encryption_key)
+  under recv_sys->mutex. Hold the mutex while mutating the vector so that a
+  reallocation triggered by push_back() cannot race with those readers. */
+  mutex_enter(&recv_sys->mutex);
+
   if (recv_sys->keys == nullptr) {
     recv_sys->keys =
         ut::new_withkey<recv_sys_t::Encryption_Keys>(UT_NEW_THIS_FILE_PSI_KEY);
@@ -11284,6 +11289,8 @@ const byte *fil_tablespace_redo_encryption(const byte *ptr, const byte *end,
     new_key.lsn = lsn;
     recv_sys->keys->push_back(new_key);
   }
+
+  mutex_exit(&recv_sys->mutex);
 
   if (space != nullptr) {
     Encryption::set_or_generate(Encryption::AES, key, iv,

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -674,12 +674,16 @@ dberr_t Datafile::validate_first_page(space_id_t space_id, lsn_t *flush_lsn,
       bool found = false;
 
       if (srv_backup_mode) {
-        recv_sys_t::Encryption_Key *recv_key = nullptr;
-        std::tie(found, recv_key) = recv_find_encryption_key(m_space_id);
+        byte recv_key[Encryption::KEY_LEN];
+        byte recv_iv[Encryption::KEY_LEN];
+        lsn_t recv_key_lsn = 0;
+        found =
+            recv_find_encryption_key(m_space_id, recv_key, recv_iv,
+                                     &recv_key_lsn);
 
         if (found) {
-          memcpy(m_encryption_key, recv_key->ptr, Encryption::KEY_LEN);
-          memcpy(m_encryption_iv, recv_key->iv, Encryption::KEY_LEN);
+          memcpy(m_encryption_key, recv_key, Encryption::KEY_LEN);
+          memcpy(m_encryption_iv, recv_iv, Encryption::KEY_LEN);
         }
       }
 

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -796,8 +796,17 @@ bool recv_sys_resize_buf();
 hash table to wait merging to file pages. */
 void recv_parse_log_recs();
 
-std::tuple<bool, recv_sys_t::Encryption_Key *> recv_find_encryption_key(
-    space_id_t space_id);
+/** Find the encryption key for a tablespace discovered during redo scanning.
+The key/iv material is copied into the caller-provided buffers while holding
+recv_sys->mutex, so the result stays valid even if the redo scan thread
+concurrently appends to recv_sys->keys and reallocates the vector.
+@param[in]   space_id  tablespace ID to look up
+@param[out]  key       buffer of Encryption::KEY_LEN bytes for the key
+@param[out]  iv        buffer of Encryption::KEY_LEN bytes for the iv
+@param[out]  lsn       LSN of the redo encryption entry
+@return true if a key entry was found */
+bool recv_find_encryption_key(space_id_t space_id, byte *key, byte *iv,
+                              lsn_t *lsn);
 
 #include "log0recv.ic"
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -4721,19 +4721,28 @@ const char *get_mlog_string(mlog_id_t type) {
 }
 #endif /* UNIV_DEBUG || UNIV_HOTBACKUP */
 
-std::tuple<bool, recv_sys_t::Encryption_Key *> recv_find_encryption_key(
-    space_id_t space_id) {
+bool recv_find_encryption_key(space_id_t space_id, byte *key, byte *iv,
+                              lsn_t *lsn) {
   if (recv_sys == nullptr || recv_sys->keys == nullptr) {
-    return {false, nullptr};
+    return false;
   }
 
+  bool found = false;
+
+  /* Copy the key material out while holding the mutex. Returning a pointer
+  into recv_sys->keys is unsafe because a concurrent append on the redo scan
+  thread may reallocate the vector and invalidate the element address. */
   mutex_enter(&recv_sys->mutex);
   for (auto &recv_key : *recv_sys->keys) {
     if (recv_key.space_id == space_id) {
-      mutex_exit(&recv_sys->mutex);
-      return {true, &recv_key};
+      memcpy(key, recv_key.ptr, Encryption::KEY_LEN);
+      memcpy(iv, recv_key.iv, Encryption::KEY_LEN);
+      *lsn = recv_key.lsn;
+      found = true;
+      break;
     }
   }
   mutex_exit(&recv_sys->mutex);
-  return {false, nullptr};
+
+  return found;
 }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -357,7 +357,11 @@ static dberr_t srv_undo_tablespace_read_encryption(pfs_os_file_t fh,
   offset = fsp_header_get_encryption_offset(space_page_size);
   ut_ad(offset);
 
-  auto [found, recv_key] = recv_find_encryption_key(space->id);
+  byte recv_key[Encryption::KEY_LEN];
+  byte recv_iv[Encryption::KEY_LEN];
+  lsn_t recv_key_lsn = 0;
+  bool found = recv_find_encryption_key(space->id, recv_key, recv_iv,
+                                        &recv_key_lsn);
 
   bool is_enc = Encryption::is_encrypted_with_v3(first_page + offset);
   lsn_t page_lsn = mach_read_from_8(first_page + FIL_PAGE_LSN);
@@ -390,11 +394,11 @@ static dberr_t srv_undo_tablespace_read_encryption(pfs_os_file_t fh,
 
   bool encryption_success = false;
 
-  if (found && recv_key->lsn >= page_lsn) {
+  if (found && recv_key_lsn >= page_lsn) {
     // Condition 1: Use key from redo if available and appropriate
     encryption_success = (use_dumped_tablespace_keys && !srv_backup_mode)
                              ? load_key_from_dump()
-                             : set_encryption(recv_key->ptr, recv_key->iv);
+                             : set_encryption(recv_key, recv_iv);
   } else if (is_enc) {
     // Condition 2: Page is encrypted
     encryption_success = (use_dumped_tablespace_keys && !srv_backup_mode)

--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -1513,13 +1513,20 @@ bool backup_start(Backup_context &context) {
   if (ddl_tracker != nullptr) {
     std::this_thread::sleep_for(
         std::chrono::milliseconds(context.redo_mgr->get_copy_interval()));
-    while (context.redo_mgr->get_scanned_lsn() < log_status.lsn &&
+    context.redo_mgr->set_parse_tail_up_to_lsn(log_status.lsn);
+    while (!context.redo_mgr->is_error() &&
            !context.redo_mgr->has_parsed_lsn(log_status.lsn)) {
       xb::info() << "Waiting for redo thread to catchup to LSN "
                  << log_status.lsn << " (currently parsing at "
                  << context.redo_mgr->get_parsed_lsn() << ")";
       std::this_thread::sleep_for(
           std::chrono::milliseconds(context.redo_mgr->get_copy_interval()));
+    }
+    context.redo_mgr->set_parse_tail_up_to_lsn(0);
+    if (context.redo_mgr->is_error()) {
+      xb::error() << "Redo thread failed while waiting to parse up to LSN "
+                  << log_status.lsn;
+      return false;
     }
     dberr_t err = ddl_tracker->handle_ddl_operations();
     if (err != DB_SUCCESS) {

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -323,6 +323,11 @@ bool ddl_tracker_t::is_tablespace_dropped(const space_id_t space_id) {
   return (drops.find(space_id) != drops.end());
 }
 
+bool ddl_tracker_t::is_recopy_renamed(const space_id_t space_id) {
+  std::lock_guard<std::mutex> lock(m_ddl_tracker_mutex);
+  return (recopy_renamed_spaces.find(space_id) != recopy_renamed_spaces.end());
+}
+
 void ddl_tracker_t::add_rename_ibd_scan(const space_id_t &space_id,
                                         std::string new_name) {
   // undo tablespaces are tracked separately.
@@ -658,6 +663,11 @@ dberr_t ddl_tracker_t::handle_ddl_operations() {
         backup_file_printf(
             convert_file_name(table, old_table_name, flags, EXT_DEL).c_str(),
             "%s", "");
+        /* The old-name base file is deleted via the .del above and the new
+        name is reconstructed from the .new file during prepare. A sparse
+        incremental delta would leave hole pages for such a table, so mark it
+        to force a full (write-through) recopy. */
+        recopy_renamed_spaces.insert(table);
       }
       string table_name = tables_copied_no_lock[table].first;
       new_tables[table] = table_name;

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -683,10 +683,11 @@ dberr_t ddl_tracker_t::handle_ddl_operations() {
     /* Remove from missing */
     missing_after_discovery.erase(space_id);
 
-    /* Remove from new tables and skip drop*/
+    /* Remove from new tables. Recopy can temporarily promote an already
+    copied tablespace into new_tables, but a captured DROP must still leave
+    a .del marker. */
     if (new_tables.find(space_id) != new_tables.end()) {
       new_tables.erase(space_id);
-      continue;
     }
 
     /* Table not in the backup, nothing to drop, skip drop*/

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -1077,30 +1077,34 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
       return false;
     }
 
-    // space_id.ren is already with the desired name. Nothing to do.
-    if (source_path != nullptr && dest_path != nullptr &&
-        strcmp(source_path, dest_path) == 0) {
+    const bool source_equals_dest =
+        source_path != nullptr && dest_path != nullptr &&
+        strcmp(source_path, dest_path) == 0;
+
+    // The .ibd may already have the desired name, but for incremental backups
+    // we still need to move the corresponding .delta/.meta files.
+    if (source_equals_dest) {
       xb::info() << "prepare_handle_ren_files: ren_file: " << ren_path
                  << " already has desired file name: " << dest_path
                  << " source path is: " << source_path;
-      os_file_delete(0, ren_path.c_str());
-      return true;
     }
 
-    pending_ren.rename_tablespace = true;
-    pending_ren.temp_space_name = make_temp_space_name(source_space_id);
-    pending_ren.temp_path = std::string(source_path) + REN_TMP_SUFFIX;
+    if (!source_equals_dest) {
+      pending_ren.rename_tablespace = true;
+      pending_ren.temp_space_name = make_temp_space_name(source_space_id);
+      pending_ren.temp_path = std::string(source_path) + REN_TMP_SUFFIX;
 
-    xb::info() << "prepare_handle_ren_files: staging " << fil_space->name
-               << " to temporary path " << pending_ren.temp_path;
+      xb::info() << "prepare_handle_ren_files: staging " << fil_space->name
+                 << " to temporary path " << pending_ren.temp_path;
 
-    if (!fil_rename_tablespace(fil_space->id, source_path,
-                               pending_ren.temp_space_name.c_str(),
-                               pending_ren.temp_path.c_str())) {
-      xb::error() << "prepare_handle_ren_files: Cannot rename "
-                  << fil_space->name << " to temporary path "
-                  << pending_ren.temp_path;
-      return false;
+      if (!fil_rename_tablespace(fil_space->id, source_path,
+                                 pending_ren.temp_space_name.c_str(),
+                                 pending_ren.temp_path.c_str())) {
+        xb::error() << "prepare_handle_ren_files: Cannot rename "
+                    << fil_space->name << " to temporary path "
+                    << pending_ren.temp_path;
+        return false;
+      }
     }
   } else {
     // In case source file doesn't exist we check if destination file is already

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -1050,6 +1050,17 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
     }
   });
 
+  // CREATE DATABASE during the backup does not produce MLOG_FILE_* records,
+  // so the destination schema directory may not exist yet in the backup dir.
+  // fil_rename_tablespace() -> os_file_rename() will not create parent dirs,
+  // so make sure the destination schema dir exists before any rename happens.
+  if (dest_path != nullptr &&
+      os_file_create_subdirs_if_needed(dest_path) != DB_SUCCESS) {
+    xb::error() << "prepare_handle_ren_files: cannot create parent directory "
+                << "for " << dest_path;
+    return false;
+  }
+
   fil_space_t *fil_space = fil_space_get(source_space_id);
 
   pending_ren_file_t pending_ren;

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -825,6 +825,27 @@ dberr_t ddl_tracker_t::handle_ddl_operations() {
     new_tables[elem.second] = elem.first;
   }
 
+  /* Every .crpt marker must be paired with either a DROP (.del) or a
+  successful recopy (.new). Otherwise prepare_handle_corrupt_files() would
+  silently delete the .ibd in the backup with no replacement, producing a
+  successful-looking backup that has actually lost the table. This must be
+  checked here, before the early-return below: when there is no other DDL,
+  new_tables is empty and the recopy loop is skipped, but the .crpt marker
+  still ends up on disk and must not be allowed to silently destroy data. */
+  for (const auto &cor : corrupted_tablespaces) {
+    space_id_t sid = cor.first;
+    const std::string &name = cor.second.first;
+    const bool dropped = drops.find(sid) != drops.end();
+    const bool recopied = new_tables.find(sid) != new_tables.end();
+    if (!dropped && !recopied) {
+      xb::error() << "DDL tracking : corrupted tablespace " << name
+                  << " (space_id=" << sid
+                  << ") is neither dropped nor recopied; aborting backup to"
+                     " avoid silent data loss.";
+      return DB_ERROR;
+    }
+  }
+
   if (new_tables.empty()) {
     xb::info() << "DDL tracking : no new files are being copied.";
     return DB_SUCCESS;

--- a/storage/innobase/xtrabackup/src/ddl_tracker.cc
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.cc
@@ -43,8 +43,71 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #include "xtrabackup.h"  // datafiles_iter_t
 
 static const int REN_FILE_VERSION = 1;
+static const char *REN_TMP_SUFFIX = ".temp";
+static const char *REN_TMP_SCHEMA_PREFIX = "xbt";
+
+struct pending_ren_file_t {
+  space_id_t space_id{};
+  bool rename_tablespace{false};
+  std::string ren_path;
+  std::string temp_space_name;
+  std::string temp_path;
+  std::string dest_space_name;
+  std::string temp_delta_path;
+  std::string dest_delta_path;
+  std::string temp_meta_path;
+  std::string dest_meta_path;
+};
+
+static std::vector<pending_ren_file_t> pending_ren_files;
+static std::string pending_ren_schema_name;
 
 extern bool xb_read_delta_metadata(const char *filepath, xb_delta_info_t *info);
+
+static bool schema_name_exists(const std::string &schema_name) {
+  bool exists = false;
+
+  Fil_space_iterator::for_each_space([&](fil_space_t *space) {
+    if (space == nullptr || space->name == nullptr) {
+      return DB_SUCCESS;
+    }
+
+    const std::string_view space_name(space->name);
+    const std::string_view schema_prefix(schema_name);
+
+    if (space_name.size() > schema_prefix.size() &&
+        space_name.compare(0, schema_prefix.size(), schema_prefix) == 0 &&
+        space_name[schema_prefix.size()] == '/') {
+      exists = true;
+    }
+
+    return DB_SUCCESS;
+  });
+
+  return exists;
+}
+
+static std::string get_temp_schema_name() {
+  if (!pending_ren_schema_name.empty()) {
+    return pending_ren_schema_name;
+  }
+
+  for (uint32_t suffix = 0;; ++suffix) {
+    std::string candidate_schema(REN_TMP_SCHEMA_PREFIX);
+    if (suffix != 0) {
+      candidate_schema.append(std::to_string(suffix));
+    }
+
+    if (!schema_name_exists(candidate_schema)) {
+      pending_ren_schema_name = candidate_schema;
+      return pending_ren_schema_name;
+    }
+  }
+}
+
+static std::string make_temp_space_name(space_id_t space_id) {
+  return get_temp_schema_name() + "/s" + std::to_string(space_id);
+}
 
 void ddl_tracker_t::backup_file_op(uint32_t space_id, mlog_id_t type,
                                    const byte *buf, ulint len,
@@ -988,6 +1051,11 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
 
   fil_space_t *fil_space = fil_space_get(source_space_id);
 
+  pending_ren_file_t pending_ren;
+  pending_ren.space_id = source_space_id;
+  pending_ren.ren_path = ren_path;
+  pending_ren.dest_space_name = dest_space_name;
+
   if (fil_space != nullptr) {
     char *source_path = nullptr, *source_space_name = nullptr;
     bool res = fil_space_read_name_and_filepath(
@@ -1014,18 +1082,23 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
       xb::info() << "prepare_handle_ren_files: ren_file: " << ren_path
                  << " already has desired file name: " << dest_path
                  << " source path is: " << source_path;
+      os_file_delete(0, ren_path.c_str());
       return true;
     }
 
-    ut_ad(!os_file_exists(dest_path));
+    pending_ren.rename_tablespace = true;
+    pending_ren.temp_space_name = make_temp_space_name(source_space_id);
+    pending_ren.temp_path = std::string(source_path) + REN_TMP_SUFFIX;
 
-    xb::info() << "prepare_handle_ren_files: renaming " << fil_space->name
-               << " to " << dest_space_name;
+    xb::info() << "prepare_handle_ren_files: staging " << fil_space->name
+               << " to temporary path " << pending_ren.temp_path;
 
     if (!fil_rename_tablespace(fil_space->id, source_path,
-                               dest_space_name.c_str(), NULL)) {
+                               pending_ren.temp_space_name.c_str(),
+                               pending_ren.temp_path.c_str())) {
       xb::error() << "prepare_handle_ren_files: Cannot rename "
-                  << fil_space->name << " to " << dest_space_name;
+                  << fil_space->name << " to temporary path "
+                  << pending_ren.temp_path;
       return false;
     }
   } else {
@@ -1056,15 +1129,17 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
       truncate_suffix(EXT_META, delta_file);
       delta_file.append(EXT_DELTA);
 
-      std::string to_delta(to_path + EXT_DELTA);
+      pending_ren.temp_delta_path = delta_file + REN_TMP_SUFFIX;
+      pending_ren.dest_delta_path = to_path + EXT_DELTA;
       xb::info() << "Renaming incremental delta file from: " << delta_file
-                 << " to: " << to_delta;
-      rename_force(delta_file, to_delta);
+                 << " to temporary path: " << pending_ren.temp_delta_path;
+      rename_force(delta_file, pending_ren.temp_delta_path);
 
-      std::string to_meta(to_path + EXT_META);
+      pending_ren.temp_meta_path = meta_file + REN_TMP_SUFFIX;
+      pending_ren.dest_meta_path = to_path + EXT_META;
       xb::info() << "Renaming incremental meta file from: " << meta_file
-                 << " to: " << to_meta;
-      rename_force(meta_file, to_meta);
+                 << " to temporary path: " << pending_ren.temp_meta_path;
+      rename_force(meta_file, pending_ren.temp_meta_path);
     } else if (fil_space == nullptr) {
       // This means the tablespace is neither found in the fullbackup dir
       // nor in the inc backup directory as .meta and .delta
@@ -1078,8 +1153,48 @@ bool prepare_handle_ren_files(const datadir_entry_t &entry, void *) {
     }
   }
 
-  // delete the .ren file, we don't need it anymore
-  os_file_delete(0, ren_path.c_str());
+  pending_ren_files.push_back(std::move(pending_ren));
+  return true;
+}
+
+bool prepare_finalize_ren_files() {
+  for (const auto &pending_ren : pending_ren_files) {
+    if (pending_ren.rename_tablespace) {
+      xb::info() << "prepare_finalize_ren_files: renaming "
+                 << pending_ren.temp_path << " to "
+                 << pending_ren.dest_space_name;
+
+      if (!fil_rename_tablespace(pending_ren.space_id,
+                                 pending_ren.temp_path.c_str(),
+                                 pending_ren.dest_space_name.c_str(), NULL)) {
+        xb::error() << "prepare_finalize_ren_files: Cannot rename "
+                    << pending_ren.temp_path << " to "
+                    << pending_ren.dest_space_name;
+        pending_ren_files.clear();
+        pending_ren_schema_name.clear();
+        return false;
+      }
+    }
+
+    if (!pending_ren.temp_delta_path.empty()) {
+      xb::info() << "prepare_finalize_ren_files: renaming incremental delta "
+                 << pending_ren.temp_delta_path << " to "
+                 << pending_ren.dest_delta_path;
+      rename_force(pending_ren.temp_delta_path, pending_ren.dest_delta_path);
+    }
+
+    if (!pending_ren.temp_meta_path.empty()) {
+      xb::info() << "prepare_finalize_ren_files: renaming incremental meta "
+                 << pending_ren.temp_meta_path << " to "
+                 << pending_ren.dest_meta_path;
+      rename_force(pending_ren.temp_meta_path, pending_ren.dest_meta_path);
+    }
+
+    os_file_delete(0, pending_ren.ren_path.c_str());
+  }
+
+  pending_ren_files.clear();
+  pending_ren_schema_name.clear();
   return true;
 }
 

--- a/storage/innobase/xtrabackup/src/ddl_tracker.h
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.h
@@ -184,6 +184,10 @@ bool prepare_handle_ren_files(
     const datadir_entry_t &entry, /*!<in: datadir entry */
     void * /*data*/);
 
+/** Finalize deferred two-pass .ren handling.
+@return true on success */
+bool prepare_finalize_ren_files();
+
 /**
  * Handle .crpt files. These files should be removed before we do *.ibd scan
  * @return true on success

--- a/storage/innobase/xtrabackup/src/ddl_tracker.h
+++ b/storage/innobase/xtrabackup/src/ddl_tracker.h
@@ -51,6 +51,12 @@ class ddl_tracker_t {
   name_to_space_id_t after_lock_undo;
   /** Tablespaces involved in encryption or bulk index load.*/
   std::unordered_set<space_id_t> recopy_tables;
+  /** Tablespaces that are both recopied and renamed during the backup. For
+  these, prepare deletes the old-name base file (.del) and reconstructs the
+  new name by applying the recopied .new.delta onto a freshly-created file.
+  A sparse incremental delta would leave hole pages, so the recopy must emit a
+  delta containing every page (full_copy) for these tablespaces. */
+  std::unordered_set<space_id_t> recopy_renamed_spaces;
   /** Drop operations found in redo log. */
   space_id_to_name_t drops;
   /* For DDL operation found in redo log,  */
@@ -159,6 +165,11 @@ class ddl_tracker_t {
   /** @return true if tablespace is dropped
   @param[in]    space_id tablespace id */
   bool is_tablespace_dropped(const space_id_t space_id);
+
+  /** @return true if the tablespace is both recopied and renamed during the
+  backup, in which case the recopy must write a full (non-sparse) copy.
+  @param[in]    space_id tablespace id */
+  bool is_recopy_renamed(const space_id_t space_id);
 };
 
 /** Insert into meta files map. This map is later used to delete the right

--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -457,7 +457,7 @@ bool Redo_Log_Parser::parse_log(const byte *buf, size_t len, lsn_t start_lsn) {
 
     recv_parse_log_recs();
     /* update parsed lsn after we have completed parsing */
-    last_parsed_lsn.store(scanned_lsn);
+    last_parsed_lsn.store(recv_sys->recovered_lsn);
 
     if (recv_sys->recovered_offset > recv_sys->buf_len / 4) {
       /* Move parsing buffer data to the buffer start */
@@ -1116,11 +1116,12 @@ void Redo_Log_Data_Manager::track_archived_log(lsn_t start_lsn, const byte *buf,
 }
 
 bool Redo_Log_Data_Manager::has_parsed_lsn(lsn_t lsn) const {
-  /* check if we have parsed up to desired lsn, or if we have not parsed
-   * anything (no redo) or are in the middle of last block */
-  return (parser.get_last_parsed_lsn() >= lsn ||
-          parser.get_last_parsed_lsn() == 0 ||
-          lsn - parser.get_last_parsed_lsn() < OS_FILE_LOG_BLOCK_SIZE);
+  /* Check if we have parsed up to desired lsn. */
+  return (parser.get_last_parsed_lsn() >= lsn);
+}
+
+void Redo_Log_Data_Manager::set_parse_tail_up_to_lsn(lsn_t lsn) {
+  parse_tail_up_to_lsn.store(lsn);
 }
 
 bool Redo_Log_Data_Manager::copy_once(bool is_last, bool *finished) {
@@ -1159,20 +1160,56 @@ bool Redo_Log_Data_Manager::copy_once(bool is_last, bool *finished) {
     }
   }
 
-  auto len = reader.read_logfile(is_last, finished);
+  auto write_len = reader.read_logfile(is_last, finished);
   error = reader.is_error();
 
-  if (len <= 0) {
-    return (len == 0);
-  }
-
-  track_archived_log(start_lsn, reader.get_buffer(), len);
-
-  if (!parser.parse_log(reader.get_buffer(), len, start_lsn)) {
+  if (write_len < 0) {
     return (false);
   }
 
-  if (!writer.write_buffer(reader.get_buffer(), len)) {
+  auto parse_len = static_cast<size_t>(write_len);
+  const auto parse_tail_lsn = parse_tail_up_to_lsn.load();
+
+  if (parse_tail_lsn != 0 && !is_last) {
+    const auto write_end_lsn = start_lsn + parse_len;
+
+    if (parse_tail_lsn > write_end_lsn) {
+      /* During DDL catchup, parser may need to inspect the target tail
+      block even though the writer must still skip it in normal copy mode. */
+      const auto target_block_end =
+          ut_uint64_align_up(parse_tail_lsn, OS_FILE_LOG_BLOCK_SIZE);
+      const auto scanned_block_end =
+          ut_uint64_align_up(reader.get_scanned_lsn(), OS_FILE_LOG_BLOCK_SIZE);
+
+      /* Only parse the target block after scan has validated it. */
+      if (parse_tail_lsn <= scanned_block_end) {
+        const auto parse_end_lsn = target_block_end < scanned_block_end
+                                       ? target_block_end
+                                       : scanned_block_end;
+
+        if (parse_end_lsn > write_end_lsn) {
+          parse_len = parse_end_lsn - start_lsn;
+        }
+      }
+    }
+  }
+
+  if (parse_len == 0) {
+    return (true);
+  }
+
+  if (write_len > 0) {
+    track_archived_log(start_lsn, reader.get_buffer(),
+                       static_cast<size_t>(write_len));
+  }
+
+  if (!parser.parse_log(reader.get_buffer(), parse_len, start_lsn)) {
+    return (false);
+  }
+
+  if (write_len > 0 &&
+      !writer.write_buffer(reader.get_buffer(),
+                           static_cast<size_t>(write_len))) {
     return (false);
   }
   scanned_lsn = reader.get_scanned_lsn();

--- a/storage/innobase/xtrabackup/src/redo_log.h
+++ b/storage/innobase/xtrabackup/src/redo_log.h
@@ -324,6 +324,9 @@ class Redo_Log_Data_Manager {
   /** whether we have parsed up to LSN */
   bool has_parsed_lsn(lsn_t lsn) const;
 
+  /** Set parse-only tail target for DDL catchup. */
+  void set_parse_tail_up_to_lsn(lsn_t lsn);
+
   ~Redo_Log_Data_Manager();
 
  private:
@@ -345,6 +348,9 @@ class Redo_Log_Data_Manager {
 
   /** lsn to stop copying at. */
   std::atomic<lsn_t> stop_lsn;
+
+  /** target LSN for parse-only tail catchup. */
+  std::atomic<lsn_t> parse_tail_up_to_lsn{0};
 
   /** checkpoint lsn at the end of the backup. */
   lsn_t last_checkpoint_lsn;

--- a/storage/innobase/xtrabackup/src/write_filt.cc
+++ b/storage/innobase/xtrabackup/src/write_filt.cc
@@ -128,8 +128,10 @@ static bool wf_incremental_process(xb_write_filt_ctxt_t *ctxt,
      * since the last backup. Hence we copy all changes to mysql.ibd since last
      * backup start_lsn instead of last backup end_lsn.
      */
-    if (cursor->space_id == dict_sys_t::s_dict_space_id &&
-        metadata_from_lsn > mach_read_from_8(page + FIL_PAGE_LSN))
+    if (cp->full_copy) {
+      /* copy every page so the .delta can rebuild a complete file */
+    } else if (cursor->space_id == dict_sys_t::s_dict_space_id &&
+               metadata_from_lsn > mach_read_from_8(page + FIL_PAGE_LSN))
       continue;
     else if (incremental_lsn > mach_read_from_8(page + FIL_PAGE_LSN))
       continue;

--- a/storage/innobase/xtrabackup/src/write_filt.h
+++ b/storage/innobase/xtrabackup/src/write_filt.h
@@ -33,6 +33,10 @@ typedef struct {
   byte *delta_buf_base;
   byte *delta_buf;
   ulint npages;
+  /* When true, copy every page regardless of its LSN so the resulting .delta
+  can rebuild a complete file (used for tablespaces recopied after a rename,
+  whose old-name base file is deleted during prepare). */
+  bool full_copy;
 } xb_wf_incremental_ctxt_t;
 
 /* Page filter context used as an opaque structure by callers */

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -2683,27 +2683,62 @@ static bool xtrabackup_read_info(char *filename) {
   } else if (xb_server_version < 80029) {
     cfg_version = IB_EXPORT_CFG_VERSION_V6;
   }
-  /* skip start_time, end_time, lock_time, binlog_pos, innodb_from_lsn,
-   * innodb_to_lsn, partial, incremental, format, compressed, encrypt */
-  for (int i = 0; i < 12; i++) {
-    char c;
-    do {
-      c = fgetc(fp);
-    } while (c != '\n');
-  }
-
-  char lock[8];
-  if (fscanf(fp, "lock_ddl_type = %7s\n", lock) != 1) {
-    xb::warn() << "lock_ddl_type parameter not found, defaulting to 'ON'";
-    opt_lock_ddl = LOCK_DDL_ON;
-  } else {
-    /* used to process the metadata files (.ren .del .new) created by backup
-     * when --lock-ddl=REDUCED  */
-    opt_lock_ddl = ddl_lock_type_from_str(string(lock));
+  /* Find lock_ddl_type in xtrabackup_info. If not found, default to 'ON'. */
+  {
+    char line[512];
+    char lock[8];
+    bool lock_ddl_found = false;
+    while (fgets(line, sizeof(line), fp) != nullptr) {
+      if (sscanf(line, "lock_ddl_type = %7s", lock) == 1) {
+        lock_ddl_found = true;
+        break;
+      }
+    }
+    if (!lock_ddl_found) {
+      xb::warn() << "lock_ddl_type parameter not found, defaulting to 'ON'";
+      opt_lock_ddl = LOCK_DDL_ON;
+    } else {
+      /* used to process the metadata files (.ren .del .new) created by backup
+       * when --lock-ddl=REDUCED  */
+      opt_lock_ddl = ddl_lock_type_from_str(string(lock));
+    }
   }
 end:
   fclose(fp);
   return (r);
+}
+
+static bool xtrabackup_read_lock_ddl_type(const char *filename,
+                                          lock_ddl_type_t *lock_ddl_type) {
+  FILE *fp;
+  char line[512];
+  char lock[8];
+  bool lock_ddl_found = false;
+
+  fp = fopen(filename, "r");
+  if (!fp) {
+    xb::error() << "cannot open " << filename;
+    return (false);
+  }
+
+  while (fgets(line, sizeof(line), fp) != nullptr) {
+    if (sscanf(line, "lock_ddl_type = %7s", lock) == 1) {
+      lock_ddl_found = true;
+      break;
+    }
+  }
+
+  fclose(fp);
+
+  if (!lock_ddl_found) {
+    xb::warn() << "lock_ddl_type parameter not found in " << filename
+               << ", defaulting to 'ON'";
+    *lock_ddl_type = LOCK_DDL_ON;
+  } else {
+    *lock_ddl_type = ddl_lock_type_from_str(string(lock));
+  }
+
+  return (true);
 }
 
 /* ================= common ================= */
@@ -6868,6 +6903,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
   fil_space_t *space;
   IORequest write_request(IORequest::WRITE);
   read_metadata();
+  const lock_ddl_type_t target_lock_ddl = opt_lock_ddl;
 
   /* prepare version check */
   if (!check_server_version(xb_server_version, mysql_server_version_str,
@@ -6906,6 +6942,25 @@ skip_check:
 
   if (xtrabackup_incremental) {
     backup_redo_log_flushed_lsn = incremental_flushed_lsn;
+  }
+
+  if (xtrabackup_incremental_dir) {
+    char xtrabackup_info_path[FN_REFLEN];
+
+    sprintf(xtrabackup_info_path, "%s/%s", xtrabackup_incremental_dir,
+            XTRABACKUP_INFO);
+    if (!xtrabackup_read_lock_ddl_type(xtrabackup_info_path, &opt_lock_ddl)) {
+      xb::error() << "Failed to parse lock_ddl_type from "
+                  << SQUOTE(xtrabackup_info_path);
+      exit(EXIT_FAILURE);
+    }
+
+    if (opt_lock_ddl != target_lock_ddl) {
+      xb::info() << "Using incremental backup lock_ddl_type "
+                 << ddl_lock_type_to_str(opt_lock_ddl)
+                 << " for DDL metadata processing; target lock_ddl_type is "
+                 << ddl_lock_type_to_str(target_lock_ddl);
+    }
   }
 
   init_mysql_environment();

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3282,6 +3282,16 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
     goto error;
   }
 
+  /* A tablespace that is both recopied and renamed during the backup has its
+  old-name base file deleted (.del) and its new name reconstructed from the
+  recopied .new.delta during prepare. A sparse incremental delta would leave
+  hole pages on the freshly-created file, so force the delta to include every
+  page for such tablespaces. */
+  if (write_filter == &wf_incremental && ddl_tracker != nullptr &&
+      ddl_tracker->is_recopy_renamed(node->space->id)) {
+    write_filt_ctxt.wf_incremental_ctxt.full_copy = true;
+  }
+
   /* do not compress encrypted tablespaces */
   if (cursor.is_encrypted) {
     dstfile =

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -3315,7 +3315,8 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
 
   if (res == XB_FIL_CUR_ERROR ||
       (res == XB_FIL_CUR_CORRUPTED &&
-       (ddl_tracker == nullptr || opt_lock_ddl != LOCK_DDL_REDUCED))) {
+       (ddl_tracker == nullptr || opt_lock_ddl != LOCK_DDL_REDUCED ||
+        is_server_locked()))) {
     goto error;
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7019,6 +7019,11 @@ skip_check:
       goto error_cleanup;
     }
 
+    if (!prepare_finalize_ren_files()) {
+      xb_data_files_close();
+      goto error_cleanup;
+    }
+
     xb_data_files_close();
     fil_close();
     innodb_free_param();

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/corrupted_tablespace_no_ddl.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/corrupted_tablespace_no_ddl.sh
@@ -1,0 +1,58 @@
+###############################################################################
+# Verifies that when a tablespace becomes corrupted during backup but is NEVER
+# covered by a DDL (no drop, no recopy trigger), xtrabackup must fail rather
+# than produce a "successful" backup with a phantom .crpt that destroys the
+# table at prepare time.
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "
+  CREATE TABLE test.t (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    payload CHAR(200)) ENGINE=InnoDB;
+  INSERT INTO test.t (payload) VALUES
+    (REPEAT('x',200)),(REPEAT('y',200)),(REPEAT('z',200));
+" test
+innodb_wait_for_flush_all
+
+# Pause xtrabackup right after tablespace discovery, before data copy starts.
+xtrabackup --backup --target-dir=$topdir/backup_corrupt \
+  --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_corrupt.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_corrupt/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+
+# Inject corruption into page 4 of the source .ibd (16K page size assumed).
+# 200 bytes of /dev/urandom is enough to break the checksum reliably.
+TABLE_FILE=$mysql_datadir/test/t.ibd
+[ -f "$TABLE_FILE" ] || die "expected $TABLE_FILE to exist"
+dd if=/dev/urandom of=$TABLE_FILE bs=1 count=200 seek=65536 conv=notrunc \
+   status=none
+
+# Resume xtrabackup. NO DDL is issued, so the corrupted sid will NOT enter
+# drops nor new_tables.
+kill -SIGCONT $xb_pid
+
+# After fix: backup must fail. Use 'wait' and capture exit code.
+set +e
+wait $job_pid
+xb_rc=$?
+set -e
+
+if [ $xb_rc -eq 0 ]; then
+    die "xtrabackup unexpectedly succeeded with an uncovered corrupted tablespace"
+fi
+
+# Sanity check on the error message produced by handle_ddl_operations.
+if ! grep -q "corrupted tablespace" $topdir/backup_corrupt.log; then
+    die "expected 'corrupted tablespace' error in backup log"
+fi
+
+vlog "OK: backup correctly aborted on uncovered corrupted tablespace"

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/inc_create_copy_drop_phantom.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/inc_create_copy_drop_phantom.sh
@@ -1,0 +1,63 @@
+###############################################################################
+# Incremental --lock-ddl=REDUCED: a tablespace created before the inc backup,
+# captured by the inc copy phase, then ADD-INDEX-ed (inplace) and DROP-ed
+# inside the same no-lock window must not reappear in the prepared backup.
+# handle_ddl_operations() must still emit a .del marker even when the recopy
+# loop has just put the sid back into new_tables.
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+innodb_wait_for_flush_all
+
+# Create the table between full and inc so the inc copy phase produces
+# t1.ibd.delta + t1.ibd.meta.
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY AUTO_INCREMENT, payload VARCHAR(32)); INSERT INTO test.t1 (payload) VALUES ('a'),('b'),('c');" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_inc \
+  --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# MLOG_INDEX_LOAD followed by DROP inside the same no-lock window.
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.t1 ADD INDEX idx_payload(payload), ALGORITHM=INPLACE;" test
+$MYSQL $MYSQL_ARGS -Ns -e "DROP TABLE test.t1;" test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir
+mkdir $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test
+
+EXISTS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='test' AND table_name='t1'"`
+if [ "$EXISTS" != "0" ]; then
+    die "test.t1 should be absent after restore, information_schema reports $EXISTS"
+fi
+
+# Orphan .ibd from apply_delta would yield ER_TABLESPACE_EXISTS.
+if ! ${MYSQL} ${MYSQL_ARGS} -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY, note VARCHAR(16)); INSERT INTO test.t1 VALUES (1,'fresh'); DROP TABLE test.t1;" ; then
+    die "CREATE TABLE test.t1 after restore failed (orphan .ibd)"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup_base $topdir/backup_inc $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/inc_cross_db_rename_with_new_db.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/inc_cross_db_rename_with_new_db.sh
@@ -1,0 +1,71 @@
+###############################################################################
+# Incremental --lock-ddl=REDUCED: destination DB is created inside the inc
+# no-lock window, then a table is cross-db renamed into it. prepare must
+# materialize the destination directory and move the base .ibd under the new
+# schema; otherwise the restored instance misses the table or leaves orphan
+# files behind.
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.cross_db_t (id INT PRIMARY KEY AUTO_INCREMENT, payload VARCHAR(32)); INSERT INTO test.cross_db_t VALUES (1,'a'),(2,'b'),(3,'c');" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_inc \
+  --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Inside the inc no-lock window: create the destination DB and move the table
+# across. CREATE DATABASE itself leaves no MLOG_FILE_* signal for ddl_tracker.
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE DATABASE test_dst;"
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.cross_db_t TO test_dst.cross_db_t;"
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test_dst.cross_db_t VALUES (4,'d');" test_dst
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/cross_db_t.ibd To: test_dst/cross_db_t.ibd' $topdir/backup_inc.log ; then
+    die "xtrabackup did not record the cross-database RENAME TABLE during the incremental backup"
+fi
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+record_db_state test_dst
+stop_server
+rm -rf $mysql_datadir
+mkdir $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test_dst
+
+ROWS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM test_dst.cross_db_t"`
+if [ "$ROWS" != "4" ]; then
+    die "test_dst.cross_db_t should have 4 rows after restore, got $ROWS"
+fi
+
+EXISTS_OLD=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='test' AND table_name='cross_db_t'"`
+if [ "$EXISTS_OLD" != "0" ]; then
+    die "test.cross_db_t should not exist after incremental restore, but information_schema reports it"
+fi
+
+if ! ${MYSQL} ${MYSQL_ARGS} -Ns -e "DROP TABLE test_dst.cross_db_t; CREATE TABLE test_dst.cross_db_t (id INT PRIMARY KEY); INSERT INTO test_dst.cross_db_t VALUES (1); SELECT COUNT(*) FROM test_dst.cross_db_t;" ; then
+    die "CREATE TABLE test_dst.cross_db_t after incremental restore failed — likely orphan .ibd left over from cross-db RENAME"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup_base $topdir/backup_inc $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_prepare_lock_ddl_type.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_prepare_lock_ddl_type.sh
@@ -1,0 +1,73 @@
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.base_lock_ddl (
+  id INT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(64),
+  payload CHAR(200)
+) ENGINE=InnoDB; INSERT INTO test.base_lock_ddl(name, payload)
+VALUES ('a', REPEAT('a', 200)), ('b', REPEAT('b', 200));" test
+
+innodb_wait_for_flush_all
+
+# The full backup intentionally uses the normal lock mode.  Incremental prepare
+# must still process reduced-lock metadata from the incremental directory.
+xtrabackup --backup --target-dir=$topdir/backup_base_lock_ddl --lock-ddl=ON
+
+xtrabackup --backup --target-dir=$topdir/backup_inc_lock_ddl \
+  --incremental-basedir=$topdir/backup_base_lock_ddl \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc_lock_ddl.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc_lock_ddl/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.base_lock_ddl ADD INDEX name_idx(name);
+  RENAME TABLE test.base_lock_ddl TO test.inc_lock_ddl;
+  INSERT INTO test.inc_lock_ddl(name, payload) VALUES ('c', REPEAT('c', 200));" test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+egrep -q "^lock_ddl_type = ON" \
+  $topdir/backup_base_lock_ddl/xtrabackup_info || \
+  die "base backup did not record lock_ddl_type ON"
+egrep -q "^lock_ddl_type = REDUCED" \
+  $topdir/backup_inc_lock_ddl/xtrabackup_info || \
+  die "incremental backup did not record lock_ddl_type REDUCED"
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base_lock_ddl
+xtrabackup --prepare --target-dir=$topdir/backup_base_lock_ddl \
+  --incremental-dir=$topdir/backup_inc_lock_ddl \
+  2> >( tee $topdir/prepare_inc_lock_ddl.log)
+
+if ! egrep -q "Using incremental backup lock_ddl_type REDUCED .* target lock_ddl_type is ON" \
+    $topdir/prepare_inc_lock_ddl.log ; then
+  die "prepare did not switch to the incremental backup lock_ddl_type"
+fi
+
+original_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.inc_lock_ddl FORCE INDEX(name_idx);" | awk {'print $1'}`
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir/*
+xtrabackup --copy-back --target-dir=$topdir/backup_base_lock_ddl
+start_server
+
+verify_db_state test
+restored_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.inc_lock_ddl FORCE INDEX(name_idx);" | awk {'print $1'}`
+
+if [ "$original_count" != "$restored_count" ]; then
+  die "rows in inc_lock_ddl via name_idx mismatch: original=$original_count restored=$restored_count"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup_base_lock_ddl \
+  $topdir/backup_inc_lock_ddl $topdir/backup_inc_lock_ddl.log \
+  $topdir/prepare_inc_lock_ddl.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_recopy_rename_hole.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_recopy_rename_hole.sh
@@ -1,0 +1,66 @@
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50), pad CHAR(200)); INSERT INTO test.t1(name,pad) VALUES ('a',REPEAT('x',200)),('b',REPEAT('y',200));" test
+for i in $(seq 1 16); do
+  $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t1(name,pad) SELECT name,pad FROM test.t1;" test
+done
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# ADD INDEX puts t1 into the recopy set; RENAME makes the recopy target a name
+# that does not exist in the base backup.
+$MYSQL $MYSQL_ARGS -Ns -e "ALTER TABLE test.t1 ADD INDEX name_idx(name); RENAME TABLE test.t1 TO test.t2;" test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+original_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.t2 FORCE INDEX(name_idx);"`
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir
+mkdir $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+
+
+$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.t2; CHECKSUM TABLE test.t2;" test
+scan_rc=$?
+if ! $MYSQL $MYSQL_ARGS -Ns -e "SELECT 1" >/dev/null 2>&1; then
+    die "mysqld crashed while reading restored t2 (lost connection): the restored tablespace is corrupt"
+fi
+if [ "$scan_rc" != "0" ]; then
+    die "full scan of restored t2 failed (rc=$scan_rc): the restored tablespace is corrupt"
+fi
+
+verify_db_state test
+
+restored_count=`$MYSQL $MYSQL_ARGS -Ns -e "SELECT COUNT(*) FROM test.t2 FORCE INDEX(name_idx);"`
+
+if [ "$original_count" != "$restored_count" ]; then
+    die "rows in t2 via secondary index mismatch: original=$original_count restored=$restored_count"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup_base $topdir/backup_inc $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_cycle_back.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_cycle_back.sh
@@ -1,0 +1,81 @@
+###############################################################################
+# Incremental --lock-ddl=REDUCED: a tablespace renamed to an intermediate
+# name before the inc copy phase, and renamed back to its original name
+# while the inc backup is running, must end up under the original name in
+# the prepared backup. prepare_handle_ren_files() must rename the captured
+# .delta/.meta to the final name even when source path == dest path.
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+$MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE test.t1 (id INT PRIMARY KEY AUTO_INCREMENT, payload VARCHAR(32)) ENGINE=InnoDB; INSERT INTO test.t1 (payload) VALUES ('a'),('b'),('c');" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
+innodb_wait_for_flush_all
+
+# Rename to the intermediate name; inc copy will capture the file under
+# this name.
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.t1 TO test.t1_mid;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t1_mid (payload) VALUES ('d'),('e');" test
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup_inc \
+  --incremental-basedir=$topdir/backup_base \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup_inc.log)&
+
+job_pid=$!
+pid_file=$topdir/backup_inc/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+# Rename back to the original name inside the inc no-lock window.
+$MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE test.t1_mid TO test.t1;" test
+$MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.t1 (payload) VALUES ('f');" test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+if ! egrep -q 'DDL tracking : LSN: [0-9]* rename space ID: [0-9]* From: test/t1_mid.ibd To: test/t1.ibd' $topdir/backup_inc.log ; then
+    die "xtrabackup did not record the cycle-back RENAME TABLE"
+fi
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+
+record_db_state test
+stop_server
+rm -rf $mysql_datadir
+mkdir $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup_base
+start_server
+verify_db_state test
+
+EXISTS_ORIG=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='test' AND table_name='t1'"`
+if [ "$EXISTS_ORIG" != "1" ]; then
+    die "test.t1 should exist after restore, information_schema reports $EXISTS_ORIG"
+fi
+EXISTS_MID=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='test' AND table_name='t1_mid'"`
+if [ "$EXISTS_MID" != "0" ]; then
+    die "test.t1_mid must not exist after restore, information_schema reports $EXISTS_MID"
+fi
+
+# 3 + 2 (between full and inc) + 1 (inside inc window) = 6
+ROWS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM test.t1"`
+if [ "$ROWS" != "6" ]; then
+    die "test.t1 should have 6 rows after restore, got $ROWS"
+fi
+
+# Orphan .ibd under the intermediate name would yield ER_TABLESPACE_EXISTS.
+if ! ${MYSQL} ${MYSQL_ARGS} -Ns -e "CREATE TABLE test.t1_mid (id INT PRIMARY KEY); DROP TABLE test.t1_mid;" ; then
+    die "CREATE TABLE test.t1_mid after restore failed (orphan .ibd)"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup_base $topdir/backup_inc $topdir/backup_inc.log

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_atomic_swap_2way.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/rename_table_atomic_swap_2way.sh
@@ -1,0 +1,60 @@
+###############################################################################
+# Atomic two-table swap (RENAME TABLE t1 TO __t, t2 TO t1, __t TO t2) inside
+# a --lock-ddl=REDUCED backup window. The .ren entries form a closed graph
+# and prepare_handle_ren_files() must rename through a unique intermediate
+# name to avoid clobbering an already-renamed file.
+###############################################################################
+
+. inc/common.sh
+
+require_debug_pxb_version
+start_server
+
+# Distinct row counts so a silent overwrite produces a wrong row count
+# instead of an undetectable permutation.
+$MYSQL $MYSQL_ARGS -Ns -e "
+CREATE TABLE test.t1 (id INT PRIMARY KEY, tag VARCHAR(8)) ENGINE=InnoDB;
+CREATE TABLE test.t2 (id INT PRIMARY KEY, tag VARCHAR(8)) ENGINE=InnoDB;
+INSERT INTO test.t1 VALUES (1,'a1'),(2,'a2');
+INSERT INTO test.t2 VALUES (1,'b1'),(2,'b2'),(3,'b3'),(4,'b4'),(5,'b5');
+" test
+
+innodb_wait_for_flush_all
+
+xtrabackup --backup --target-dir=$topdir/backup \
+  --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
+  2> >( tee $topdir/backup.log)&
+
+job_pid=$!
+pid_file=$topdir/backup/xtrabackup_debug_sync
+wait_for_xb_to_suspend $pid_file
+xb_pid=`cat $pid_file`
+echo "backup pid is $job_pid"
+
+$MYSQL $MYSQL_ARGS -Ns -e "
+RENAME TABLE test.t1 TO test.t_tmp,
+             test.t2 TO test.t1,
+             test.t_tmp TO test.t2;" test
+
+vlog "Resuming xtrabackup"
+kill -SIGCONT $xb_pid
+run_cmd wait $job_pid
+
+xtrabackup --prepare --target-dir=$topdir/backup
+record_db_state test
+stop_server
+rm -rf $mysql_datadir
+mkdir $mysql_datadir
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server
+verify_db_state test
+
+# After t1 <-> t2 swap : t1=5, t2=2.
+T1_ROWS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM test.t1"`
+T2_ROWS=`${MYSQL} ${MYSQL_ARGS} -Ns -e "SELECT COUNT(*) FROM test.t2"`
+if [ "$T1_ROWS" != "5" ] || [ "$T2_ROWS" != "2" ]; then
+    die "atomic 2-way swap produced wrong rows: t1=$T1_ROWS (want 5) t2=$T2_ROWS (want 2)"
+fi
+
+stop_server
+rm -rf $mysql_datadir $topdir/backup $topdir/backup.log


### PR DESCRIPTION
This PR fixes several edge cases in --lock-ddl=REDUCED DDL tracking and prepare handling.

The affected cases are mostly around tablespaces that are renamed, recopied, deleted, or found corrupted during the backup window. Some of these cases could previously make backup or prepare fail, or produce a successful-looking backup that later misses a tablespace.

Related PXB issues:

https://perconadev.atlassian.net/browse/PXB-3808
https://perconadev.atlassian.net/browse/PXB-3809
https://perconadev.atlassian.net/browse/PXB-3810
https://perconadev.atlassian.net/browse/PXB-3813
https://perconadev.atlassian.net/browse/PXB-3812
https://perconadev.atlassian.net/browse/PXB-3816
https://perconadev.atlassian.net/browse/PXB-3819
https://perconadev.atlassian.net/browse/PXB-3825
https://perconadev.atlassian.net/browse/PXB-3822

Main fixes:

1. Use two-pass .ren handling during prepare
2. Still handle incremental .delta/.meta when .ibd rename is a no-op
3. Create destination schema directories for cross-database rename
4. Preserve .del handling for recopy followed by drop
5. Prevent silent data loss for corrupted tablespaces
6.  Fix incremental recopy + rename handling
7. Parse redo log until catching up log_status lsn
8. Fix incremental backup ddl lock option during prepare
9. Fix unsafe access to recv_sys->keys

@satya-bodapati Could you please take a close look at these changes and let me know if you have any suggestions?