### PR TITLE
PXB-3883 : [9.7] Install the clang-format version .clang-format asks for, and fix the branch names

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-# We currently use clang-format version 10.
+# We currently use clang-format version 11.
 #
 # This is the output of
 #

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,11 +32,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '32'
-    - name: Install clang-format-11
-      run: sudo apt-get install -y clang-format-11
+    - name: Install the clang-format version .clang-format asks for
+      run: |
+        REQUIRED=$(sed -n 's/^# We currently use clang-format version \([0-9][0-9]*\)\..*/\1/p' .clang-format | head -1)
+        if [ -z "${REQUIRED}" ]; then
+          echo "Could not read the required clang-format version from .clang-format"
+          exit 1
+        fi
+        echo "Required clang-format version: ${REQUIRED}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+        echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |
-        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | clang-format-diff-11 -style=file -p1 >_GIT_DIFF
+        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | "clang-format-diff-${CLANG_FORMAT_VERSION}" -style=file -p1 >_GIT_DIFF
         if [ ! -s _GIT_DIFF ]; then
           echo The last git commit is clang-formatted;
         else

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Pre-commit Checks
 on:
   push:
     branches:
-      - trunk
+      - 9.7
       - release-*
   pull_request:
 
@@ -17,8 +17,8 @@ jobs:
         fetch-depth: '32'
     - name: Run BiDi Scan
       run: |
-        git fetch origin trunk
-        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/trunk -- . | tr '\n' ' ')
+        git fetch origin 9.7
+        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/9.7 -- . | tr '\n' ' ')
 
         if [ -z "${CHANGED_FILES}" ]; then
             echo --- No changed files

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,18 @@ jobs:
         echo "Required clang-format version: ${REQUIRED}"
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+
+        # Guard against the tool and the config drifting apart again. The
+        # package name carries the version, but check what the binary really
+        # reports rather than trusting the name.
+        INSTALLED=$("clang-format-${REQUIRED}" --version | sed -n 's/.*clang-format version \([0-9][0-9]*\)\..*/\1/p')
+        if [ "${INSTALLED}" != "${REQUIRED}" ]; then
+          echo "clang-format version mismatch"
+          echo "  .clang-format asks for: ${REQUIRED}"
+          echo "  installed binary is:    ${INSTALLED:-unknown}"
+          exit 1
+        fi
+        echo "Using clang-format ${INSTALLED}, matching .clang-format"
         echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |


### PR DESCRIPTION
## What

Two independent problems with `.github/workflows/checks.yml` on this branch.

**1. Wrong clang-format version.** The job hardcodes `clang-format-11`, but `.clang-format` here asks for **15**. The configs are not interchangeable — 8.4 carries four keys 9.7 does not (`DerivePointerAlignment`, `IncludeBlocks: Regroup`, `PointerAlignment`, `Standard: Auto`) — so someone formatting with the documented 15 can produce a diff CI rejects, and CI can pass code 15 would reformat. Ubuntu 22.04 packages 15, so no runner change is needed.

**2. This branch's workflow refers to trunk.** It is a verbatim copy of the trunk file:

```yaml
on: push: branches: [ trunk ]
git fetch origin trunk
CHANGED_FILES=$(git diff ... origin/trunk ...)
```

So pushes to 9.7 never trigger it, and the BiDi scan on a 9.7 PR diffs against trunk, listing files unrelated to the change.

## Commits

Merged forward from the 8.4 branch (#1806), plus one commit specific to this line:

| commit | what |
|---|---|
| `2a354e288f0` | 8.4: `.clang-format` records 11 instead of 10 |
| `7ebdc160386` | install the version `.clang-format` asks for |
| `627c663c4d4` | fail if the installed binary is not that version |
| `0072eac2d8d` | merge, keeping this branch on 15 |
| `dde724568b3` | point the checks at 9.7 |

The merge conflicted on `.clang-format` exactly as it should — 8.4 moved 10 to 11 while this branch says 15 — and was resolved keeping 15.

## The version guard

```
clang-format version mismatch
  .clang-format asks for: 15
  installed binary is:    11
```

It asks the binary what it is rather than trusting the package name, so the tool and the config cannot drift apart again. Handles both `--version` shapes (plain and `Ubuntu `-prefixed); verified against real clang-format 10, 11 and 15.

## Not changed

The `HEAD^1` diff range and `fetch-depth: 32` stay as they are. On a `pull_request` event the checkout is the merge ref, so `HEAD^1` is the base branch and the diff already covers the whole PR.

## Testing

Validated by running it: https://github.com/satya-bodapati/percona-xtrabackup/pull/11 — both jobs pass, `clang_format` in 1m12s, roughly the current cost (the extra seconds are installing 15 rather than 11).

https://perconadev.atlassian.net/browse/PXB-3883