### PR TITLE
PXB-3863 [8.4]: Fix xbcloud with Azure Hierarchical Namespace (HNS) storage

### DIFF
--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -197,8 +197,6 @@ void Azure_signer::sign_request(const std::string &container,
 
   std::string decoded_access_key = base64_decode(access_key);
 
-  trim(decoded_access_key);
-
   auto signature =
       base64_encode(hmac_sha256(decoded_access_key, string_to_sign));
 

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.cc
@@ -378,6 +378,32 @@ bool Azure_client::container_exists(const std::string &name, bool &exists) {
   return false;
 }
 
+bool Azure_client::is_hns_enabled() {
+  if (hns_enabled.has_value()) {
+    return hns_enabled.value();
+  }
+
+  Http_request req(Http_request::GET, protocol, host, "/");
+  req.add_param("restype", "account");
+  req.add_param("comp", "properties");
+  signer->sign_request("", "", req, time(0));
+
+  Http_response resp;
+  if (!http_client->make_request(req, resp)) {
+    hns_enabled = false;
+    return false;
+  }
+
+  if (!resp.ok()) {
+    hns_enabled = false;
+    return false;
+  }
+
+  auto it = resp.headers().find("x-ms-is-hns-enabled");
+  hns_enabled = it != resp.headers().end() && it->second == "true";
+  return hns_enabled.value();
+}
+
 bool Azure_client::upload_object(const std::string &container,
                                  const std::string &name,
                                  const Http_buffer &contents) {

--- a/storage/innobase/xtrabackup/src/xbcloud/azure.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/azure.h
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 #define __XBCLOUD_AZURE_H__
 
 #include <iostream>
+#include <optional>
 #include "object_store.h"
 #include "xbcloud/http.h"
 #include "xbcloud/util.h"
@@ -92,6 +93,8 @@ class Azure_client {
   Http_request::protocol_t protocol;
   ulong max_retries;
   ulong max_backoff;
+
+  std::optional<bool> hns_enabled;
 
   static void upload_callback(Azure_client *client, std::string container,
                               std::string name, Http_request *req,
@@ -170,6 +173,8 @@ class Azure_client {
                                    const std::string &prefix,
                                    std::vector<std::string> &files,
                                    std::vector<std::string> &dirs);
+
+  bool is_hns_enabled();
 
   ulong get_max_retries() { return max_retries; }
 
@@ -265,6 +270,20 @@ class Azure_object_store : public Object_store {
       std::vector<std::string> &dirs) override {
     return azure_client.list_objects_files_and_dirs(container, directory + "/",
                                                     files, dirs);
+  }
+  // Strip leading slashes for HNS-enabled accounts.
+  // Azure HNS silently normalizes blob paths by removing leading slashes,
+  // so "/backup/chunk.00000" is stored as "backup/chunk.00000".  Without
+  // this, xbcloud's expected prefix no longer matches what the API returns.
+  // Example: "/db/mybackup" -> "db/mybackup"
+  // Flat accounts are unaffected — the name is returned as-is.
+  std::string normalize_name(const std::string &name) override {
+    if (azure_client.is_hns_enabled()) {
+      std::string result = name;
+      ltrim_slashes(result);
+      return result;
+    }
+    return name;
   }
 };
 }  // namespace xbcloud

--- a/storage/innobase/xtrabackup/src/xbcloud/object_store.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/object_store.h
@@ -71,6 +71,15 @@ class Object_store {
                                            const std::string &directory,
                                            std::vector<std::string> &files,
                                            std::vector<std::string> &dirs);
+  /**
+   * Normalize a backup name according to storage-specific rules.
+   *
+   * Default implementation returns the name unchanged.
+   *
+   * @param name Backup name to normalize.
+   * @return Normalized name.
+   */
+  virtual std::string normalize_name(const std::string &name) { return name; }
   virtual ~Object_store() {}
 };
 

--- a/storage/innobase/xtrabackup/src/xbcloud/util.h
+++ b/storage/innobase/xtrabackup/src/xbcloud/util.h
@@ -65,6 +65,11 @@ static inline void rtrim_slashes(std::string &s) {
           s.end());
 }
 
+static inline void ltrim_slashes(std::string &s) {
+  s.erase(s.begin(),
+          std::find_if(s.begin(), s.end(), [](int ch) { return ch != '/'; }));
+}
+
 static inline void to_lower(std::string &s) {
   s.resize(s.length());
   std::transform(s.begin(), s.end(), s.begin(), ::tolower);

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1605,6 +1605,13 @@ int main(int argc, char **argv) {
     reinterpret_cast<Azure_object_store *>(object_store.get())
         ->set_extra_http_headers(extra_http_headers);
   }
+
+  backup_name = object_store->normalize_name(backup_name);
+  if (backup_name.empty()) {
+    msg_ts("%s: Backup name is empty after normalization.\n", my_progname);
+    return EXIT_FAILURE;
+  }
+
   /* validation */
   if (opt_threads > 1 && opt_fifo_dir == nullptr && opt_mode != MODE_DELETE) {
     msg_ts(

--- a/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
+++ b/storage/innobase/xtrabackup/src/xbcloud/xbcloud.cc
@@ -1037,7 +1037,7 @@ cleanup:
 @return true in case of success or false otherwise */
 bool chunk_name_to_file_name(const std::string &chunk_name,
                              std::string &file_name, my_off_t &idx) {
-  if (chunk_name.size() < 22 && chunk_name[chunk_name.size() - 21] != '.') {
+  if (chunk_name.size() < 22 || chunk_name[chunk_name.size() - 21] != '.') {
     /* chunk name is invalid */
     return false;
   }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3863

Problem
=======

xbcloud put, get, and delete fail on Azure storage accounts with Hierarchical Namespace (HNS) enabled. Azure HNS silently strips leading slashes from blob names, so a blob uploaded as "/backup/file.00000000000000000000" is stored as
"backup/file.00000000000000000000". When xbcloud later lists the container, the returned names no longer match the expected prefix, causing put to report an incomplete backup and get to fail downloading chunks.

Fix
===

Add a virtual normalize_name() method to Object_store with a default identity implementation. Azure_object_store overrides it to detect HNS via the Get Account Information REST API (x-ms-is-hns-enabled header) and strip leading slashes from the backup name. The HNS detection result is cached in a std::optional<bool> to avoid repeated REST calls. After the object store is constructed in main(), backup_name is passed through normalize_name() so all subsequent operations use the normalized path.

Additionally fix two pre-existing bugs found during investigation:

1. Remove trim() on the base64-decoded access key in Azure_signer::sign_request(). The decoded key is arbitrary binary data; trimming it corrupts keys whose decoded form happens to start or end with whitespace-like bytes (0x09, 0x0a, 0x0d, 0x20), causing authentication failures on affected accounts.

2. Fix the logical condition in chunk_name_to_file_name(): change (size < 22 && name[size-21] != '.') to use || so that short names are rejected before indexing into them.