### PR TITLE
PXB-3853: Fix page-tracking incremental backups reading unmodified page ranges between changed-page blocks

### DIFF
--- a/storage/innobase/xtrabackup/src/changed_page_tracking.cc
+++ b/storage/innobase/xtrabackup/src/changed_page_tracking.cc
@@ -281,6 +281,15 @@ void range_get_next_page(xb_page_set *page_set) {
     }
     auto next_page = *page_set->current_page_it;
     if (next_page != current_page + 1) {
+      /* The next changed page is not adjacent to the current block. Step
+      back so that the iterator points to the last page of the current
+      contiguous block, as documented in the function comment. Leaving the
+      iterator on the next (non-adjacent) changed page makes the caller
+      extend the read batch up to that page, silently reading all the
+      unmodified pages in between. For large tablespaces with sparsely
+      distributed changed pages this degenerates into reading almost the
+      entire data file, defeating the purpose of page tracking. (PXB-3853) */
+      --page_set->current_page_it;
       break;
     }
   }


### PR DESCRIPTION
## Problem

`--page-tracking` incremental backups read far more data than the number of changed pages reported by the `mysqlbackup` component. For large tablespaces with sparsely distributed changed pages, the backup effectively reads the file from the first changed page to the last changed page, **including all unmodified pages in between**.

### Production evidence (PXB 8.0.35-34, Percona Server 8.0.44-35, ~5.5 TB datadir)

- The `mysqlbackup` component reported **6,399 changed pages total (~100 MB)** for one hourly incremental window; the resulting `.delta` files were only a few hundred KB each.
- Nevertheless `xtrabackup` read **~1.4-3+ TB per hourly incremental run** at >1 GB/s, with the log timeline showing each large tablespace being read essentially end-to-end. A 1.5 TB tablespace with only **452 changed pages** took 20 minutes of continuous sequential reads.
- ~700 small tablespaces were processed within seconds (correct behavior); only large tablespaces with scattered changed pages (typical append-heavy or randomly-updated tables) exhibit the near-full reads.
- No entries in `full_scan_tables` applied: no inplace DDL (`MLOG_INDEX_LOAD`) and no encryption changes occurred in the backup windows (verified via `performance_schema` digests and logs).

## Root cause

`pagetracking::range_get_next_page()` is documented as:

> Move the current_page_it iterator to point the last page id in current block

When the scan hits the end of the page set, the iterator is correctly stepped back (`--page_set->current_page_it`). But when the loop breaks because the next changed page is **not adjacent**, the iterator is left pointing at that next, non-adjacent changed page.

The caller `rf_page_tracking_get_next_batch()` then computes:

```cpp
ctxt->filter_batch_end = (*space->current_page_it) + 1;
...
*read_batch_len = ctxt->filter_batch_end * ctxt->page_size - ctxt->offset;
```

so the read batch spans from the start of the current block **through the entire gap** up to and including the first page of the next block. Iterated across a tablespace, every gap between changed-page blocks is read.

Example: changed pages `{10, 11, 12, 50}` result in pages 10-50 being read (41 pages) instead of pages 10-12 and 50 (4 pages). With changed pages near the beginning and end of a multi-TB file, this reads nearly the whole file.

## Fix

Step the iterator back to the last page of the current contiguous block before breaking, matching both the documented behavior and the existing end-of-set branch. Read batches then cover exactly the contiguous changed-page ranges.

The `UNIV_DEBUG` helper `verify_skipped_pages()` still validates that skipped gap pages contain no modifications in the LSN window.

## Notes

- The same code exists identically in the `8.0`, `8.4`, and `trunk` branches; this PR targets `trunk` and the fix applies cleanly to the release branches.
- Logic-level patch validated against production observations; I do not have a full build/test environment for PXB, so please run the regression suite (particularly the page-tracking tests) on this change.


Made with [Cursor](https://cursor.com)