### PR TITLE
PXB-3502 [9.7]: Process largest files first in all parallel phases

### DIFF
--- a/storage/innobase/xtrabackup/src/backup_copy.cc
+++ b/storage/innobase/xtrabackup/src/backup_copy.cc
@@ -60,6 +60,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <set>
 #include <sstream>
 #include <string>
+#include <vector>
 #include "changed_page_tracking.h"
 #include "common.h"
 #include "fil_cur.h"
@@ -104,16 +105,39 @@ xb_regex_t preg_filepath;
 static std::set<std::string> skip_copy_back_list;
 
 class datadir_queue {
-  std::queue<datadir_entry_t> queue;
+  // Comparator sorting datadir entries by their size.
+  struct queued_datadir_entry_compare {
+    bool operator()(const datadir_entry_t &lhs,
+                    const datadir_entry_t &rhs) const {
+      // Empty directories are considered to be smaller than files.
+      if (lhs.is_empty_dir != rhs.is_empty_dir) {
+        return lhs.is_empty_dir;
+      }
+
+      auto lhs_size = lhs.file_size >= 0 ? lhs.file_size : -1;
+      auto rhs_size = rhs.file_size >= 0 ? rhs.file_size : -1;
+
+      if (lhs_size != rhs_size) {
+        return lhs_size < rhs_size;
+      }
+
+      // If files are same size, order them by path to keep sorting
+      // deterministic.
+      return lhs.path > rhs.path;
+    }
+  };
+
+  std::priority_queue<datadir_entry_t, std::vector<datadir_entry_t>,
+                      queued_datadir_entry_compare>
+      queue;
   mysql_mutex_t mutex;
   mysql_cond_t cond;
-  bool final;
+  bool final = false;
 
  public:
   datadir_queue() {
     mysql_mutex_init(0, &mutex, MY_MUTEX_INIT_FAST);
     mysql_cond_init(0, &cond);
-    final = false;
   }
   ~datadir_queue() {
     mysql_cond_destroy(&cond);
@@ -140,7 +164,7 @@ class datadir_queue {
       mysql_mutex_unlock(&mutex);
       return false;
     }
-    entry = queue.front();
+    entry = queue.top();
     queue.pop();
     mysql_mutex_unlock(&mutex);
     return true;
@@ -424,9 +448,14 @@ bool backup_file_printf(const char *filename, const char *fmt, ...) {
   return (result);
 }
 
+/************************************************************************
+Common body for parallel thread execution. Takes a pre-populated and
+completed datadir_queue and spawns N worker threads that each receive a
+datadir_thread_ctxt_t*. Waits for all threads to finish and returns
+true if every thread succeeded. */
 template <typename F>
-bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
-                      const char *thread_description) {
+bool run_worker_threads(datadir_queue &queue, F func, uint n,
+                        const char *thread_description) {
   datadir_thread_ctxt_t *data_threads;
   uint i, count;
   ib_mutex_t count_mutex;
@@ -439,25 +468,14 @@ bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
   mutex_create(LATCH_ID_XTRA_COUNT_MUTEX, &count_mutex);
   count = n;
 
-  datadir_queue queue;
-
   for (i = 0; i < n; i++) {
     data_threads[i].n_thread = i + 1;
     data_threads[i].count = &count;
     data_threads[i].count_mutex = &count_mutex;
     data_threads[i].queue = &queue;
+    data_threads[i].ret = true;
     os_thread_create(PFS_NOT_INSTRUMENTED, 0, func, &data_threads[i]).start();
   }
-
-  xb_process_datadir(
-      dir, suffix,
-      [&](const datadir_entry_t &entry, void *arg) mutable -> bool {
-        queue.push(entry);
-        return true;
-      },
-      nullptr);
-
-  queue.complete();
 
   /* Wait for threads to exit */
   while (1) {
@@ -482,7 +500,25 @@ bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
 
   ut::free(data_threads);
 
-  return (ret);
+  return ret;
+}
+
+template <typename F>
+bool run_data_threads(const char *dir, const char *suffix, F func, uint n,
+                      const char *thread_description) {
+  datadir_queue queue;
+
+  xb_process_datadir(
+      dir, suffix,
+      [&](const datadir_entry_t &entry, void *arg) mutable -> bool {
+        queue.push(entry);
+        return true;
+      },
+      nullptr);
+
+  queue.complete();
+
+  return run_worker_threads(queue, func, n, thread_description);
 }
 
 // Explicit instantiation for function pointer type:
@@ -589,9 +625,15 @@ bool copy_file(ds_ctxt_t *datasink, const char *src_file_path,
   action = xb_get_copy_action();
   if (pos >= 0) {
     xb::info() << action << " " << src_file_path << " to " << dstfile->path
-               << " up to position " << pos;
+               << " up to position " << pos << ", size "
+               << cursor.statinfo.st_size << " ("
+               << xtrabackup::utils::human_readable(cursor.statinfo.st_size)
+               << ")";
   } else {
-    xb::info() << action << " " << src_file_path << " to " << dstfile->path;
+    xb::info() << action << " " << src_file_path << " to " << dstfile->path
+               << ", size " << cursor.statinfo.st_size << " ("
+               << xtrabackup::utils::human_readable(cursor.statinfo.st_size)
+               << ")";
   }
 
   /* The main copy loop */
@@ -1156,21 +1198,23 @@ void Myrocks_datadir::scan_dir(const std::string &dir,
           return;
         }
         char buf[FN_REFLEN];
+        struct stat statinfo;
         fn_format(buf, name, path, "", MY_UNPACK_FILENAME | MY_SAFE_PATH);
+        ssize_t fsize = (stat(buf, &statinfo) == 0) ? statinfo.st_size : -1;
         if (ends_with(name, ".log")) {
           if (scan_type == SCAN_ALL || scan_type == SCAN_WAL) {
             result.push_back(datadir_entry_t(
                 "", buf, dest_wal_dir != nullptr ? dest_wal_dir : dest_data_dir,
-                name, false));
+                name, false, fsize));
           }
         } else if (ends_with(name, ".sst")) {
           if (scan_type == SCAN_ALL || scan_type == SCAN_DATA) {
             result.push_back(
-                datadir_entry_t("", buf, dest_data_dir, name, false));
+                datadir_entry_t("", buf, dest_data_dir, name, false, fsize));
           }
         } else if (scan_type == SCAN_ALL || scan_type == SCAN_META) {
           result.push_back(
-              datadir_entry_t("", buf, dest_data_dir, name, false));
+              datadir_entry_t("", buf, dest_data_dir, name, false, fsize));
         }
       },
       false);
