### PR TITLE
PXB-3758 : [trunk] Introduce --apply-redo-only as the name for --apply-log-only

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -693,6 +693,7 @@ enum options_xtrabackup {
   OPT_XTRA_PREPARE,
   OPT_XTRA_EXPORT,
   OPT_XTRA_APPLY_LOG_ONLY,
+  OPT_XTRA_APPLY_REDO_ONLY,
   OPT_XTRA_PRINT_PARAM,
   OPT_XTRA_USE_MEMORY,
   OPT_XTRA_USE_FREE_MEMORY_PCT,
@@ -887,13 +888,19 @@ struct my_option xb_client_options[] = {
      NO_ARG, 0, 0, 0, 0, 0, 0},
     {"check-tables", OPT_XTRA_CHECK_TABLES,
      "Validate all InnoDB B-tree indexes during --prepare. "
-     "Runs after redo apply (including --apply-log-only). "
+     "Runs after redo apply (including --apply-redo-only). "
      "Read-only: does not modify any InnoDB data.",
      (G_PTR *)&xtrabackup_check_tables, (G_PTR *)&xtrabackup_check_tables, 0,
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+    {"apply-redo-only", OPT_XTRA_APPLY_REDO_ONLY,
+     "During --prepare, apply the redo log but skip undo, so that the LSN "
+     "does not progress past the applied redo. Use this on a base backup "
+     "that further incremental backups will be applied to.",
+     (G_PTR *)&xtrabackup_apply_log_only, (G_PTR *)&xtrabackup_apply_log_only,
+     0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"apply-log-only", OPT_XTRA_APPLY_LOG_ONLY,
-     "stop recovery process not to progress LSN after applying log when "
-     "prepare.",
+     "(deprecated) Synonym for --apply-redo-only. Will be removed in "
+     "a future release; use --apply-redo-only instead.",
      (G_PTR *)&xtrabackup_apply_log_only, (G_PTR *)&xtrabackup_apply_log_only,
      0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"print-param", OPT_XTRA_PRINT_PARAM,
@@ -7091,7 +7098,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
     metadata_type = METADATA_FULL_BACKUP;
   } else if (!strcmp(metadata_type_str, "log-applied")) {
     xb::info() << "This target seems to be already prepared with "
-                  "--apply-log-only.";
+                  "--apply-redo-only.";
     metadata_type = METADATA_LOG_APPLIED;
     goto skip_check;
   } else if (!strcmp(metadata_type_str, "full-prepared")) {
@@ -7104,7 +7111,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
 
   if (xtrabackup_incremental) {
     xb::error() << "applying incremental backup needs target prepared "
-                   "with --apply-log-only.";
+                   "with --apply-redo-only.";
     exit(EXIT_FAILURE);
   }
 skip_check:
@@ -7445,7 +7452,7 @@ skip_check:
     re-dirty them). Flush once so the on-disk image read by the checksum scan
     below equals the recovered state -- otherwise a raw read could see a stale
     or torn page and report a false positive. Flushing pages does not advance
-    the redo checkpoint, so this is safe under --apply-log-only too. */
+    the redo checkpoint, so this is safe under --apply-redo-only too. */
     buf_flush_sync_all_buf_pools();
 
     /* --check-tables only reads; redo has already been applied. Forbid the
@@ -7734,6 +7741,25 @@ bool xb_init() {
     xb::error() << mixed_options[0] << " and " << mixed_options[1]
                 << " are mutually exclusive";
     return (false);
+  }
+
+  /* --apply-log-only was renamed --apply-redo-only. Both spellings drive
+  xtrabackup_apply_log_only, so a command line carrying both is always
+  operator confusion rather than intent - reject it instead of picking one. */
+  {
+    const bool redo_only_set = check_if_param_set("apply-redo-only");
+    const bool log_only_set = check_if_param_set("apply-log-only");
+
+    if (redo_only_set && log_only_set) {
+      xb::error() << "--apply-log-only and --apply-redo-only are the same "
+                     "option; pass only one.";
+      return (false);
+    }
+
+    if (log_only_set) {
+      xb::warn() << "--apply-log-only is deprecated and will be removed in "
+                    "a future release. Please use --apply-redo-only instead.";
+    }
   }
 
   if (xtrabackup_backup) {
@@ -8518,7 +8544,7 @@ int main(int argc, char **argv) {
     read_metadata();
     if (strcmp(metadata_type_str, "full-prepared") != 0) {
       xb::error() << "The target is not fully prepared. Please prepare it "
-                     "without option --apply-log-only";
+                     "without option --apply-redo-only";
       exit(EXIT_FAILURE);
     }
 

--- a/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
+++ b/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
@@ -1,0 +1,65 @@
+#
+# PXB-3758: --apply-redo-only replaces the confusingly named --apply-log-only.
+#
+# Both spellings drive the same knob, so this test pins down all three cases:
+# the new name works (and stops at redo, so an incremental still applies on
+# top), the old name still works but warns, and passing both is rejected.
+#
+
+start_server
+
+mysql -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+mysql -e "INSERT INTO t1 (a) VALUES (1), (2), (3)" test
+
+xtrabackup --backup --target-dir=$topdir/full
+
+mysql -e "INSERT INTO t1 (a) VALUES (10), (20), (30)" test
+
+xtrabackup --backup --incremental-basedir=$topdir/full \
+	   --target-dir=$topdir/inc
+
+record_db_state test
+
+# --apply-redo-only is the recommended spelling: it must not nag the operator.
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
+
+if grep -q "apply-log-only is deprecated" $OUTFILE ; then
+	die "--apply-redo-only must not emit the --apply-log-only deprecation warning"
+fi
+
+# It has to leave the backup at "redo applied, undo skipped" - that is the
+# whole point of the option, and what makes the incremental below apply.
+grep -q "backup_type = log-applied" $topdir/full/xtrabackup_checkpoints \
+	|| die "--apply-redo-only did not stop after redo apply"
+
+# The old spelling keeps working, on the same backup, and warns once.
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+	   --target-dir=$topdir/full
+
+grep -q "apply-log-only is deprecated and will be removed in a future release" \
+	$OUTFILE || die "--apply-log-only did not emit a deprecation warning"
+
+xtrabackup --prepare --target-dir=$topdir/full
+
+# Both spellings at once is operator confusion, never intent.
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-redo-only \
+		       --apply-log-only --target-dir=$topdir/full
+
+grep -q "are the same option; pass only one" $OUTFILE \
+	|| die "passing both spellings was not rejected with the expected error"
+
+# Order must not matter, and neither should an explicit value.
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-log-only \
+		       --apply-redo-only --target-dir=$topdir/full
+
+# The chain prepared through both spellings restores to the recorded state.
+stop_server
+rm -rf $mysql_datadir/*
+
+xtrabackup --copy-back --target-dir=$topdir/full
+
+start_server
+
+verify_db_state test
+
+rm -rf $topdir/full $topdir/inc


### PR DESCRIPTION
## What

trunk version of #1798, brought over by merging the 9.7 branch (not cherry-picked).

`--apply-log-only` does not apply anything called a "log only" — it applies the redo log and skips undo. This adds **`--apply-redo-only`** pointing at the same internal boolean, and keeps `--apply-log-only` accepted so existing scripts keep working.

| command line | behaviour |
|---|---|
| `--apply-redo-only` | works, silent |
| `--apply-log-only` | works, one startup deprecation warning |
| both spellings | **rejected** (exit 1), regardless of values or order |

```
[Warning] --apply-log-only is deprecated and will be removed in a future release.
          Please use --apply-redo-only instead.
[ERROR]   --apply-log-only and --apply-redo-only are the same option; pass only one.
```

`--help` documents the new name and marks the old one `(deprecated)`. The messages that named the old option now name `--apply-redo-only`. No specific removal version is named, since the next LTS is not decided yet.

## Note on the commit list

Three commits show above `trunk`: the merge, the fix, and `b381c5f08e2` (the 9.7 merge of #1793). trunk did not have that commit as an ancestor, but its content is already in trunk via #1794 and the null merge #1795, so **the diff against trunk is exactly this fix** and nothing else.

## Test

`t/apply_redo_only_alias.sh` — same coverage as #1798: new spelling silent and still stops after redo apply so an incremental applies on top; old spelling works and warns once; both together rejected in either order; and the chain prepared through both spellings restores to the recorded state.

## Results

Full framework run on a 128-core host, every suite, with S3/MinIO, Vault and KMIP configured:

```
429 run, 319 successful, 110 skipped, 0 failed
```

Log posted as a comment below.

https://perconadev.atlassian.net/browse/PXB-3758