### PR TITLE
PXB-2553 [trunk]: Fix stacktrace assertion in bug766305 test

### DIFF
--- a/storage/innobase/xtrabackup/test/t/bug766305.sh
+++ b/storage/innobase/xtrabackup/test/t/bug766305.sh
@@ -29,5 +29,5 @@ kill -SIGCONT $xb_pid
 
 run_cmd_expect_failure wait $job_pid
 
-grep -q "handle_fatal_signal" $OUTFILE || \
+grep -qE "#[0-9]+ 0x[0-9a-f]+ .+ at " $OUTFILE || \
   die "Could not find a resolved stacktrace in the log"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-2553

Problem:
--------
The test sends SIGSEGV to xtrabackup and verifies a resolved stack trace is produced. The assertion grepped for "handle_fatal_signal", which only appears when the signal handler frame is resolved as a symbol in the backtrace. This is platform- and compiler-dependent: the signal is delivered to an arbitrary thread, and the backtrace shows that thread's stack, not the signal handler's frame.

Fix:
----
Replace the assertion with a regex matching any resolved stack frame with a source location ("... <symbol> at ..."), which is always present regardless of which thread receives the signal.