@@ -1301,63 +1345,96 @@ Myrocks_checkpoint::file_list Myrocks_checkpoint::data_files() const {
   return Myrocks_datadir(checkpoint_dir).data_files();
 }
 
-static void par_copy_or_move_rocksdb_files(
-    const Myrocks_datadir::const_iterator &start,
-    const Myrocks_datadir::const_iterator &end, size_t thread_n, ds_ctxt_t *ds,
-    bool *result) {
-  for (auto it = start; it != end; it++) {
-    if (ends_with(it->path.c_str(), ".qp") ||
-        ends_with(it->path.c_str(), ".lz4") ||
-        ends_with(it->path.c_str(), ".zst") ||
-        ends_with(it->path.c_str(), ".xbcrypt")) {
-      continue;
-    }
-    if (xtrabackup_copy_back) {
-      if (!copy_file(ds, it->path.c_str(), it->rel_path.c_str(), thread_n,
-                     FILE_PURPOSE_OTHER, it->file_size)) {
-        *result = false;
-      }
-    } else {
-      if (!move_file(ds, it->path.c_str(), it->rel_path.c_str(), ds->root,
-                     thread_n, FILE_PURPOSE_OTHER)) {
-        *result = false;
-      }
-    }
-    if (!*result) {
-      break;
-    }
+/************************************************************************
+Run parallel threads over a RocksDB file list using work-stealing from a
+priority queue (largest files first).  Each worker pops one entry at a time
+and invokes the per-entry callback. */
+using rocksdb_entry_func_t =
+    std::function<bool(const datadir_entry_t &entry, uint thread_n)>;
+
+static bool run_rocksdb_threads(Myrocks_datadir::file_list &files,
+                                rocksdb_entry_func_t func, uint n) {
+  if (files.empty()) return true;
+
+  datadir_queue queue;
+  for (const auto &entry : files) {
+    queue.push(entry);
   }
+  queue.complete();
+
+  auto worker = [&func](datadir_thread_ctxt_t *ctx) {
+    datadir_entry_t entry;
+    bool ret = true;
+    THD *thd = nullptr;
+
+    if (my_thread_init()) {
+      ret = false;
+      goto cleanup;
+    }
+    thd = create_thd(false, false, true, 0, 0);
+
+    while (ctx->queue->pop(entry)) {
+      if (!func(entry, ctx->n_thread)) {
+        ret = false;
+        break;
+      }
+    }
+
+  cleanup:
+    destroy_thd(thd);
+    my_thread_end();
+    mutex_enter(ctx->count_mutex);
+    --(*ctx->count);
+    mutex_exit(ctx->count_mutex);
+    ctx->ret = ret;
+  };
+
+  return run_worker_threads(queue, worker, n, "rocksdb copy");
 }
 
-static void backup_rocksdb_files(const Myrocks_datadir::const_iterator &start,
-                                 const Myrocks_datadir::const_iterator &end,
-                                 size_t thread_n, bool *result) {
-  for (auto it = start; it != end; it++) {
-    if (!copy_file(ds_uncompressed_data, it->path.c_str(), it->rel_path.c_str(),
-                   thread_n, FILE_PURPOSE_OTHER, it->file_size)) {
-      *result = false;
-    }
-    if (!*result) {
-      break;
-    }
-  }
+/************************************************************************
+Copy or move RocksDB files in parallel (largest first), skipping compressed
+or encrypted files that will be handled by the decompress/decrypt pass. */
+static bool copy_or_move_rocksdb_files(Myrocks_datadir::file_list &files,
+                                       ds_ctxt_t *ds, uint n) {
+  return run_rocksdb_threads(
+      files,
+      [ds](const datadir_entry_t &entry, uint thread_n) -> bool {
+        if (ends_with(entry.path.c_str(), ".qp") ||
+            ends_with(entry.path.c_str(), ".lz4") ||
+            ends_with(entry.path.c_str(), ".zst") ||
+            ends_with(entry.path.c_str(), ".xbcrypt")) {
+          return true;
+        }
+        if (xtrabackup_copy_back) {
+          return copy_file(ds, entry.path.c_str(), entry.rel_path.c_str(),
+                           thread_n, FILE_PURPOSE_OTHER, entry.file_size);
+        } else {
+          return move_file(ds, entry.path.c_str(), entry.rel_path.c_str(),
+                           ds->root, thread_n, FILE_PURPOSE_OTHER);
+        }
+      },
+      n);
+}
+
+/************************************************************************
+Backup RocksDB files in parallel (largest first). */
+static bool backup_rocksdb_files(Myrocks_datadir::file_list &files, uint n) {
+  return run_rocksdb_threads(
+      files,
+      [](const datadir_entry_t &entry, uint thread_n) {
+        return copy_file(ds_uncompressed_data, entry.path.c_str(),
+                         entry.rel_path.c_str(), thread_n, FILE_PURPOSE_OTHER,
+                         entry.file_size);
+      },
+      n);
 }
 
 static bool backup_rocksdb_wal(const Myrocks_checkpoint &checkpoint,
                                const log_status_t &log_status) {
-  bool result = true;
+  auto live_wal_files = checkpoint.wal_files(log_status);
 
-  using std::placeholders::_1;
-  using std::placeholders::_2;
-  using std::placeholders::_3;
-
-  std::function<void(const Myrocks_datadir::const_iterator &,
-                     const Myrocks_datadir::const_iterator &, size_t)>
-      copy = std::bind(&backup_rocksdb_files, _1, _2, _3, &result);
-
-  const auto live_wal_files = checkpoint.wal_files(log_status);
-
-  par_for(PFS_NOT_INSTRUMENTED, live_wal_files, xtrabackup_parallel, copy);
+  bool result = backup_rocksdb_files(live_wal_files, xtrabackup_parallel);
 
   if (!result) {
     xb::error() << "failed to backup rocksdb WAL files.";
@@ -1367,16 +1444,6 @@ static bool backup_rocksdb_wal(const Myrocks_checkpoint &checkpoint,
 }
 
 static bool backup_rocksdb_checkpoint(Backup_context &context, bool final) {
-  bool result = true;
-
-  using std::placeholders::_1;
-  using std::placeholders::_2;
-  using std::placeholders::_3;
-
-  std::function<void(const Myrocks_datadir::const_iterator &,
-                     const Myrocks_datadir::const_iterator &, size_t)>
-      copy = std::bind(&backup_rocksdb_files, _1, _2, _3, &result);
-
   auto checkpoint_files =
       final ? context.myrocks_checkpoint.checkpoint_files(log_status)
             : context.myrocks_checkpoint.data_files();
@@ -1393,7 +1460,7 @@ static bool backup_rocksdb_checkpoint(Backup_context &context, bool final) {
     context.rocksdb_files.insert(f.file_name);
   }
 
-  par_for(PFS_NOT_INSTRUMENTED, checkpoint_files, xtrabackup_parallel, copy);
+  bool result = backup_rocksdb_files(checkpoint_files, xtrabackup_parallel);
 
   if (!result) {
     xb::error() << "failed to backup rocksdb datadir.";
@@ -1994,16 +2061,10 @@ bool copy_incremental_over_full() {
       }
     }
 
-    using std::placeholders::_1;
-    using std::placeholders::_2;
-    using std::placeholders::_3;
-    bool result = true;
-    std::function<void(const Myrocks_datadir::const_iterator &,
-                       const Myrocks_datadir::const_iterator &, size_t)>
-        copy = std::bind(&par_copy_or_move_rocksdb_files, _1, _2, _3, ds_data,
-                         &result);
-
-    par_for(PFS_NOT_INSTRUMENTED, rocksdb.files(), xtrabackup_parallel, copy);
+    auto rdb_files = rocksdb.files();
+    if (!copy_or_move_rocksdb_files(rdb_files, ds_data, xtrabackup_parallel)) {
+      ret = false;
+    }
   }
 
 cleanup:
@@ -2505,22 +2566,18 @@ bool copy_back(int argc, char **argv) {
 
     ds_data = ds_create(rocksdb_datadir.c_str(), DS_TYPE_LOCAL);
 
-    using std::placeholders::_1;
-    using std::placeholders::_2;
-    using std::placeholders::_3;
-    std::function<void(const Myrocks_datadir::const_iterator &,
-                       const Myrocks_datadir::const_iterator &, size_t)>
-        copy = std::bind(&par_copy_or_move_rocksdb_files, _1, _2, _3, ds_data,
-                         &ret);
-
     if (rocksdb_wal_dir.empty()) {
-      par_for(PFS_NOT_INSTRUMENTED, rocksdb.files("", ""), xtrabackup_parallel,
-              copy);
+      auto files = rocksdb.files("", "");
+      if (!copy_or_move_rocksdb_files(files, ds_data, xtrabackup_parallel)) {
+        ret = false;
+      }
     } else {
-      par_for(PFS_NOT_INSTRUMENTED, rocksdb.data_files(""), xtrabackup_parallel,
-              copy);
-      par_for(PFS_NOT_INSTRUMENTED, rocksdb.meta_files(""), xtrabackup_parallel,
-              copy);
+      auto files = rocksdb.data_files("");
+      auto meta = rocksdb.meta_files("");
+      files.insert(files.end(), meta.begin(), meta.end());
+      if (!copy_or_move_rocksdb_files(files, ds_data, xtrabackup_parallel)) {
+        ret = false;
+      }
     }
 
     if (!ret) goto cleanup;
@@ -2540,16 +2597,11 @@ bool copy_back(int argc, char **argv) {
 
       ds_data = ds_create(rocksdb_wal_dir.c_str(), DS_TYPE_LOCAL);
 
-      using std::placeholders::_1;
-      using std::placeholders::_2;
-      using std::placeholders::_3;
-      std::function<void(const Myrocks_datadir::const_iterator &,
-                         const Myrocks_datadir::const_iterator &, size_t)>
-          copy = std::bind(&par_copy_or_move_rocksdb_files, _1, _2, _3, ds_data,
-                           &ret);
-
-      par_for(PFS_NOT_INSTRUMENTED, rocksdb.wal_files(""), xtrabackup_parallel,
-              copy);
+      auto wal_files = rocksdb.wal_files("");
+      if (!copy_or_move_rocksdb_files(wal_files, ds_data,
+                                      xtrabackup_parallel)) {
+        ret = false;
+      }
 
       if (!ret) goto cleanup;
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -84,9 +84,11 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sql/current_thd.h>
 #include <sql/srv_session.h>
 #include <table_cache.h>
+#include <algorithm>
 #include <list>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include "sql/signal_handler.h"
 
 #include <api0api.h>
@@ -601,6 +603,32 @@ datafiles_iter_t *datafiles_iter_new(
     }
     return (DB_SUCCESS);
   });
+
+  // Order tablespaces largest first so parallel consumers reduce the long
+  // tail of work caused by late-discovered big files. File name is used as a
+  // deterministic tie-breaker for equal-size files.
+  std::sort(it->nodes.begin(), it->nodes.end(),
+            [](const fil_node_t *lhs, const fil_node_t *rhs) {
+              auto file_size = [](const fil_node_t *node) -> uint64_t {
+                if (!node || !node->space) {
+                  return 0;
+                }
+                const page_size_t ps(node->space->flags);
+                return static_cast<uint64_t>(node->size) * ps.physical();
+              };
+
+              auto file_name = [](const fil_node_t *node) -> std::string_view {
+                return node && node->name ? node->name : "";
+              };
+
+              const auto lhs_size = file_size(lhs);
+              const auto rhs_size = file_size(rhs);
+              if (lhs_size != rhs_size) {
+                return lhs_size > rhs_size;
+              }
+
+              return file_name(lhs) < file_name(rhs);
+            });
 
   it->i = it->nodes.begin();
 
@@ -3299,11 +3327,16 @@ bool xtrabackup_copy_datafile_func(fil_node_t *node, uint thread_n,
   action = xb_get_copy_action();
 
   if (xtrabackup_stream) {
-    xb::info() << "space_id: " << node->space->id << ", " << action
-               << node_path;
+    xb::info() << "space_id: " << node->space->id << ", " << action << node_path
+               << ", size " << cursor.statinfo.st_size << " ("
+               << xtrabackup::utils::human_readable(cursor.statinfo.st_size)
+               << ")";
   } else {
     xb::info() << "space_id: " << node->space->id << ", " << action << " "
-               << node_path << " to " << dstfile->path;
+               << node_path << " to " << dstfile->path << ", size "
+               << cursor.statinfo.st_size << " ("
+               << xtrabackup::utils::human_readable(cursor.statinfo.st_size)
+               << ")";
   }
 
   /* The main copy loop */
@@ -5764,7 +5797,8 @@ void process_datadir_l2cbk(const char *datadir, const char *dbname,
       (strlen(name) > suffix_len &&
        strcmp(name + strlen(name) - suffix_len, suffix) == 0)) {
     check_datadir_enctry_access(name, &statinfo);
-    func(datadir_entry_t(datadir, path, dbname, name, false), data);
+    func(datadir_entry_t(datadir, path, dbname, name, false, statinfo.st_size),
+         data);
   }
 }
 
@@ -5810,7 +5844,8 @@ void process_datadir_l1cbk(const char *datadir, const char *path,
       (strlen(name) > suffix_len &&
        strcmp(name + strlen(name) - suffix_len, suffix) == 0)) {
     check_datadir_enctry_access(name, &statinfo);
-    func(datadir_entry_t(datadir, path, "", name, false), data);
+    func(datadir_entry_t(datadir, path, "", name, false, statinfo.st_size),
+         data);
   }
 }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.h
+++ b/storage/innobase/xtrabackup/src/xtrabackup.h
@@ -336,11 +336,10 @@ struct datadir_entry_t {
   std::string db_name;
   std::string file_name;
   std::string rel_path;
-  bool is_empty_dir;
-  ssize_t file_size;
+  bool is_empty_dir = false;
+  ssize_t file_size = -1;
 
-  datadir_entry_t()
-      : datadir(), path(), db_name(), file_name(), rel_path(), is_empty_dir() {}
+  datadir_entry_t() = default;
 
   datadir_entry_t(const datadir_entry_t &) = default;
 

--- a/storage/innobase/xtrabackup/test/suites/compression/largest_first_decompress.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/largest_first_decompress.sh
@@ -1,0 +1,85 @@
+#
+# Test that decompression processes largest files first.
+# With --parallel=1 the processing order is deterministic and must be
+# strictly descending by file size.
+#
+
+require_lz4
+
+start_server --innodb_file_per_table
+
+# Create tables with dramatically different sizes.
+mysql -e "CREATE TABLE t_large (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255), c VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_medium (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_small (a INT PRIMARY KEY) ENGINE=InnoDB" test
+
+# Fill tables
+# Use recursive CTE for compatibility with both Oracle MySQL and Percona Server.
+mysql test <<EOF
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 500)
+SELECT REPEAT('x', 200), REPEAT('y', 200) FROM seq;
+INSERT INTO t_medium (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 100)
+SELECT REPEAT('m', 200) FROM seq;
+INSERT INTO t_small VALUES (1);
+EOF
+mysql -e "FLUSH TABLES" test
+
+###############################################################################
+# Test: Decompress with --parallel=1 processes largest files first
+###############################################################################
+
+# Take a compressed backup
+xtrabackup --backup --target-dir=$topdir/backup --compress=lz4 --parallel=1
+
+# Show compressed file sizes for debugging
+ls -lS $topdir/backup/test/*.lz4 2>/dev/null || true
+
+# Decompress with --parallel=1
+xtrabackup --decompress --target-dir=$topdir/backup --parallel=1
+
+# The decompress log lines have format: "decompressing ./test/t_xxx.ibd.lz4"
+# Check that .ibd.lz4 files for our test tables appear in largest-first order.
+grep "decompressing.*test/t_" $OUTFILE | head -10
+
+large_line=$(grep -n "decompressing.*test/t_large" $OUTFILE | head -1 | cut -d: -f1)
+medium_line=$(grep -n "decompressing.*test/t_medium" $OUTFILE | head -1 | cut -d: -f1)
+small_line=$(grep -n "decompressing.*test/t_small" $OUTFILE | head -1 | cut -d: -f1)
+
+vlog "Decompress order: t_large at line $large_line, t_medium at line $medium_line, t_small at line $small_line"
+
+if [ -z "$large_line" ] || [ -z "$medium_line" ] || [ -z "$small_line" ]; then
+  die "Could not find all tables in decompress log"
+fi
+
+if [ "$large_line" -ge "$medium_line" ]; then
+  die "FAIL: t_large (line $large_line) was not decompressed before t_medium (line $medium_line)"
+fi
+
+if [ "$medium_line" -ge "$small_line" ]; then
+  die "FAIL: t_medium (line $medium_line) was not decompressed before t_small (line $small_line)"
+fi
+
+vlog "PASS: Decompress processes files in largest-first order"
+
+###############################################################################
+# Verify the backup is usable (prepare + restore)
+###############################################################################
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup --parallel=1
+
+start_server
+
+# Verify data
+count=$(mysql -N -e "SELECT COUNT(*) FROM t_large" test)
+if [ "$count" -lt 500 ]; then
+  die "FAIL: t_large has only $count rows after restore, expected >= 500"
+fi
+
+vlog "PASS: Data verified after restore"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first.sh
@@ -1,0 +1,123 @@
+#
+# Test that parallel processing handles largest RocksDB files first.
+# With --parallel=1 the processing order is deterministic and must be
+# strictly descending by file size.
+#
+
+require_rocksdb
+
+start_server
+
+init_rocksdb
+
+# Create a RocksDB table with enough data to produce multiple .sst files
+# of different sizes after compaction.
+mysql -e "CREATE TABLE t_large (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255), c VARCHAR(255)) ENGINE=ROCKSDB" test
+mysql -e "CREATE TABLE t_small (a INT PRIMARY KEY) ENGINE=ROCKSDB" test
+
+# Fill t_large to produce large .sst files (bulk insert for speed)
+# Use recursive CTE for compatibility with both Oracle MySQL and Percona Server.
+mysql test <<EOF
+SET SESSION cte_max_recursion_depth = 10000;
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 1000)
+SELECT REPEAT('x', 200), REPEAT('y', 200) FROM seq;
+INSERT INTO t_small VALUES (1);
+EOF
+
+# Force RocksDB to flush memtable to SST files
+mysql -e "SET GLOBAL rocksdb_force_flush_memtable_now = ON"
+
+# Give compaction time to settle
+sleep 2
+
+# Show .sst file sizes for debugging
+ls -lS $mysql_datadir/.rocksdb/*.sst 2>/dev/null >&2 || true
+
+###############################################################################
+# Test 1: Backup with --parallel=1 processes largest .sst first
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/backup --parallel=1
+
+# The log now prints ", size <bytes> (<human>)" for each file.
+# Extract sizes from .sst copy lines and verify non-increasing order.
+backup_sst_log=$topdir/backup_sst_lines.txt
+grep "Copying.*\.sst.*size [0-9]" $OUTFILE | grep -v "Done:" > $backup_sst_log || true
+
+vlog "SST files copied during backup:"
+
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  file_size=$(echo "$line" | sed -n 's/.*, size \([0-9]*\) .*/\1/p')
+  file_name=$(echo "$line" | sed -n 's/.*Copying \([^ ]*\.sst\).*/\1/p')
+  if [ -z "$file_size" ] || [ -z "$file_name" ]; then
+    continue
+  fi
+  vlog "  $file_name: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $backup_sst_log
+
+if [ "$count" -lt 2 ]; then
+  die "Only $count .sst files found in backup log, need at least 2 to test ordering"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: RocksDB .sst files were not backed up in largest-first order"
+fi
+
+vlog "PASS: Backup processes $count RocksDB .sst files in largest-first order"
+
+###############################################################################
+# Test 2: Copy-back with --parallel=1 processes largest .sst first
+###############################################################################
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup --parallel=1
+
+# Exclude checkpoint lines (those are from the backup phase).
+copyback_sst_log=$topdir/copyback_sst_lines.txt
+grep "Copying.*\.sst.*size [0-9]" $OUTFILE | grep -v "Done:" | grep -v "checkpoint" > $copyback_sst_log || true
+
+vlog "SST files copied during copy-back:"
+
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  file_size=$(echo "$line" | sed -n 's/.*, size \([0-9]*\) .*/\1/p')
+  file_name=$(echo "$line" | sed -n 's/.*Copying \([^ ]*\.sst\).*/\1/p')
+  if [ -z "$file_size" ] || [ -z "$file_name" ]; then
+    continue
+  fi
+  vlog "  $file_name: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $copyback_sst_log
+
+if [ "$count" -lt 2 ]; then
+  die "Only $count .sst files found in copy-back log, need at least 2 to test ordering"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: RocksDB .sst files were not copied back in largest-first order"
+fi
+
+vlog "PASS: Copy-back processes $count RocksDB .sst files in largest-first order"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
@@ -1,0 +1,160 @@
+#
+# Test that RocksDB incremental prepare copies files in largest-first order.
+# With --parallel=1 the processing order is deterministic and must be
+# strictly descending by file size.
+#
+
+require_rocksdb
+
+start_server
+
+init_rocksdb
+
+# Create RocksDB tables with different sizes.
+mysql -e "CREATE TABLE t_large (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255), c VARCHAR(255)) ENGINE=ROCKSDB" test
+mysql -e "CREATE TABLE t_medium (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(200)) ENGINE=ROCKSDB" test
+mysql -e "CREATE TABLE t_small (a INT PRIMARY KEY) ENGINE=ROCKSDB" test
+
+mysql test <<EOF
+SET SESSION cte_max_recursion_depth = 10000;
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 1000)
+SELECT REPEAT('x', 200), REPEAT('y', 200) FROM seq;
+INSERT INTO t_medium (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 200)
+SELECT REPEAT('m', 150) FROM seq;
+INSERT INTO t_small VALUES (1);
+EOF
+
+# Flush to SST
+mysql -e "SET GLOBAL rocksdb_force_flush_memtable_now = ON"
+sleep 2
+
+# Show SST file sizes for debugging
+ls -lS $mysql_datadir/.rocksdb/*.sst 2>/dev/null >&2 || true
+
+###############################################################################
+# Take full backup
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/full --parallel=1
+
+###############################################################################
+# Insert more data to create new SST files for the incremental
+###############################################################################
+
+mysql test <<EOF
+SET SESSION cte_max_recursion_depth = 10000;
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 2000)
+SELECT REPEAT('X', 200), REPEAT('Y', 200) FROM seq;
+INSERT INTO t_medium (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 100)
+SELECT REPEAT('M', 150) FROM seq;
+INSERT INTO t_small VALUES (2);
+EOF
+
+# Flush to create new SST files
+mysql -e "SET GLOBAL rocksdb_force_flush_memtable_now = ON"
+sleep 2
+
+###############################################################################
+# Take incremental backup
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --parallel=1
+
+# Show RocksDB files in incremental directory
+vlog "RocksDB files in incremental backup:"
+ls -lS $topdir/inc/.rocksdb/*.sst 2>/dev/null >&2 || true
+
+# Record .sst file sizes before prepare (move_file doesn't log sizes)
+sst_sizes=$topdir/sst_sizes.txt
+rm -f $sst_sizes
+for f in $topdir/inc/.rocksdb/*.sst; do
+  [ -f "$f" ] || continue
+  fname=$(basename "$f")
+  fsize=$(stat -c%s "$f" 2>/dev/null || stat -f%z "$f" 2>/dev/null)
+  echo "$fname $fsize" >> $sst_sizes
+done
+
+vlog "SST sizes in incremental dir:"
+cat $sst_sizes >&2
+
+###############################################################################
+# Test: Prepare with --parallel=1 copies RocksDB files largest-first
+###############################################################################
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+  --target-dir=$topdir/full --parallel=1
+
+# During incremental prepare, copy_incremental_over_full() moves RocksDB files
+# using our priority queue. The log has "Moving *.sst to *" lines.
+# Extract only the .sst "Moving" lines from the prepare phase.
+# Lines after the last "Starting InnoDB instance" belong to incremental prepare.
+rocksdb_log=$topdir/rocksdb_inc_move.txt
+last_start=$(grep -n "Starting InnoDB instance" $OUTFILE | tail -1 | cut -d: -f1)
+if [ -n "$last_start" ]; then
+  tail -n +${last_start} $OUTFILE | grep "Moving.*\.sst" | grep -v "Done:" > $rocksdb_log || true
+fi
+
+vlog "RocksDB .sst files moved during incremental prepare:"
+cat $rocksdb_log >&2
+
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  # Extract filename: "Moving .../inc/.rocksdb/000020.sst to ..."
+  sst_file=$(echo "$line" | sed -n 's|.*/\([0-9]*\.sst\) to .*|\1|p')
+  if [ -z "$sst_file" ]; then
+    continue
+  fi
+
+  # Look up the size from our recorded sizes
+  file_size=$(grep "^${sst_file} " $sst_sizes | awk '{print $2}')
+  if [ -z "$file_size" ]; then
+    vlog "  WARNING: could not find size for $sst_file, skipping"
+    continue
+  fi
+
+  vlog "  $sst_file: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $rocksdb_log
+
+if [ "$count" -lt 2 ]; then
+  die "Only $count RocksDB .sst files found in prepare log, need at least 2 to test ordering"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: RocksDB .sst files were not moved in largest-first order during incremental prepare"
+fi
+
+vlog "PASS: Incremental prepare moves $count RocksDB .sst files in largest-first order"
+
+###############################################################################
+# Verify the backup is usable (final prepare + restore)
+###############################################################################
+
+xtrabackup --prepare --target-dir=$topdir/full
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/full --parallel=1
+
+start_server
+
+count=$(mysql -N -e "SELECT COUNT(*) FROM t_large" test)
+if [ "$count" -lt 3000 ]; then
+  die "FAIL: t_large has only $count rows after restore, expected >= 3000"
+fi
+
+vlog "PASS: Data verified after RocksDB incremental restore"

--- a/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
@@ -1,0 +1,141 @@
+#
+# Test that parallel delta application processes largest .delta files first.
+# With --parallel=1 the processing order is deterministic and must be
+# strictly descending by .delta file size.
+#
+
+start_server --innodb_file_per_table
+
+# Create tables with dramatically different sizes.
+# Use recursive CTE for compatibility with both Oracle MySQL and Percona Server.
+mysql -e "CREATE TABLE t_large (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255), c VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_medium (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_small (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(50)) ENGINE=InnoDB" test
+
+mysql test <<EOF
+SET SESSION cte_max_recursion_depth = 10000;
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 5000)
+SELECT REPEAT('x', 250), REPEAT('y', 250) FROM seq;
+INSERT INTO t_medium (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 500)
+SELECT REPEAT('m', 200) FROM seq;
+INSERT INTO t_small (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 20)
+SELECT REPEAT('s', 40) FROM seq;
+EOF
+mysql -e "FLUSH TABLES" test
+
+###############################################################################
+# Take full backup
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/full --parallel=1
+
+###############################################################################
+# Modify all tables to create .delta files of different sizes.
+# UPDATE all rows to dirty all pages, making .delta size proportional to table.
+###############################################################################
+
+mysql test <<EOF
+SET SESSION cte_max_recursion_depth = 10000;
+UPDATE t_large SET b = REPEAT('X', 250), c = REPEAT('Y', 250);
+UPDATE t_medium SET b = REPEAT('M', 200);
+UPDATE t_small SET b = REPEAT('S', 40);
+EOF
+mysql -e "FLUSH TABLES" test
+
+###############################################################################
+# Take incremental backup
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --parallel=1
+
+# Show .delta file sizes for debugging
+vlog "Delta file sizes in incremental backup:"
+ls -lS $topdir/inc/test/*.delta 2>/dev/null >&2 || true
+
+# Record .delta file sizes into an associative structure for later verification.
+# Build a mapping: filename -> size
+delta_sizes=$topdir/delta_sizes.txt
+for f in $topdir/inc/test/*.delta; do
+  fname=$(basename "$f")
+  fsize=$(stat -c%s "$f" 2>/dev/null || stat -f%z "$f" 2>/dev/null)
+  echo "$fname $fsize" >> $delta_sizes
+done
+
+vlog "Delta sizes:"
+cat $delta_sizes >&2
+
+###############################################################################
+# Test: Prepare with --parallel=1 applies largest .delta first
+###############################################################################
+
+xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+  --target-dir=$topdir/full --parallel=1
+
+# Extract the "Applying" lines from the log (only those referencing test/ deltas)
+apply_log=$topdir/apply_order.txt
+grep "Applying.*test/.*\.delta" $OUTFILE > $apply_log || true
+
+vlog "Delta apply order from log:"
+cat $apply_log >&2
+
+# Verify that files were applied in descending .delta file size order
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  # Extract filename from "Applying /path/to/inc/test/t_xxx.ibd.delta to ..."
+  delta_file=$(echo "$line" | sed -n 's|.*Applying .*/test/\([^ ]*\.delta\) to .*|\1|p')
+  if [ -z "$delta_file" ]; then
+    continue
+  fi
+
+  # Look up the size from our recorded sizes
+  file_size=$(grep "^${delta_file} " $delta_sizes | awk '{print $2}')
+  if [ -z "$file_size" ]; then
+    vlog "  WARNING: could not find size for $delta_file, skipping"
+    continue
+  fi
+
+  vlog "  $delta_file: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $apply_log
+
+if [ "$count" -lt 3 ]; then
+  die "Only $count .delta files found in apply log, need at least 3"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: .delta files were not applied in largest-first order"
+fi
+
+vlog "PASS: Delta apply processes $count .delta files in largest-first order"
+
+###############################################################################
+# Verify the backup is usable (final prepare + restore)
+###############################################################################
+
+xtrabackup --prepare --target-dir=$topdir/full
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/full --parallel=1
+
+start_server
+
+count=$(mysql -N -e "SELECT COUNT(*) FROM t_large" test)
+if [ "$count" -lt 5000 ]; then
+  die "FAIL: t_large has only $count rows after restore, expected >= 5000"
+fi
+
+vlog "PASS: Data verified after incremental restore"

--- a/storage/innobase/xtrabackup/test/t/pxb_largest_first_innodb.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb_largest_first_innodb.sh
@@ -1,0 +1,118 @@
+#
+# Test that parallel processing handles largest InnoDB files first.
+# With --parallel=1 the processing order is deterministic and must be
+# strictly descending by file size.
+#
+
+start_server --innodb_file_per_table
+
+# Create tables with dramatically different sizes.
+mysql -e "CREATE TABLE t_large (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255), c VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_medium (a INT AUTO_INCREMENT PRIMARY KEY, b VARCHAR(255)) ENGINE=InnoDB" test
+mysql -e "CREATE TABLE t_small (a INT PRIMARY KEY) ENGINE=InnoDB" test
+
+# Fill tables to ensure significant size differences.
+# Use recursive CTE for compatibility with both Oracle MySQL and Percona Server.
+mysql test <<EOF
+INSERT INTO t_large (b, c)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 500)
+SELECT REPEAT('x', 200), REPEAT('y', 200) FROM seq;
+INSERT INTO t_medium (b)
+WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n+1 FROM seq WHERE n < 100)
+SELECT REPEAT('m', 200) FROM seq;
+INSERT INTO t_small VALUES (1);
+EOF
+
+mysql -e "FLUSH TABLES" test
+
+# Record actual file sizes for debugging
+ls -lS $mysql_datadir/test/*.ibd
+
+###############################################################################
+# Test 1: Backup with --parallel=1 processes largest .ibd first
+###############################################################################
+
+xtrabackup --backup --target-dir=$topdir/backup --parallel=1
+
+# The log now prints "size <bytes>" for each file copied. Extract sizes from
+# lines matching our test tables and verify they are in non-increasing order.
+backup_log=$topdir/backup_sizes.txt
+grep "space_id:.*Copying.*test/t_" $OUTFILE | grep -v "Done:" > $backup_log
+
+vlog "InnoDB files copied during backup:"
+
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  file_size=$(echo "$line" | sed -n 's/.*, size \([0-9]*\) .*/\1/p')
+  file_name=$(echo "$line" | sed -n 's/.*Copying \([^ ]*\) to .*/\1/p')
+  if [ -z "$file_size" ] || [ -z "$file_name" ]; then
+    continue
+  fi
+  vlog "  $file_name: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $backup_log
+
+if [ "$count" -lt 3 ]; then
+  die "Only $count test tables found in backup log, need at least 3"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: InnoDB files were not backed up in largest-first order"
+fi
+
+vlog "PASS: Backup processes $count InnoDB files in largest-first order"
+
+###############################################################################
+# Test 2: Copy-back with --parallel=1 processes largest .ibd first
+###############################################################################
+
+xtrabackup --prepare --target-dir=$topdir/backup
+
+stop_server
+rm -rf $mysql_datadir
+
+xtrabackup --copy-back --target-dir=$topdir/backup --parallel=1
+
+# Copy-back log uses "Copying <path> to <dest>, size <bytes> (<human>)".
+# Exclude backup-phase lines by filtering out "space_id:" prefix.
+copyback_log=$topdir/copyback_sizes.txt
+grep "Copying.*test/t_.*size [0-9]" $OUTFILE | grep -v "Done:" | grep -v "space_id:" > $copyback_log
+
+vlog "InnoDB files copied during copy-back:"
+
+prev_size=999999999999
+ordered=true
+count=0
+
+while IFS= read -r line; do
+  file_size=$(echo "$line" | sed -n 's/.*, size \([0-9]*\) .*/\1/p')
+  file_name=$(echo "$line" | sed -n 's/.*Copying \([^ ]*\) to .*/\1/p')
+  if [ -z "$file_size" ] || [ -z "$file_name" ]; then
+    continue
+  fi
+  vlog "  $file_name: $file_size bytes"
+  if [ "$file_size" -gt "$prev_size" ]; then
+    ordered=false
+    vlog "  ERROR: size $file_size > previous $prev_size (not largest-first)"
+  fi
+  prev_size=$file_size
+  count=$((count + 1))
+done < $copyback_log
+
+if [ "$count" -lt 3 ]; then
+  die "Only $count test tables found in copy-back log, need at least 3"
+fi
+
+if [ "$ordered" = "false" ]; then
+  die "FAIL: InnoDB files were not copied back in largest-first order"
+fi
+
+vlog "PASS: Copy-back processes $count InnoDB files in largest-first order"


