### PR TITLE
PXB-3883 : [8.4] Install the clang-format version .clang-format asks for

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-# We currently use clang-format version 10.
+# We currently use clang-format version 11.
 #
 # This is the output of
 #

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,11 +32,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '32'
-    - name: Install clang-format-11
-      run: sudo apt-get install -y clang-format-11
+    - name: Install the clang-format version .clang-format asks for
+      run: |
+        REQUIRED=$(sed -n 's/^# We currently use clang-format version \([0-9][0-9]*\)\..*/\1/p' .clang-format | head -1)
+        if [ -z "${REQUIRED}" ]; then
+          echo "Could not read the required clang-format version from .clang-format"
+          exit 1
+        fi
+        echo "Required clang-format version: ${REQUIRED}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+        echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |
-        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | clang-format-diff-11 -style=file -p1 >_GIT_DIFF
+        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | "clang-format-diff-${CLANG_FORMAT_VERSION}" -style=file -p1 >_GIT_DIFF
         if [ ! -s _GIT_DIFF ]; then
           echo The last git commit is clang-formatted;
         else

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,18 @@ jobs:
         echo "Required clang-format version: ${REQUIRED}"
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+
+        # Guard against the tool and the config drifting apart again. The
+        # package name carries the version, but check what the binary really
+        # reports rather than trusting the name.
+        INSTALLED=$("clang-format-${REQUIRED}" --version | sed -n 's/.*clang-format version \([0-9][0-9]*\)\..*/\1/p')
+        if [ "${INSTALLED}" != "${REQUIRED}" ]; then
+          echo "clang-format version mismatch"
+          echo "  .clang-format asks for: ${REQUIRED}"
+          echo "  installed binary is:    ${INSTALLED:-unknown}"
+          exit 1
+        fi
+        echo "Using clang-format ${INSTALLED}, matching .clang-format"
         echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |


### PR DESCRIPTION
## What

The `clang_format` job hardcodes `clang-format-11`, while `.clang-format` on this branch asks for version 10. The two have never matched, and nothing checks that they do.

Three commits:

| commit | what |
|---|---|
| `2a354e288f0` | `.clang-format` records 11 instead of 10 |
| `7ebdc160386` | install the version `.clang-format` asks for, instead of hardcoding one |
| `627c663c4d4` | fail if the installed binary is not that version |

## Why 11 and not 10 on this branch

clang-format 10 is only packaged in Ubuntu 20.04, and that GitHub runner image was retired in April 2025. Ubuntu 22.04 carries 11 through 15.

More to the point, **11 is what CI has actually been installing and enforcing here all along** — the `10` in `.clang-format` was inherited and never matched what anyone ran. Recording 11 makes the file describe reality. Nothing is reformatted by this change, and clang-format 11 accepts every key the config uses.

The alternative would be running the job in a `ubuntu:20.04` container to get 10. I tried that first; it works, but it takes a retired image as a hard dependency for no practical gain.

## The version guard

Reading the version from the file is only half of it. If the package is missing, renamed, or resolves to something else, the run should say so rather than quietly format with a different tool:

```
clang-format version mismatch
  .clang-format asks for: 11
  installed binary is:    14
```

It asks the binary what it is rather than trusting the package name. The parsing handles both shapes the tool reports, plain `clang-format version 11.0.0` and Ubuntu builds prefixed with `Ubuntu `. Verified against real clang-format 10, 11 and 15 binaries.

## Not changed

The `HEAD^1` diff range stays as it is. On a `pull_request` event the checkout is the merge ref, so `HEAD^1` is the base branch and the diff already covers the whole PR. `fetch-depth` stays at `32` — raising it costs a full-history fetch and buys nothing.

## Testing

Validated by running it: https://github.com/satya-bodapati/percona-xtrabackup/pull/10 — both jobs pass, `clang_format` in 59s, in line with the current job. A `pull_request` event uses the workflow from the merge ref, so that PR exercised this version of the file rather than the one on the base branch.

https://perconadev.atlassian.net/browse/PXB-3883