### PR TITLE
PXB-3788 : [9.7] Warn at startup for deprecated xtrabackup options

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -7736,14 +7736,53 @@ bool xb_init() {
     return (false);
   }
 
-  if (xtrabackup_backup) {
+  /* Options the runtime stopped acting on long ago. They stay in the option
+  table for the 8.4/9.7 window so existing scripts keep parsing, but operators
+  keep pasting them in expecting an effect, so say plainly that there is none.
+  Scheduled for removal from the option table in a future release. */
+  {
+    static const struct {
+      const char *name;
+      const char *reason;
+    } dead_options[] = {
+        {"log",
+         "It is accepted only for MySQL client option compatibility and is "
+         "never read."},
+        {"innodb",
+         "It is accepted only for MySQL client option compatibility and is "
+         "never read."},
+        {"create-ib-logfile", "It does not create ib_logfile* files."},
+        {"rebuild_threads",
+         "It only ever applied to --rebuild-indexes, which was removed."},
 #ifdef HAVE_VERSION_CHECK
-    if (opt_noversioncheck) {
-      xb::warn()
-          << "version check is removed and --no-version-check is deprecated.";
-    }
+        {"no-version-check",
+         "The version check it disabled was itself removed."},
 #endif
+    };
 
+    for (const auto &dead : dead_options) {
+      if (check_if_param_set(dead.name)) {
+        xb::warn() << "--" << dead.name << " is deprecated and has no effect. "
+                   << dead.reason << " It will be removed in a future release.";
+      }
+    }
+  }
+
+  /* --rsync is deprecated but NOT dead: it still routes the non-InnoDB copy
+  through rsync (see backup_files() in backup_copy.cc), so this is a "going
+  away" notice rather than a "does nothing" one. The code and the rsync
+  binary dependency stay for now; only the option is deprecated. */
+  if (check_if_param_set("rsync")) {
+    xb::warn()
+        << "--rsync is deprecated and unsupported, and will be removed "
+           "in a future release. All it did was shorten the FLUSH TABLES "
+           "WITH READ LOCK window while non-InnoDB files were copied, "
+           "which no longer matters now that backup locks and "
+           "--lock-ddl=REDUCED let DDL and DML proceed during the "
+           "backup.";
+  }
+
+  if (xtrabackup_backup) {
     if ((mysql_connection = xb_mysql_connect()) == NULL) {
       return (false);
     }

--- a/storage/innobase/xtrabackup/test/t/deprecated_options.sh
+++ b/storage/innobase/xtrabackup/test/t/deprecated_options.sh
@@ -1,0 +1,76 @@
+#
+# PXB-3788: options the runtime stopped acting on must say so at startup.
+#
+# Every option below is still accepted (no script breaks, no exit-code
+# change), but passing one now prints a warning naming it. --rsync is the
+# odd one out: it is deprecated but still functional, so it must be
+# announced as going away rather than as having no effect.
+#
+
+start_server
+
+mysql -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+mysql -e "INSERT INTO t1 (a) VALUES (1), (2), (3)" test
+
+dead_options="log innodb create-ib-logfile rebuild_threads"
+
+# --no-version-check only exists in a -DWITH_VERSION_CHECK=ON build.
+if $XB_BIN --help 2>&1 | grep -q -- "--no-version-check" ; then
+	dead_options="$dead_options no-version-check"
+fi
+
+# Control: a backup passing none of them must stay quiet, so any warning
+# later in this test can only come from the option actually being set.
+xtrabackup --backup --target-dir=$topdir/backup
+
+if grep -q "is deprecated and has no effect" $OUTFILE ; then
+	die "deprecation warning emitted for an option that was not passed"
+fi
+
+if grep -q -- "--rsync is deprecated" $OUTFILE ; then
+	die "--rsync warning emitted when --rsync was not passed"
+fi
+
+# --rsync is a --backup option, so exercise it there rather than under
+# --prepare. It shells out to the rsync binary, so skip this part when that
+# is not installed - same convention as t/ib_rsync.sh and friends.
+if which rsync > /dev/null 2>&1 ; then
+	xtrabackup --backup --rsync --target-dir=$topdir/backup_rsync
+
+	grep -q -- "--rsync is deprecated and unsupported" $OUTFILE \
+		|| die "no deprecation warning for --rsync"
+
+	# The warning has to name the lock whose window rsync shortened.
+	grep -q "shorten the FLUSH TABLES WITH READ LOCK window" $OUTFILE \
+		|| die "--rsync warning does not name FLUSH TABLES WITH READ LOCK"
+
+	# --rsync really does route the non-InnoDB copy through rsync, so it
+	# must never be described as having no effect.
+	if grep -q -- "--rsync is deprecated and has no effect" $OUTFILE ; then
+		die "--rsync must not be described as having no effect - it still works"
+	fi
+else
+	vlog "rsync is not installed - skipping the --rsync part of this test"
+fi
+
+stop_server
+
+# The dead options are never read, so the mode does not matter. Use
+# --prepare, which additionally proves --no-version-check now warns outside
+# --backup (it used to warn only there).
+dead_args=""
+for opt in $dead_options ; do
+	case $opt in
+		rebuild_threads) dead_args="$dead_args --rebuild_threads=4" ;;
+		*)               dead_args="$dead_args --$opt" ;;
+	esac
+done
+
+xtrabackup --prepare --target-dir=$topdir/backup $dead_args
+
+for opt in $dead_options ; do
+	grep -q -- "--$opt is deprecated and has no effect" $OUTFILE \
+		|| die "no deprecation warning for --$opt"
+done
+
+rm -rf $topdir/backup $topdir/backup_rsync