### PR DESCRIPTION
PXB-3502: Process largest files first in all parallel phases

https://perconadev.atlassian.net/browse/PXB-3502

Problem
=======

When xtrabackup processes files in parallel (backup, copy-back,
decompress, incremental apply), the work queue is FIFO. If the
largest tablespace or SST file happens to be discovered last, it
starts processing after all other threads have finished their
smaller files, resulting in a single thread running alone for the
duration of that large file. This "tail latency" problem makes
parallel restores and backups slower than necessary.

Fix
===

Replace FIFO scheduling with largest-first scheduling across all
parallel processing phases so that the longest-running task always
starts immediately, minimizing wall-clock time.

Affected scenarios (all use --parallel):

1. xtrabackup --backup: InnoDB tablespace copying is now ordered
   largest-first via sorted datafiles_iter_t.

2. xtrabackup --backup (RocksDB): SST and meta file copying is
   now ordered largest-first via queue-based work-stealing.

3. xtrabackup --backup --stream=xbstream: files are written to
   the stream in largest-first order, so downstream xbstream
   extraction and decompression inherits that order.

4. xtrabackup --prepare --incremental-dir (delta apply): InnoDB
   .delta files are applied largest-first via the priority queue.

5. xtrabackup --prepare --incremental-dir (RocksDB): SST files
   from the incremental directory are copied/moved largest-first.

