### PR TITLE
PXB-3858 Tablespace_map::scan() via INNODB_TABLESPACES_BRIEF

### DIFF
--- a/storage/innobase/xtrabackup/src/space_map.cc
+++ b/storage/innobase/xtrabackup/src/space_map.cc
@@ -24,6 +24,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <my_systime.h>
 
+#include <dict0dict.h>
 #include <fil0fil.h>
 #include <srv0srv.h>
 
@@ -63,32 +64,29 @@ std::string xb_tablespace_backup_file_path(const std::string &file_name) {
 
 Tablespace_map &Tablespace_map::instance() { return (static_tablespace_map); }
 
-/** Scan I_S.FILES for extended tablespaces.
+/** Scan I_S for extended tablespaces.
 @param[in]  connection MySQL connection object */
 void Tablespace_map::scan(MYSQL *connection) {
-  /* combine General and single tablespace */
+  /* Reading INNODB_TABLESPACES would open every .ibd */
   const char *query =
-      "SELECT T2.PATH, "
-      "       T2.NAME, "
-      "       T1.SPACE_TYPE "
-      "FROM   INFORMATION_SCHEMA.INNODB_TABLESPACES T1 "
-      "       JOIN INFORMATION_SCHEMA.INNODB_TABLESPACES_BRIEF T2 USING "
-      "(SPACE) "
-      "WHERE  T1.SPACE_TYPE = 'Single' && T1.ROW_FORMAT != 'Undo'"
-      "UNION "
-      "SELECT T2.PATH, "
-      "       SUBSTRING_INDEX(SUBSTRING_INDEX(T2.PATH, '/', -1), '.', 1) NAME, "
-      "       T1.SPACE_TYPE "
-      "FROM   INFORMATION_SCHEMA .INNODB_TABLESPACES T1 "
-      "       JOIN INFORMATION_SCHEMA .INNODB_TABLESPACES_BRIEF T2 USING "
-      "(SPACE) "
-      "WHERE  T1.SPACE_TYPE = 'General' && T1.ROW_FORMAT != 'Undo'";
+      "SELECT PATH, "
+      "       IF(SPACE_TYPE='General', "
+      "          SUBSTRING_INDEX(SUBSTRING_INDEX(PATH, '/', -1), '.', 1), "
+      "          NAME "
+      "       ) AS NAME, "
+      "       SPACE "
+      "FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_BRIEF "
+      "WHERE SPACE_TYPE IN ('General', 'Single')";
   MYSQL_RES *mysql_result;
   MYSQL_ROW row;
 
   mysql_result = xb_mysql_query(connection, query, true);
 
   while ((row = mysql_fetch_row(mysql_result)) != nullptr) {
+    space_id_t space_id = static_cast<space_id_t>(strtoul(row[2], nullptr, 10));
+    /* BRIEF reports undo as SPACE_TYPE='Single'; drop undo and other
+       reserved/internal spaces here by space-id. */
+    if (dict_sys_t::is_reserved(space_id)) continue;
     const tablespace_t tablespace(row[0], row[1], TABLESPACE);
     add(tablespace);
   }

--- a/storage/innobase/xtrabackup/test/t/external_general_tablespace_scan.sh
+++ b/storage/innobase/xtrabackup/test/t/external_general_tablespace_scan.sh
@@ -1,0 +1,47 @@
+########################################################################
+# PXB-3858: Tablespace_map::scan() reads INNODB_TABLESPACES_BRIEF and
+# excludes undo/reserved spaces by space-id (dict_sys_t::is_reserved).
+#
+# Verifies that an out-of-datadir general tablespace is backed up and
+# restored to its ORIGINAL (external) path.
+########################################################################
+
+. inc/common.sh
+
+# external general tablespaces (innodb_directories) require 8.0.21+
+require_server_version_higher_than 8.0.20
+
+ext_dir=${TEST_VAR_ROOT}/ext_dir
+mkdir $ext_dir
+
+start_server --innodb-directories="$ext_dir"
+
+run_cmd $MYSQL $MYSQL_ARGS <<EOF
+CREATE TABLESPACE ts_ext ADD DATAFILE '$ext_dir/ts_ext.ibd' ENGINE=InnoDB;
+CREATE TABLE test.t_ext (c1 INT PRIMARY KEY) TABLESPACE ts_ext;
+INSERT INTO test.t_ext VALUES (1), (2), (3);
+
+CREATE TABLE test.t_in (c1 INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO test.t_in VALUES (10), (20), (30);
+EOF
+
+record_db_state test
+
+xtrabackup --backup  --target-dir=$topdir/backup
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+rm -rf $ext_dir
+
+xtrabackup --copy-back --target-dir=$topdir/backup
+start_server --innodb-directories="$ext_dir/"
+
+# PXB-2124: the external datafile must be restored to its original path,
+# not relocated into the data directory.
+[ -f "$ext_dir/ts_ext.ibd" ] \
+    || die "ts_ext.ibd was not restored to the external directory"
+[ ! -f "$mysql_datadir/ts_ext.ibd" ] \
+    || die "ts_ext.ibd was wrongly restored into the data directory (PXB-2124)"
+
+verify_db_state test


### PR DESCRIPTION
Fixes [PXB-3858](https://perconadev.atlassian.net/browse/PXB-3858).

Swapping a query against INNODB_TABLESPACES to INNODB_TABLESPACES_BRIEF and a code-layer filter against reserved space ids, which is equivalent behavior to the original query but without 4x stat calls to every ibd on disk. 

The original query's JOIN filtered out the mysql and innodb_temporary tablespaces, and then used a where clause to exclude the undo tablespaces. Now we're just recognizing that all those excluded tablespaces just happen to be the reserved tablespace space ids and choosing to filter them out in code instead.

The subset of tests that I ran all passed on release-8.4.0-6
```
[100%] Built target xtrabackup
Using /tmp/xbtest/var as test root
Detecting server version...
Running against Percona Server 8.4.10-10 (XtraDB 8.4.10-10)
Using 'xtrabackup' as xtrabackup binary
Using 8 parallel workers

==============================================================================
TEST                                   WORKER    RESULT     TIME(s) or COMMENT
------------------------------------------------------------------------------
validate_copy_back                       w5	[passed]    17
external_general_tablespace_scan         w4	[passed]    27
create_tablespace                        w3	[passed]    36
remote_tablespaces                       w2	[passed]    39
undo_tablespaces                         w1	[passed]    88
==============================================================================
Spent 207 of 92 seconds executing testcases

SUMMARY: 5 run, 5 successful, 0 skipped, 0 failed
```

[PXB-3858]: https://perconadev.atlassian.net/browse/PXB-3858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The JIRA link carries more information.