### PR DESCRIPTION
## What

xtrabackup accepts a handful of options the runtime stopped acting on long ago, and operators keep pasting them into scripts expecting an effect. This emits **one startup warning per offending option**, naming it and saying why it is dead. Every option stays in the option table — no script breaks, no exit-code change.

Warned about as having **no effect**:

| option | reason |
|---|---|
| `--log`, `--innodb` | accepted only for MySQL client option compatibility; values never read |
| `--create-ib-logfile` | does not create `ib_logfile*` files |
| `--rebuild_threads` | only ever applied to `--rebuild-indexes`, which was removed |
| `--no-version-check` | the version check it disabled was itself removed |

```
[Warning] --log is deprecated and has no effect. It is accepted only for MySQL
          client option compatibility and is never read. It will be removed in
          a future release.
```

`--no-version-check` already warned, but only under `--backup` and only in a `HAVE_VERSION_CHECK` build. It is folded into the common startup path so `--prepare` warns too, keeping the `#ifdef` since the option is registered only in that configuration.

## `--rsync` is handled differently, on purpose

The ticket lists `--rsync` as having no effect. **It does have an effect**, so this deliberately does not say that. `opt_rsync` is read at five places in `backup_copy.cc` — it selects `datafile_rsync_backup()` over `datafile_copy_backup()`, gates whether the prep-mode pass runs at all, builds and runs the rsync command, and changes buffer-pool-dump handling. It also has live tests (`t/PXB-1548_rsync_*.sh`, `t/ib_rsync*.sh`), and a backup genuinely fails when the `rsync` binary is missing.

Telling operators it "has no effect" would be false, and acting on that advice would silently change their copy path. So it gets its own wording:

```
[Warning] --rsync is deprecated and unsupported, and will be removed in a future
          release. All it did was shorten the FLUSH TABLES WITH READ LOCK window
          while non-InnoDB files were copied, which no longer matters now that
          backup locks and --lock-ddl=REDUCED let DDL and DML proceed during the
          backup.
```

Accurate on both counts: the option is unsupported and going away, but because its *purpose* is obsolete, not because the code is dead. **The rsync code and its binary dependency stay for now.**

For the record, `--rsync` never required FTWRL: its two-pass structure is gated only on `!opt_no_lock` and runs *before* `lock_tables_maybe()` chooses between `LOCK TABLES FOR BACKUP` and FTWRL — and FTWRL itself is still reachable (`--slave-info` against a non-Percona server without auto-position, or when backup locks are unavailable).

`--compact` and `--rebuild-indexes` need no warning path: they are not registered, so they already fail at parse time as unknown options.

No specific removal version is named anywhere, since the next LTS is not decided yet.

## Test

`t/deprecated_options.sh` asserts:
- a clean backup warns about nothing, so any later warning can only come from the option being set;
- each dead option produces its own warning naming it;
- `--prepare --no-version-check` warns, proving the check is no longer backup-only;
- `--rsync` is announced as deprecated and unsupported, names FLUSH TABLES WITH READ LOCK, and is **never** described as having no effect.

`--rsync` is exercised under `--backup`, the only mode that reaches its code path, guarded by a `which rsync` check as `t/ib_rsync.sh` and its siblings do.

Against a stock 9.7 binary the test fails with `no deprecation warning for --log`, so it genuinely covers the change.

## Results

Full framework run on a 128-core host, every suite, with S3/MinIO, Vault and KMIP configured:

```
429 run, 319 successful, 110 skipped, 0 failed
```

Log posted as a comment below.

Based on `9.7` at `b381c5f08e2`.

https://perconadev.atlassian.net/browse/PXB-3788