6. xtrabackup --copy-back / --move-back: all data files (InnoDB,
   RocksDB, non-InnoDB) are processed largest-first.

7. xtrabackup --decompress: compressed files are decompressed
   largest-first via the priority queue.

Implementation
==============

1. datadir_queue (backup_copy.cc): Convert the internal std::queue
   to std::priority_queue with a comparator that orders entries by
   descending file_size. Tie-break on path for determinism. Empty
   directories get lowest priority.

2. datafiles_iter_t (xtrabackup.cc): Sort the tablespace node
   vector by descending byte size (page count * physical page size)
   at the end of datafiles_iter_new().

3. RocksDB (backup_copy.cc): Replace par_for()-based contiguous
   slicing with a queue-based work-stealing approach. RocksDB data
   and meta file lists are merged into a single datadir_queue so
   that all files compete globally for largest-first scheduling.
   Extract run_worker_threads() as a common template for thread
   lifecycle management shared between run_data_threads() and
   run_rocksdb_threads().

4. File size propagation: Populate file_size in datadir_entry_t
   during directory scanning (xb_process_datadir via stat()) and
   in Myrocks_datadir::scan_dir().

5. Log enhancement: Print both raw byte size and human-readable
   size in file copy/move log messages.

Tests
=====

Five test scripts verify ordering with --parallel=1 (which makes
scheduling deterministic):

- t/pxb_largest_first_innodb.sh: InnoDB backup and copy-back
- t/pxb_largest_first_delta.sh: InnoDB incremental delta apply
- suites/rocksdb/largest_first.sh: RocksDB backup and copy-back
- suites/rocksdb/largest_first_incremental.sh: RocksDB incremental
- suites/compression/largest_first_decompress.sh: LZ4 decompression