### PR TITLE
PXB-3609 : [8.4] xbcloud delete leaves the .md5 file behind

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -223,7 +223,7 @@ void Azure_client::set_endpoint(const std::string &ep, bool development_storage,
 }
 
 bool Azure_client::delete_object(const std::string &container,
-                                 const std::string &name) {
+                                 const std::string &name, bool best_effort) {
   Http_request req(Http_request::DELETE, protocol, host,
                    "/" + container + "/" + name);
   signer->sign_request(container, name, req, time(0));
@@ -234,6 +234,11 @@ bool Azure_client::delete_object(const std::string &container,
   }
 
   if (resp.ok()) {
+    return true;
+  }
+
+  /* Object is not there (BlobNotFound), or we have no permission on it. */
+  if (best_effort && (resp.http_code() == 404 || resp.http_code() == 403)) {
     return true;
   }
 

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.h
@@ -127,7 +127,8 @@ class Azure_client {
   void set_endpoint(const std::string &ep, bool development_storage,
                     const std::string &storage_account);
 
-  bool delete_object(const std::string &container, const std::string &name);
+  bool delete_object(const std::string &container, const std::string &name,
+                     bool best_effort);
 
   bool create_container(const std::string &name);
 
@@ -256,8 +257,9 @@ class Azure_object_store : public Object_store {
                                             });
   }
   virtual bool delete_object(const std::string &container,
-                             const std::string &name) override {
-    return azure_client.delete_object(container, name);
+                             const std::string &name,
+                             bool best_effort) override {
+    return azure_client.delete_object(container, name, best_effort);
   }
   virtual Http_buffer download_object(const std::string &container,
                                       const std::string &name,

--- a/storage/innobase/xtrabackup/src/xbcloud/object_store.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/object_store.h
@@ -51,8 +51,18 @@ class Object_store {
   virtual bool async_delete_object(const std::string &container,
                                    const std::string &object, Event_handler *h,
                                    std::function<void(bool)> f = {}) = 0;
+  /**
+   * Delete a single object.
+   *
+   * @param container    Container/bucket name.
+   * @param name         Object name.
+   * @param best_effort  When true, an object we cannot delete because it is
+   *                     not there, or because we have no permission on it,
+   *                     is a success and is not logged.
+   * @return true on success, false on error.
+   */
   virtual bool delete_object(const std::string &container,
-                             const std::string &name) = 0;
+                             const std::string &name, bool best_effort) = 0;
   virtual Http_buffer download_object(const std::string &container,
                                       const std::string &name,
                                       bool &success) = 0;

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.cc
@@ -293,7 +293,7 @@ void S3_signerV2::sign_request(const std::string &hostname,
 }
 
 bool S3_client::delete_object(const std::string &bucket,
-                              const std::string &name) {
+                              const std::string &name, bool best_effort) {
   Http_request req(Http_request::DELETE, protocol, hostname(bucket),
                    bucketname(bucket) + "/" + name);
   signer->sign_request(hostname(bucket), bucket, req, time(0));
@@ -304,6 +304,12 @@ bool S3_client::delete_object(const std::string &bucket,
   }
 
   if (resp.ok()) {
+    return true;
+  }
+
+  /* Object is not there (S3 answers 204 for this, some S3-compatible
+  services 404), or we have no permission on it. Neither is our problem. */
+  if (best_effort && (resp.http_code() == 404 || resp.http_code() == 403)) {
     return true;
   }
 

--- a/storage/innobase/xtrabackup/src/xbcloud/s3.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/s3.h
@@ -229,7 +229,8 @@ class S3_client {
 
   bool probe_api_version_and_lookup(const std::string &bucket);
 
-  bool delete_object(const std::string &bucket, const std::string &name);
+  bool delete_object(const std::string &bucket, const std::string &name,
+                     bool best_effort);
 
   bool create_bucket(const std::string &name);
 
@@ -355,8 +356,9 @@ class S3_object_store : public Object_store {
                                          });
   }
   virtual bool delete_object(const std::string &container,
-                             const std::string &name) override {
-    return s3_client.delete_object(container, name);
+                             const std::string &name,
+                             bool best_effort) override {
+    return s3_client.delete_object(container, name, best_effort);
   }
   virtual Http_buffer download_object(const std::string &container,
                                       const std::string &name,

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.cc
@@ -590,7 +590,7 @@ bool Swift_client::validate_response(const Http_request &req,
 }
 
 bool Swift_client::delete_object(const std::string &container,
-                                 const std::string &name) {
+                                 const std::string &name, bool best_effort) {
   Http_request req(Http_request::DELETE, protocol, host,
                    path + container + "/" + name);
   req.add_header("X-Auth-Token", token);
@@ -601,6 +601,11 @@ bool Swift_client::delete_object(const std::string &container,
   }
 
   if (resp.ok()) {
+    return true;
+  }
+
+  /* Object is not there, or we have no permission on it. */
+  if (best_effort && (resp.http_code() == 404 || resp.http_code() == 403)) {
     return true;
   }
 

--- a/storage/innobase/xtrabackup/src/xbcloud/swift.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/swift.h
@@ -166,7 +166,8 @@ class Swift_client {
     split_url(url, protocol, host, path);
   }
 
-  bool delete_object(const std::string &container, const std::string &name);
+  bool delete_object(const std::string &container, const std::string &name,
+                     bool best_effort);
 
   Http_buffer download_object(const std::string &container,
                               const std::string &name, bool &success);
@@ -258,8 +259,9 @@ class Swift_object_store : public Object_store {
                                             });
   }
   virtual bool delete_object(const std::string &container,
-                             const std::string &name) override {
-    return swift_client.delete_object(container, name);
+                             const std::string &name,
+                             bool best_effort) override {
+    return swift_client.delete_object(container, name, best_effort);
   }
   virtual Http_buffer download_object(const std::string &container,
                                       const std::string &name,

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1120,7 +1120,7 @@ bool xbcloud_delete(Object_store *store, const std::string &container,
     std::sort(dirs.begin(), dirs.end(), std::greater<std::string>());
     for (const auto &d : dirs) {
       msg_ts("%s: Deleting directory %s.\n", my_progname, d.c_str());
-      if (!store->delete_object(container, d)) {
+      if (!store->delete_object(container, d, false)) {
         msg_ts("%s: Delete failed. Cannot delete directory %s.\n", my_progname,
                d.c_str());
         return false;
@@ -1129,9 +1129,26 @@ bool xbcloud_delete(Object_store *store, const std::string &container,
 
     // Delete the root directory of the backup
     msg_ts("%s: Deleting directory %s.\n", my_progname, backup_name.c_str());
-    if (!store->delete_object(container, backup_name)) {
+    if (!store->delete_object(container, backup_name, false)) {
       msg_ts("%s: Warning: Failed to delete root directory %s.\n", my_progname,
              backup_name.c_str());
+    }
+  }
+
+  /* put --md5 uploads the checksum file as <backup_name>.md5, next to the
+  backup directory and not inside it, so the listing above never returns it.
+  Delete it here.
+
+  We do not know whether this backup was taken with --md5, so the delete is
+  unconditional and best_effort: a .md5 file that is not there, or that we
+  are not allowed to delete, leaves us behaving as we did before.
+
+  Partial deletes keep the backup, so they keep its .md5 file too. */
+  if (partial_file_list.empty()) {
+    const std::string md5_object = backup_name + ".md5";
+    if (!store->delete_object(container, md5_object, true)) {
+      msg_ts("%s: Warning: Failed to delete %s.\n", my_progname,
+             md5_object.c_str());
     }
   }
 

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete.sh
@@ -1,0 +1,136 @@
+################################################################################
+# PXB-3609: xbcloud delete must remove the <backup_name>.md5 file.
+#
+# `xbcloud put --md5` uploads the checksum file as <backup_name>.md5, next to
+# the backup directory and not inside it.  `xbcloud delete` lists only what is
+# under <backup_name>/, so before the fix that file was never deleted and
+# stayed in the bucket after the backup itself was gone.
+#
+# Scenarios:
+#   1. put --md5 then delete  -> the .md5 file goes with the backup.
+#   2. put (no --md5) then delete -> completes cleanly; a .md5 file that was
+#      never created must not turn into an error.
+#
+# Needs the MinIO client (mc) to look at individual object names, which
+# xbcloud itself cannot show.  mc talks to MinIO over the network, so no
+# docker is involved.  In CI the pipeline copies mc out of the MinIO image and
+# points XBCLOUD_MC at it; developers can also just have mc in PATH.
+################################################################################
+. inc/xbcloud_common.sh
+is_xbcloud_credentials_set
+is_minio_server || skip_test "requires MinIO to list bucket contents"
+
+MC_BIN=${XBCLOUD_MC:-$(command -v mc 2>/dev/null || true)}
+[ -n "$MC_BIN" ] && [ -x "$MC_BIN" ] \
+    || skip_test "requires the MinIO client: set XBCLOUD_MC or put mc in PATH"
+
+ENDPOINT=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-endpoint=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_KEY=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-access-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_SECRET=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-secret-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+[ -n "$ENDPOINT" ] && [ -n "$ROOT_KEY" ] && [ -n "$ROOT_SECRET" ] \
+    || skip_test "XBCLOUD_CREDENTIALS lacks s3-endpoint/access-key/secret-key"
+
+# mc keeps its configuration under $HOME, which is not writable in the test
+# image, so give it one of our own.  Credentials go in MC_HOST_<alias> rather
+# than on the command line, where they would end up in the test log.
+# $topdir only exists once the server has been set up, and mc needs a config
+# directory it can write to before that, so fall back to the worker's own
+# scratch space rather than ending up at /mcconf.
+MC="$MC_BIN --config-dir ${topdir:-${MYSQLD_VARDIR:-$PWD/var}}/mcconf.$$"
+export MC_HOST_pxb="${ENDPOINT%%://*}://${ROOT_KEY}:${ROOT_SECRET}@${ENDPOINT#*://}"
+
+# The test owns its bucket: nothing has to exist beforehand, and workers
+# running in parallel cannot collide.  mb -p is happy if it is already there.
+BUCKET="pxbmd5-${uuid}"
+XB_FLAGS="--storage=s3 --s3-endpoint=${ENDPOINT} --s3-bucket=${BUCKET} \
+--s3-access-key=${ROOT_KEY} --s3-secret-key=${ROOT_SECRET} --s3-bucket-lookup=path"
+
+$MC mb -p "pxb/${BUCKET}" >/dev/null 2>&1 || die "could not create bucket ${BUCKET}"
+
+# An alias mc cannot resolve is treated as a local path rather than an error,
+# which would make every listing come back empty instead of failing.  Check it
+# once here so the tests below cannot pass for that reason.
+$MC ls "pxb/${BUCKET}" >/dev/null 2>&1 \
+    || die "cannot reach bucket ${BUCKET} through mc -- check XBCLOUD_CREDENTIALS"
+
+cleanup_md5_delete() {
+    local rc=$?
+    $MC rb --force "pxb/${BUCKET}" >/dev/null 2>&1 || true
+    return $rc
+}
+trap cleanup_md5_delete EXIT
+
+start_server --innodb_file_per_table
+
+md5_backup="md5_backup_${uuid}"
+plain_backup="plain_backup_${uuid}"
+
+mysql -e "CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(64))" test
+mysql -e "INSERT INTO t VALUES (1,'one'),(2,'two'),(3,'three')" test
+
+# Every object key in the bucket, one per line.  mc ls prints the key last.
+list_files_in_bucket() {
+    $MC ls --recursive "pxb/${BUCKET}" 2>/dev/null | awk '{print $NF}'
+}
+
+# The keys belonging to one backup: everything under <name>/ plus the
+# <name>.md5 file.  Other tests share this bucket, so the question can only be
+# asked per backup, never by checking for an empty bucket.  grep exits 1 when
+# nothing matches, which is the success case here, hence || true.
+list_files_of_backup() {
+    list_files_in_bucket | grep -E "^${1}(/|\.md5$)" || true
+}
+
+################################################################################
+# Scenario 1: a backup taken with --md5 must lose its .md5 file on delete.
+################################################################################
+
+vlog "take a full backup and upload it with --md5"
+
+md5_dir=$topdir/md5_backup
+mkdir -p $md5_dir
+xtrabackup --backup --stream=xbstream --extra-lsndir=$md5_dir \
+    --target-dir=$md5_dir \
+    | run_cmd xbcloud put --md5 --parallel=4 $XB_FLAGS ${md5_backup}
+
+list_files_of_backup "$md5_backup" | grep -q "^${md5_backup}\.md5$" \
+    || die "expected ${md5_backup}.md5 to exist after put --md5"
+vlog "${md5_backup}.md5 present after put"
+
+run_cmd xbcloud delete --parallel=4 $XB_FLAGS ${md5_backup}
+
+remaining=$(list_files_of_backup "$md5_backup")
+if [ -n "$remaining" ]; then
+    echo "PXB-3609: objects left in bucket after delete:" >&2
+    echo "$remaining" >&2
+    die "PXB-3609: xbcloud delete left objects behind: $(echo $remaining)"
+fi
+vlog "delete removed the backup and ${md5_backup}.md5"
+
+################################################################################
+# Scenario 2: a backup taken without --md5 has no .md5 file.  The delete is
+# issued unconditionally -- checking first would make delete require
+# s3:GetObject -- so a file that is not there must not be treated as an error.
+################################################################################
+
+vlog "take a full backup and upload it without --md5"
+
+plain_dir=$topdir/plain_backup
+mkdir -p $plain_dir
+xtrabackup --backup --stream=xbstream --extra-lsndir=$plain_dir \
+    --target-dir=$plain_dir \
+    | run_cmd xbcloud put --parallel=4 $XB_FLAGS ${plain_backup}
+
+list_files_of_backup "$plain_backup" | grep -q "^${plain_backup}\.md5$" \
+    && die "put without --md5 unexpectedly wrote ${plain_backup}.md5"
+
+run_cmd xbcloud delete --parallel=4 $XB_FLAGS ${plain_backup}
+
+remaining=$(list_files_of_backup "$plain_backup")
+[ -z "$remaining" ] \
+    || die "objects left after deleting a backup without --md5: $(echo $remaining)"
+
+vlog "delete of a backup without --md5 completed cleanly"

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_permissions.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_permissions.sh
@@ -1,0 +1,168 @@
+################################################################################
+# PXB-3609: deleting the .md5 file must not require new privileges.
+#
+# The .md5 file is deleted unconditionally rather than checked for first,
+# precisely so that a least-privilege retention user can still clean it up.
+# Checking would need s3:GetObject, which such a user is not granted -- the
+# check would be denied, the delete would be skipped, and the .md5 file would
+# be left behind for exactly the users who follow least-privilege guidance.
+#
+# This test pins that: a MinIO user holding only
+#   s3:ListBucket   (on the bucket)
+#   s3:DeleteObject (on the objects)
+# must be able to delete a backup taken with --md5, .md5 file included.
+#
+# Needs the MinIO client (mc) to create the restricted user and to look at
+# object names.  mc talks to MinIO over the network, so no docker is involved.
+# In CI the pipeline copies mc out of the MinIO image and points XBCLOUD_MC at
+# it; developers can also just have mc in PATH.
+################################################################################
+. inc/xbcloud_common.sh
+is_xbcloud_credentials_set
+is_minio_server || skip_test "requires MinIO for IAM users and bucket listing"
+
+MC_BIN=${XBCLOUD_MC:-$(command -v mc 2>/dev/null || true)}
+[ -n "$MC_BIN" ] && [ -x "$MC_BIN" ] \
+    || skip_test "requires the MinIO client: set XBCLOUD_MC or put mc in PATH"
+
+ENDPOINT=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-endpoint=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_KEY=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-access-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_SECRET=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-secret-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+[ -n "$ENDPOINT" ] && [ -n "$ROOT_KEY" ] && [ -n "$ROOT_SECRET" ] \
+    || skip_test "XBCLOUD_CREDENTIALS lacks s3-endpoint/access-key/secret-key"
+
+# mc keeps its configuration under $HOME, which is not writable in the test
+# image, so give it one of our own.  Credentials go in MC_HOST_<alias> rather
+# than on the command line, where they would end up in the test log.
+# $topdir only exists once the server has been set up, and mc needs a config
+# directory it can write to before that, so fall back to the worker's own
+# scratch space rather than ending up at /mcconf.
+MC="$MC_BIN --config-dir ${topdir:-${MYSQLD_VARDIR:-$PWD/var}}/mcconf.$$"
+export MC_HOST_pxb="${ENDPOINT%%://*}://${ROOT_KEY}:${ROOT_SECRET}@${ENDPOINT#*://}"
+
+# Workers run in parallel against one MinIO, so the bucket, the user and the
+# policy all carry this test's own uuid.  Bucket names must be lowercase and
+# at most 63 characters; the uuid is 36.
+BUCKET="pxbmd5perm-${uuid}"
+DEL_USER="md5perm-${uuid}"
+DEL_POLICY="${DEL_USER}-pol"
+BACKUP_NAME="md5perm_backup_${uuid}"
+
+ROOT_FLAGS="--storage=s3 --s3-endpoint=${ENDPOINT} --s3-bucket=${BUCKET} \
+--s3-access-key=${ROOT_KEY} --s3-secret-key=${ROOT_SECRET} --s3-bucket-lookup=path"
+DEL_PASS="md5permsecret"
+DEL_FLAGS="--storage=s3 --s3-endpoint=${ENDPOINT} --s3-bucket=${BUCKET} \
+--s3-access-key=${DEL_USER} --s3-secret-key=${DEL_PASS} --s3-bucket-lookup=path"
+
+$MC mb -p "pxb/${BUCKET}" >/dev/null 2>&1 || die "could not create bucket ${BUCKET}"
+
+# An alias mc cannot resolve is treated as a local path rather than an error,
+# which would make every listing come back empty instead of failing.  Check it
+# once here so the tests below cannot pass for that reason.
+$MC ls "pxb/${BUCKET}" >/dev/null 2>&1 \
+    || die "cannot reach bucket ${BUCKET} through mc -- check XBCLOUD_CREDENTIALS"
+
+# List the bucket, delete objects, and deliberately no s3:GetObject.
+cat > $topdir/${DEL_POLICY}.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${BUCKET}" },
+    { "Effect": "Allow",
+      "Action": "s3:DeleteObject",
+      "Resource": "arn:aws:s3:::${BUCKET}/*" }
+  ]
+}
+EOF
+
+$MC admin policy create pxb "$DEL_POLICY" $topdir/${DEL_POLICY}.json >/dev/null \
+    || die "could not create policy ${DEL_POLICY}"
+$MC admin user add pxb "$DEL_USER" "$DEL_PASS" >/dev/null \
+    || die "could not create user ${DEL_USER}"
+$MC admin policy attach pxb "$DEL_POLICY" --user "$DEL_USER" >/dev/null \
+    || die "could not attach policy ${DEL_POLICY} to ${DEL_USER}"
+
+cleanup_md5_delete_permissions() {
+    local rc=$?
+    $MC rb --force "pxb/${BUCKET}" >/dev/null 2>&1 || true
+    $MC admin policy detach pxb "$DEL_POLICY" --user "$DEL_USER" >/dev/null 2>&1 || true
+    $MC admin user remove pxb "$DEL_USER" >/dev/null 2>&1 || true
+    $MC admin policy remove pxb "$DEL_POLICY" >/dev/null 2>&1 || true
+    return $rc
+}
+trap cleanup_md5_delete_permissions EXIT
+
+start_server --innodb_file_per_table
+
+mysql -e "CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(64))" test
+mysql -e "INSERT INTO t VALUES (1,'one'),(2,'two'),(3,'three')" test
+
+# Listed with root credentials: the restricted user is what we are testing,
+# not what we measure with.
+list_files_in_bucket() {
+    $MC ls --recursive "pxb/${BUCKET}" 2>/dev/null | awk '{print $NF}'
+}
+
+vlog "upload a backup WITH --md5 using root credentials"
+
+LOG_UPLOAD=${OUTFILE}.xbcloud_put.log
+full_dir=$topdir/full
+mkdir -p "$full_dir"
+xtrabackup --backup --stream=xbstream --extra-lsndir="$full_dir" \
+    --target-dir="$full_dir" 2>/dev/null \
+    | xbcloud put --md5 --parallel=4 $ROOT_FLAGS "$BACKUP_NAME" \
+        > $LOG_UPLOAD 2>&1
+rc=("${PIPESTATUS[@]}")
+[ "${rc[0]}" = "0" ] && [ "${rc[1]}" = "0" ] \
+    || { cat $LOG_UPLOAD >&2; die "test setup: xbcloud put --md5 failed"; }
+
+list_files_in_bucket | grep -q "^${BACKUP_NAME}\.md5$" \
+    || die "test setup: expected ${BACKUP_NAME}.md5 after put --md5"
+vlog "${BACKUP_NAME}.md5 uploaded"
+
+# Prove the policy is in force before drawing any conclusion from a successful
+# delete: a policy that failed to attach would leave the user with default
+# rights and this test would pass for the wrong reason.  A read of the .md5
+# file must be refused -- that is the request a check-before-delete would make.
+export MC_HOST_del="${ENDPOINT%%://*}://${DEL_USER}:${DEL_PASS}@${ENDPOINT#*://}"
+
+if $MC cat "del/${BUCKET}/${BACKUP_NAME}.md5" >/dev/null 2>&1; then
+    die "delete-only user can read ${BACKUP_NAME}.md5 -- the policy is not in \
+force, so this test would not prove anything"
+fi
+vlog "confirmed: the delete-only user is denied read access to ${BACKUP_NAME}.md5"
+
+# ... and it must still be able to list, or a failed delete would prove nothing
+# either.
+$MC ls "del/${BUCKET}" >/dev/null 2>&1 \
+    || die "delete-only user cannot list the bucket -- policy setup is broken"
+
+vlog "delete the backup as the delete-only user (ListBucket + DeleteObject, no GetObject)"
+
+LOG_DELETE=${OUTFILE}.xbcloud_delete.log
+if ! xbcloud delete --parallel=4 $DEL_FLAGS "$BACKUP_NAME" > $LOG_DELETE 2>&1; then
+    cat $LOG_DELETE >&2
+    die "PXB-3609: delete-only user could not delete the backup -- xbcloud is \
+demanding privileges beyond ListBucket + DeleteObject"
+fi
+
+# An AccessDenied that xbcloud swallowed would show up here even with a clean
+# exit status.
+if grep -qiE 'access denied|forbidden|403' $LOG_DELETE; then
+    cat $LOG_DELETE >&2
+    die "PXB-3609: delete-only user hit a permission error during delete"
+fi
+
+remaining=$(list_files_in_bucket)
+if [ -n "$remaining" ]; then
+    echo "objects left in bucket after the delete-only user ran delete:" >&2
+    echo "$remaining" >&2
+    die "PXB-3609: delete-only user left objects behind: $(echo $remaining)"
+fi
+
+vlog "delete-only user removed the whole backup including ${BACKUP_NAME}.md5"

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_prefix_scope.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_prefix_scope.sh
@@ -1,0 +1,149 @@
+################################################################################
+# PXB-3609: a user scoped to the backup prefix must not be disturbed by the
+# .md5 file.
+#
+# <backup_name>.md5 sits next to the backup directory, so a user whose rights
+# are scoped to <backup_name>/* has none on it at all.  The DELETE we now
+# issue for it comes back 403, not 404.  That must not become a warning or a
+# failure: such a user could never have uploaded a .md5 file either, and if
+# one is there it belongs to somebody else.  xbcloud has to behave exactly as
+# it did before this fix.
+#
+# Needs the MinIO client (mc) to create the restricted user and to look at
+# object names.  mc talks to MinIO over the network, so no docker is involved.
+# In CI the pipeline copies mc out of the MinIO image and points XBCLOUD_MC at
+# it; developers can also just have mc in PATH.
+################################################################################
+. inc/xbcloud_common.sh
+is_xbcloud_credentials_set
+is_minio_server || skip_test "requires MinIO for IAM users and bucket listing"
+
+MC_BIN=${XBCLOUD_MC:-$(command -v mc 2>/dev/null || true)}
+[ -n "$MC_BIN" ] && [ -x "$MC_BIN" ] \
+    || skip_test "requires the MinIO client: set XBCLOUD_MC or put mc in PATH"
+
+ENDPOINT=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-endpoint=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_KEY=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-access-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+ROOT_SECRET=$(echo "$XBCLOUD_CREDENTIALS" \
+    | awk -F's3-secret-key=' '{print $2}' | awk '{print $1}' | tr -d "'")
+[ -n "$ENDPOINT" ] && [ -n "$ROOT_KEY" ] && [ -n "$ROOT_SECRET" ] \
+    || skip_test "XBCLOUD_CREDENTIALS lacks s3-endpoint/access-key/secret-key"
+
+# mc keeps its configuration under $HOME, which is not writable in the test
+# image, so give it one of our own.  Credentials go in MC_HOST_<alias> rather
+# than on the command line, where they would end up in the test log.
+# $topdir only exists once the server has been set up, and mc needs a config
+# directory it can write to before that, so fall back to the worker's own
+# scratch space rather than ending up at /mcconf.
+MC="$MC_BIN --config-dir ${topdir:-${MYSQLD_VARDIR:-$PWD/var}}/mcconf.$$"
+export MC_HOST_pxb="${ENDPOINT%%://*}://${ROOT_KEY}:${ROOT_SECRET}@${ENDPOINT#*://}"
+
+# Workers run in parallel against one MinIO, so the bucket, the user and the
+# policy all carry this test's own uuid.
+BUCKET="pxbmd5pfx-${uuid}"
+PFX_USER="md5pfx-${uuid}"
+PFX_POLICY="${PFX_USER}-pol"
+PFX_PASS="md5pfxsecret"
+BACKUP_NAME="md5pfx_backup_${uuid}"
+
+ROOT_FLAGS="--storage=s3 --s3-endpoint=${ENDPOINT} --s3-bucket=${BUCKET} \
+--s3-access-key=${ROOT_KEY} --s3-secret-key=${ROOT_SECRET} --s3-bucket-lookup=path"
+PFX_FLAGS="--storage=s3 --s3-endpoint=${ENDPOINT} --s3-bucket=${BUCKET} \
+--s3-access-key=${PFX_USER} --s3-secret-key=${PFX_PASS} --s3-bucket-lookup=path"
+
+$MC mb -p "pxb/${BUCKET}" >/dev/null 2>&1 || die "could not create bucket ${BUCKET}"
+
+# An alias mc cannot resolve is treated as a local path rather than an error,
+# which would make every listing come back empty instead of failing.  Check it
+# once here so the tests below cannot pass for that reason.
+$MC ls "pxb/${BUCKET}" >/dev/null 2>&1 \
+    || die "cannot reach bucket ${BUCKET} through mc -- check XBCLOUD_CREDENTIALS"
+
+# Rights on everything inside <backup>/ and nothing at the bucket root, so
+# <backup>.md5 is out of reach.
+cat > $topdir/${PFX_POLICY}.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${BUCKET}" },
+    { "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+      "Resource": "arn:aws:s3:::${BUCKET}/${BACKUP_NAME}/*" }
+  ]
+}
+EOF
+
+$MC admin policy create pxb "$PFX_POLICY" $topdir/${PFX_POLICY}.json >/dev/null \
+    || die "could not create policy ${PFX_POLICY}"
+$MC admin user add pxb "$PFX_USER" "$PFX_PASS" >/dev/null \
+    || die "could not create user ${PFX_USER}"
+$MC admin policy attach pxb "$PFX_POLICY" --user "$PFX_USER" >/dev/null \
+    || die "could not attach policy ${PFX_POLICY} to ${PFX_USER}"
+
+cleanup_md5_delete_prefix_scope() {
+    local rc=$?
+    $MC rb --force "pxb/${BUCKET}" >/dev/null 2>&1 || true
+    $MC admin policy detach pxb "$PFX_POLICY" --user "$PFX_USER" >/dev/null 2>&1 || true
+    $MC admin user remove pxb "$PFX_USER" >/dev/null 2>&1 || true
+    $MC admin policy remove pxb "$PFX_POLICY" >/dev/null 2>&1 || true
+    return $rc
+}
+trap cleanup_md5_delete_prefix_scope EXIT
+
+start_server --innodb_file_per_table
+
+mysql -e "CREATE TABLE t (a INT PRIMARY KEY, b VARCHAR(64))" test
+mysql -e "INSERT INTO t VALUES (1,'one'),(2,'two'),(3,'three')" test
+
+list_files_in_bucket() {
+    $MC ls --recursive "pxb/${BUCKET}" 2>/dev/null | awk '{print $NF}'
+}
+
+vlog "upload a backup WITH --md5 using root credentials"
+
+LOG_UPLOAD=${OUTFILE}.xbcloud_put.log
+full_dir=$topdir/full
+mkdir -p "$full_dir"
+xtrabackup --backup --stream=xbstream --extra-lsndir="$full_dir" \
+    --target-dir="$full_dir" 2>/dev/null \
+    | xbcloud put --md5 --parallel=4 $ROOT_FLAGS "$BACKUP_NAME" \
+        > $LOG_UPLOAD 2>&1
+rc=("${PIPESTATUS[@]}")
+[ "${rc[0]}" = "0" ] && [ "${rc[1]}" = "0" ] \
+    || { cat $LOG_UPLOAD >&2; die "test setup: xbcloud put --md5 failed"; }
+
+list_files_in_bucket | grep -q "^${BACKUP_NAME}\.md5$" \
+    || die "test setup: expected ${BACKUP_NAME}.md5 after put --md5"
+
+vlog "delete the backup as the prefix-scoped user"
+
+LOG_DELETE=${OUTFILE}.xbcloud_delete.log
+if ! xbcloud delete --parallel=4 $PFX_FLAGS "$BACKUP_NAME" > $LOG_DELETE 2>&1; then
+    cat $LOG_DELETE >&2
+    die "PXB-3609: delete failed for a prefix-scoped user -- being unable to \
+remove the .md5 file must not fail the delete"
+fi
+
+# The .md5 file is out of this user's reach.  Saying so on every delete would
+# be noise, and it is what xbcloud did before the fix, so the run has to be
+# quiet about it.
+if grep -qiE 'warning|failed to delete|access denied|forbidden|403' $LOG_DELETE; then
+    cat $LOG_DELETE >&2
+    die "PXB-3609: delete complained about ${BACKUP_NAME}.md5, which this user \
+has no rights on"
+fi
+
+# The backup itself must be gone ...
+remaining=$(list_files_in_bucket | grep -E "^${BACKUP_NAME}/" || true)
+[ -z "$remaining" ] || die "backup objects left behind: $(echo $remaining)"
+
+# ... and the .md5 file is expected to survive: nobody with these rights could
+# have removed it, before or after this fix.
+list_files_in_bucket | grep -q "^${BACKUP_NAME}\.md5$" \
+    || die "unexpected: ${BACKUP_NAME}.md5 was removed by a user with no rights on it"
+
+vlog "prefix-scoped delete removed the backup quietly and left ${BACKUP_NAME}.md5"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3609

xbcloud put --md5 uploads the checksum file as <backup_name>.md5, next to the backup directory and not inside it. xbcloud delete lists only what is under <backup_name>/, so the .md5 file xbcloud generated was never deleted and stayed in the bucket after the backup itself was gone.

Delete <backup_name>.md5 along with the backup.

At delete time we do not know whether the backup was taken with --md5, so the delete is unconditional and delete_object() takes a best_effort flag for it: an object that is not there, or that we have no permission on, is not reported as an error. S3 answers 204 for a DELETE of a missing key while Azure and Swift answer 404, and a user whose rights are scoped to <backup_name>/* gets 403 for the .md5 file whether it exists or not. In all of those cases we stay quiet and leave things as they were before this fix. Real errors are still reported, and the backup itself is deleted as usual.

We do not check whether the file exists before deleting it, so that delete does not start requiring s3:GetObject - a retention user with only ListBucket and DeleteObject must still be able to remove a backup.

Tests: md5_delete, md5_delete_permissions, md5_delete_prefix_scope.