### PR TITLE
PXB-3609 : Fix a flaky permission check in the md5 delete tests (trunk)

### DIFF
--- a/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_permissions.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_permissions.sh
@@ -152,8 +152,10 @@ demanding privileges beyond ListBucket + DeleteObject"
 fi
 
 # An AccessDenied that xbcloud swallowed would show up here even with a clean
-# exit status.
-if grep -qiE 'access denied|forbidden|403' $LOG_DELETE; then
+# exit status.  Match the messages xbcloud actually prints -- a bare "403"
+# also occurs inside the random bucket and backup names, which made this fire
+# on a perfectly good delete.
+if grep -qiE 'Failed to delete|Delete failed|Access Denied|Forbidden' $LOG_DELETE; then
     cat $LOG_DELETE >&2
     die "PXB-3609: delete-only user hit a permission error during delete"
 fi

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_prefix_scope.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/md5_delete_prefix_scope.sh
@@ -131,7 +131,9 @@ fi
 # The .md5 file is out of this user's reach.  Saying so on every delete would
 # be noise, and it is what xbcloud did before the fix, so the run has to be
 # quiet about it.
-if grep -qiE 'warning|failed to delete|access denied|forbidden|403' $LOG_DELETE; then
+# Match the messages xbcloud actually prints: a bare "403", and even the word
+# "warning", can occur inside the random bucket and backup names.
+if grep -qiE 'Warning:|Failed to delete|Delete failed|Access Denied|Forbidden' $LOG_DELETE; then
     cat $LOG_DELETE >&2
     die "PXB-3609: delete complained about ${BACKUP_NAME}.md5, which this user \
 has no rights on"


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PXB-3609

Follow-up to the PXB-3609 tests that just landed.

md5_delete_permissions.sh and md5_delete_prefix_scope.sh scan the delete log for a permission error, and the pattern included the bare string 403. Bucket and backup names carry a random uuid, so a uuid whose hex happens to contain 403 makes every "Deleting <backup_name>/..." line match, and the test fails on a delete that did exactly what it should.

That is what happened on the 8.4.0-7 build: the delete removed every object and printed "Delete completed.", and the test still failed. The backup name was md5perm_backup_dccc6ed8-7d7f-4ae7-8f72-0234031762d5 - the uuid ends in ...0234031762d5, which contains 403.

Match the messages xbcloud actually prints instead. Every alternative now contains a space or a colon, so a hex uuid cannot produce one.

Measured over 200000 random uuids: 0.52% matched the old pattern, none match the new one. Reproduced by forcing the uuid from the failed run: the old pattern fails the test, the new one passes.

Verified locally against MinIO: md5_delete, md5_delete_permissions and md5_delete_prefix_scope all pass.

Merge of PXB-9.7-3609-flaky into trunk.