### PR TITLE
PXB-3883 : [trunk] Install the clang-format version .clang-format asks for

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-# We currently use clang-format version 10.
+# We currently use clang-format version 11.
 #
 # This is the output of
 #

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,11 +32,20 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '32'
-    - name: Install clang-format-11
-      run: sudo apt-get install -y clang-format-11
+    - name: Install the clang-format version .clang-format asks for
+      run: |
+        REQUIRED=$(sed -n 's/^# We currently use clang-format version \([0-9][0-9]*\)\..*/\1/p' .clang-format | head -1)
+        if [ -z "${REQUIRED}" ]; then
+          echo "Could not read the required clang-format version from .clang-format"
+          exit 1
+        fi
+        echo "Required clang-format version: ${REQUIRED}"
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+        echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |
-        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | clang-format-diff-11 -style=file -p1 >_GIT_DIFF
+        git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | "clang-format-diff-${CLANG_FORMAT_VERSION}" -style=file -p1 >_GIT_DIFF
         if [ ! -s _GIT_DIFF ]; then
           echo The last git commit is clang-formatted;
         else

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Pre-commit Checks
 on:
   push:
     branches:
-      - trunk
+      - 9.7
       - release-*
   pull_request:
 
@@ -17,8 +17,8 @@ jobs:
         fetch-depth: '32'
     - name: Run BiDi Scan
       run: |
-        git fetch origin trunk
-        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/trunk -- . | tr '\n' ' ')
+        git fetch origin 9.7
+        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/9.7 -- . | tr '\n' ' ')
 
         if [ -z "${CHANGED_FILES}" ]; then
             echo --- No changed files

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,6 +42,18 @@ jobs:
         echo "Required clang-format version: ${REQUIRED}"
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends "clang-format-${REQUIRED}"
+
+        # Guard against the tool and the config drifting apart again. The
+        # package name carries the version, but check what the binary really
+        # reports rather than trusting the name.
+        INSTALLED=$("clang-format-${REQUIRED}" --version | sed -n 's/.*clang-format version \([0-9][0-9]*\)\..*/\1/p')
+        if [ "${INSTALLED}" != "${REQUIRED}" ]; then
+          echo "clang-format version mismatch"
+          echo "  .clang-format asks for: ${REQUIRED}"
+          echo "  installed binary is:    ${INSTALLED:-unknown}"
+          exit 1
+        fi
+        echo "Using clang-format ${INSTALLED}, matching .clang-format"
         echo "CLANG_FORMAT_VERSION=${REQUIRED}" >> "${GITHUB_ENV}"
     - name: Run clang-format
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Pre-commit Checks
 on:
   push:
     branches:
-      - 9.7
+      - trunk
       - release-*
   pull_request:
 
@@ -17,8 +17,8 @@ jobs:
         fetch-depth: '32'
     - name: Run BiDi Scan
       run: |
-        git fetch origin 9.7
-        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/9.7 -- . | tr '\n' ' ')
+        git fetch origin trunk
+        CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/trunk -- . | tr '\n' ' ')
 
         if [ -z "${CHANGED_FILES}" ]; then
             echo --- No changed files


### PR DESCRIPTION
## What

The `clang_format` job hardcodes `clang-format-11`, but `.clang-format` on this branch asks for **15**. The style configs are not interchangeable, so a developer formatting with the documented version can produce a diff CI rejects, and CI can pass code that version would reformat. Ubuntu 22.04 packages 15, so the runner does not change.

Merged forward from 9.7 (#1807), which came from 8.4 (#1806).

| commit | what |
|---|---|
| `2a354e288f0` | 8.4: `.clang-format` records 11 instead of 10 |
| `7ebdc160386` | install the version `.clang-format` asks for |
| `627c663c4d4` | fail if the installed binary is not that version |
| `0072eac2d8d` | merge into 9.7, keeping that line on 15 |
| `dde724568b3` | 9.7: point the checks at 9.7 |
| `c1c29c223fe` | merge into trunk |
| `29be91c13c0` | keep the branch references pointing at trunk |

## Note on that last commit

The forward merge from 9.7 brought its branch names with it, so this file briefly triggered on pushes to `9.7` and diffed the BiDi scan against `origin/9.7`. Git had no reason to flag it: both sides touched those lines and only one side had changed them, so it merged silently.

The branch names are the one part of `checks.yml` that is branch specific and must not travel with a forward merge. Worth re-checking after every merge into this branch — the commit message says so too.

## The version guard

```
clang-format version mismatch
  .clang-format asks for: 15
  installed binary is:    11
```

Asks the binary what it is rather than trusting the package name, so the tool and the config cannot drift apart again. Handles both `--version` shapes; verified against clang-format 10, 11 and 15.

## Not changed

The `HEAD^1` diff range and `fetch-depth: 32` stay as they are — on a `pull_request` the checkout is the merge ref, so `HEAD^1` is the base and the diff already covers the whole PR.

## Testing

Validated by running it: https://github.com/satya-bodapati/percona-xtrabackup/pull/12 — both jobs pass, `clang_format` in 1m11s.

https://perconadev.atlassian.net/browse/PXB-3883