### PR TITLE
PXB-3800: xtrabackup crashes on system tablespace MLOG_FILE_EXTEND

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -10739,8 +10739,9 @@ byte *fil_tablespace_redo_extend(byte *ptr, const byte *end,
                                  bool parse_only) {
   ut_a(page_id.page_no() == 0);
 
-  /* We never recreate the system tablespace. */
-  ut_a(page_id.space() != TRX_SYS_SPACE);
+  /* Since MySQL 8.0.37 (Bug#36511673) the server redo-logs MLOG_FILE_EXTEND
+  records for the system tablespace as well, so page_id.space() may legitimately
+  be TRX_SYS_SPACE here. Do not assert against it. */
 
   ut_a(parsed_bytes != ULINT_UNDEFINED);
 


### PR DESCRIPTION
## Problem

Jira: [PXB-3800](https://perconadev.atlassian.net/browse/PXB-3800)

`xtrabackup --backup` crashes while copying/parsing the redo log when the source
server is MySQL/Percona Server **8.0.37 or newer**:

```
InnoDB: Assertion failure: fil0fil.cc:...:page_id.space() != TRX_SYS_SPACE
...
fil_tablespace_redo_extend(...)
recv_parse_log_recs()
Redo_Log_Parser::parse_log(...)
Redo_Log_Data_Manager::copy_once(...)
```

## Root cause

`fil_tablespace_redo_extend()` asserts:

```c
/* We never recreate the system tablespace. */
ut_a(page_id.space() != TRX_SYS_SPACE);
```

That assertion predates upstream MySQL **Bug#36511673** ("MLOG_FILE_EXTEND log
record is not redo logged for System tablespace"), fixed in 8.0.37. Since that
fix, the server *does* redo-log `MLOG_FILE_EXTEND` records for the system
tablespace (space 0). When a pre-fix xtrabackup backs up a fixed server, it
aborts the moment it parses one of those records.

Upstream removed this assertion from the server in the same bug fix; xtrabackup
still carries it.

## Fix

Remove the stale assertion so space 0 is handled on the same code path as every
other tablespace.

This is safe for xtrabackup: the apply body of `fil_tablespace_redo_extend()` is
compiled out under `XTRABACKUP` (`#if !defined(UNIV_HOTBACKUP) &&
!defined(XTRABACKUP)`), so during `--backup` the record only needs to *parse*.
The system tablespace is sized during `--prepare` from its FSP header
(`xtrabackup_space_extend()` → `fil_space_extend()`), not from this redo record —
the same mechanism that already handled an auto-extending `ibdata1` before this
redo record ever existed. So the extend record is parsed and skipped, exactly as
it is for every other tablespace.

## Testing

- Confirmed the crash originates from this assertion via the stack trace and by
  diffing against `release-8.0.45-36`, where the server-side change is present.
- Verified `storage/innobase/fil/fil0fil.cc` compiles cleanly (Ubuntu, `-Werror`).


[PXB-3800]: https://perconadev.atlassian.net/browse/PXB-3800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