### PR TITLE
Fix restore crash when Smart memory estimation is used

### DIFF
--- a/storage/innobase/xtrabackup/src/utils.cc
+++ b/storage/innobase/xtrabackup/src/utils.cc
@@ -169,12 +169,14 @@ unsigned long host_total_memory() {
   meminfo();
   return kb_main_total * 1024;
 #else
-  struct meminfo_info *mem_info;
+  struct meminfo_info *mem_info = nullptr;
   if (procps_meminfo_new(&mem_info) < 0) {
     return 0;
   }
 
-  return MEMINFO_GET(mem_info, MEMINFO_MEM_TOTAL, ul_int) * 1024;
+  unsigned long total_mem = MEMINFO_GET(mem_info, MEMINFO_MEM_TOTAL, ul_int) * 1024;
+  procps_meminfo_unref(&mem_info);
+  return total_mem;
 #endif  // HAVE_PROCPS_V3
 }
 
@@ -183,12 +185,14 @@ unsigned long host_free_memory() {
   meminfo();
   return kb_main_available * 1024;
 #else
-  struct meminfo_info *mem_info;
+  struct meminfo_info *mem_info = nullptr;
   if (procps_meminfo_new(&mem_info) < 0) {
     return 0;
   }
 
-  return MEMINFO_GET(mem_info, MEMINFO_MEM_AVAILABLE, ul_int) * 1024;
+  unsigned long free_mem = MEMINFO_GET(mem_info, MEMINFO_MEM_AVAILABLE, ul_int) * 1024;
+  procps_meminfo_unref(&mem_info);
+  return free_mem;
 #endif  // HAVE_PROCPS_V3
 }
 #endif


### PR DESCRIPTION
The `libproc2` variants of `host_free_memory()`/`host_total_memory()` declare `struct meminfo_info *mem_info;` uninitialized and pass it to `procps_meminfo_new(&mem_info)`. `procps_meminfo_new()` rejects a non-`NULL` `*info` with `-EINVAL`:

```c++
    // procps-ng library/meminfo.c, procps_meminfo_new()
    if (info == NULL || *info != NULL)
        return -EINVAL;
```

If the uninitialized stack slot holds a non-`NULL` value the call fails, the `if (rc < 0) return 0;` guard fires, and the function reports `0` bytes free.

With `--prepare --use-free-memory-pct` that `0` leads to a negative buffer pool size and crashes `--prepare` (exit 2). Initialize the pointer to `nullptr`, and release the handle with `procps_meminfo_unref()` before returning.