### PR TITLE
PXB-3758, PXB-3840 : [9.7] Option aliases: --apply-redo-only and the incremental options

### DIFF
--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -86,6 +86,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sql/srv_session.h>
 #include <table_cache.h>
 #include <algorithm>
+#include <array>
 #include <list>
 #include <set>
 #include <sstream>
@@ -7678,6 +7679,45 @@ static void append_defaults_group(const char *group,
   ut_a(appended);
 }
 
+/** An option that was renamed. Both spellings drive the same variable, so
+they are one option under two names. */
+struct renamed_option {
+  std::string_view old_name;
+  std::string_view new_name;
+};
+
+/** Every option rename lives here, old name first. Adding a rename means
+adding a row, nothing else. Entries are string literals, so data() is safe to
+hand to check_if_param_set(). */
+static const std::array<renamed_option, 0> renamed_options = {};
+
+/** Warn once for every deprecated option name that was used, and reject an
+old name passed together with its new one. They name the same knob, so a
+command line carrying both is operator confusion rather than intent: picking
+one silently would hide the mistake.
+@return false if the caller should stop. */
+static bool check_renamed_options() {
+  for (const auto &renamed : renamed_options) {
+    const bool old_set = check_if_param_set(renamed.old_name.data());
+    const bool new_set = check_if_param_set(renamed.new_name.data());
+
+    if (old_set && new_set) {
+      xb::error() << "--" << renamed.old_name << " and --" << renamed.new_name
+                  << " are the same option; pass only one.";
+      return (false);
+    }
+
+    if (old_set) {
+      xb::warn() << "--" << renamed.old_name
+                 << " is deprecated and will be removed in a future release. "
+                    "Please use --"
+                 << renamed.new_name << " instead.";
+    }
+  }
+
+  return (true);
+}
+
 bool xb_init() {
   const char *mixed_options[4] = {NULL, NULL, NULL, NULL};
   int n_mixed_options;
@@ -7733,6 +7773,10 @@ bool xb_init() {
   if (n_mixed_options > 1) {
     xb::error() << mixed_options[0] << " and " << mixed_options[1]
                 << " are mutually exclusive";
+    return (false);
+  }
+
+  if (!check_renamed_options()) {
     return (false);
   }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -694,6 +694,7 @@ enum options_xtrabackup {
   OPT_XTRA_PREPARE,
   OPT_XTRA_EXPORT,
   OPT_XTRA_APPLY_LOG_ONLY,
+  OPT_XTRA_APPLY_REDO_ONLY,
   OPT_XTRA_PRINT_PARAM,
   OPT_XTRA_USE_MEMORY,
   OPT_XTRA_USE_FREE_MEMORY_PCT,
@@ -888,13 +889,19 @@ struct my_option xb_client_options[] = {
      NO_ARG, 0, 0, 0, 0, 0, 0},
     {"check-tables", OPT_XTRA_CHECK_TABLES,
      "Validate all InnoDB B-tree indexes during --prepare. "
-     "Runs after redo apply (including --apply-log-only). "
+     "Runs after redo apply (including --apply-redo-only). "
      "Read-only: does not modify any InnoDB data.",
      (G_PTR *)&xtrabackup_check_tables, (G_PTR *)&xtrabackup_check_tables, 0,
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
+    {"apply-redo-only", OPT_XTRA_APPLY_REDO_ONLY,
+     "During --prepare, apply the redo log but skip undo, so that the LSN "
+     "does not progress past the applied redo. Use this on a base backup "
+     "that further incremental backups will be applied to.",
+     (G_PTR *)&xtrabackup_apply_log_only, (G_PTR *)&xtrabackup_apply_log_only,
+     0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"apply-log-only", OPT_XTRA_APPLY_LOG_ONLY,
-     "stop recovery process not to progress LSN after applying log when "
-     "prepare.",
+     "(deprecated) Synonym for --apply-redo-only. Will be removed in "
+     "a future release; use --apply-redo-only instead.",
      (G_PTR *)&xtrabackup_apply_log_only, (G_PTR *)&xtrabackup_apply_log_only,
      0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"print-param", OPT_XTRA_PRINT_PARAM,
@@ -7092,7 +7099,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
     metadata_type = METADATA_FULL_BACKUP;
   } else if (!strcmp(metadata_type_str, "log-applied")) {
     xb::info() << "This target seems to be already prepared with "
-                  "--apply-log-only.";
+                  "--apply-redo-only.";
     metadata_type = METADATA_LOG_APPLIED;
     goto skip_check;
   } else if (!strcmp(metadata_type_str, "full-prepared")) {
@@ -7105,7 +7112,7 @@ static void xtrabackup_prepare_func(int argc, char **argv) {
 
   if (xtrabackup_incremental) {
     xb::error() << "applying incremental backup needs target prepared "
-                   "with --apply-log-only.";
+                   "with --apply-redo-only.";
     exit(EXIT_FAILURE);
   }
 skip_check:
@@ -7446,7 +7453,7 @@ skip_check:
     re-dirty them). Flush once so the on-disk image read by the checksum scan
     below equals the recovered state -- otherwise a raw read could see a stale
     or torn page and report a false positive. Flushing pages does not advance
-    the redo checkpoint, so this is safe under --apply-log-only too. */
+    the redo checkpoint, so this is safe under --apply-redo-only too. */
     buf_flush_sync_all_buf_pools();
 
     /* --check-tables only reads; redo has already been applied. Forbid the
@@ -7689,7 +7696,9 @@ struct renamed_option {
 /** Every option rename lives here, old name first. Adding a rename means
 adding a row, nothing else. Entries are string literals, so data() is safe to
 hand to check_if_param_set(). */
-static const std::array<renamed_option, 0> renamed_options = {};
+static const std::array<renamed_option, 1> renamed_options = {{
+    {"apply-log-only", "apply-redo-only"},
+}};
 
 /** Warn once for every deprecated option name that was used, and reject an
 old name passed together with its new one. They name the same knob, so a
@@ -8562,7 +8571,7 @@ int main(int argc, char **argv) {
     read_metadata();
     if (strcmp(metadata_type_str, "full-prepared") != 0) {
       xb::error() << "The target is not fully prepared. Please prepare it "
-                     "without option --apply-log-only";
+                     "without option --apply-redo-only";
       exit(EXIT_FAILURE);
     }
 

--- a/storage/innobase/xtrabackup/src/xtrabackup.cc
+++ b/storage/innobase/xtrabackup/src/xtrabackup.cc
@@ -703,8 +703,10 @@ enum options_xtrabackup {
   OPT_XTRA_LOG_COPY_INTERVAL,
   OPT_XTRA_INCREMENTAL,
   OPT_XTRA_INCREMENTAL_BASEDIR,
+  OPT_XTRA_BACKUP_INCREMENTAL_BASE,
   OPT_XTRA_EXTRA_LSNDIR,
   OPT_XTRA_INCREMENTAL_DIR,
+  OPT_XTRA_PREPARE_INCREMENTAL_FROM_DIR,
   OPT_XTRA_ARCHIVED_TO_LSN,
   OPT_XTRA_TABLES,
   OPT_XTRA_TABLES_FILE,
@@ -950,9 +952,15 @@ struct my_option xb_client_options[] = {
      "careful!",
      (G_PTR *)&xtrabackup_incremental, (G_PTR *)&xtrabackup_incremental, 0,
      GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+    {"backup-incremental-base", OPT_XTRA_BACKUP_INCREMENTAL_BASE,
+     "(for --backup): copy only .ibd pages newer than the backup at the "
+     "specified location.",
+     (G_PTR *)&xtrabackup_incremental_basedir,
+     (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
+     0, 0, 0, 0},
     {"incremental-basedir", OPT_XTRA_INCREMENTAL_BASEDIR,
-     "(for --backup): copy only .ibd pages newer than backup at specified "
-     "directory.",
+     "(deprecated) Synonym for --backup-incremental-base. Will be removed in "
+     "a future release; use --backup-incremental-base instead.",
      (G_PTR *)&xtrabackup_incremental_basedir,
      (G_PTR *)&xtrabackup_incremental_basedir, 0, GET_STR, REQUIRED_ARG, 0, 0,
      0, 0, 0, 0},
@@ -962,9 +970,15 @@ struct my_option xb_client_options[] = {
      (G_PTR *)&xtrabackup_redo_log_arch_dir,
      (G_PTR *)&xtrabackup_redo_log_arch_dir, 0, GET_STR, REQUIRED_ARG, 0, 0, 0,
      0, 0, 0},
-    {"incremental-dir", OPT_XTRA_INCREMENTAL_DIR,
+    {"prepare-incremental-from-dir", OPT_XTRA_PREPARE_INCREMENTAL_FROM_DIR,
      "(for --prepare): apply .delta files and logfile in the specified "
      "directory.",
+     (G_PTR *)&xtrabackup_incremental_dir, (G_PTR *)&xtrabackup_incremental_dir,
+     0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+    {"incremental-dir", OPT_XTRA_INCREMENTAL_DIR,
+     "(deprecated) Synonym for --prepare-incremental-from-dir. Will be "
+     "removed in a future release; use --prepare-incremental-from-dir "
+     "instead.",
      (G_PTR *)&xtrabackup_incremental_dir, (G_PTR *)&xtrabackup_incremental_dir,
      0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
     {"to-archived-lsn", OPT_XTRA_ARCHIVED_TO_LSN,
@@ -7696,8 +7710,10 @@ struct renamed_option {
 /** Every option rename lives here, old name first. Adding a rename means
 adding a row, nothing else. Entries are string literals, so data() is safe to
 hand to check_if_param_set(). */
-static const std::array<renamed_option, 1> renamed_options = {{
+static const std::array<renamed_option, 3> renamed_options = {{
     {"apply-log-only", "apply-redo-only"},
+    {"incremental-basedir", "backup-incremental-base"},
+    {"incremental-dir", "prepare-incremental-from-dir"},
 }};
 
 /** Warn once for every deprecated option name that was used, and reject an

--- a/storage/innobase/xtrabackup/test/inc/binlog_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/binlog_common.sh
@@ -16,7 +16,7 @@ function backup() {
   mysql -e "INSERT INTO t (a) VALUES (1), (2), (3)" test
 
   xtrabackup --backup --target-dir=$topdir/backup
-  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+  xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
   mysql -e "INSERT INTO t (a) VALUES (1), (2), (3)" test
 

--- a/storage/innobase/xtrabackup/test/inc/binlog_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/binlog_common.sh
@@ -20,8 +20,8 @@ function backup() {
 
   mysql -e "INSERT INTO t (a) VALUES (1), (2), (3)" test
 
-  xtrabackup --backup --target-dir=$topdir/backup1 --incremental-basedir=$topdir/backup
-  xtrabackup --prepare --incremental-dir=$topdir/backup1 --target-dir=$topdir/backup
+  xtrabackup --backup --target-dir=$topdir/backup1 --backup-incremental-base=$topdir/backup
+  xtrabackup --prepare --prepare-incremental-from-dir=$topdir/backup1 --target-dir=$topdir/backup
 
   stop_server
 

--- a/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
@@ -7,7 +7,7 @@
 #                       backup invocations.
 #    ib_full_backup_extra_args: extra args to be passed to xtrabackup backup invocations.
 #    ib_inc_use_lsn:    if 1, use --incremental-lsn instead of
-#                       --incremental-basedir
+#                       --backup-incremental-base
 
 . inc/common.sh
 
@@ -70,7 +70,7 @@ then
 
     ib_inc_extra_args="${ib_inc_extra_args:-""} --incremental-lsn=$inc_lsn"
 else
-    ib_inc_extra_args="${ib_inc_extra_args:-""} --incremental-basedir=$full_backup_dir"
+    ib_inc_extra_args="${ib_inc_extra_args:-""} --backup-incremental-base=$full_backup_dir"
 fi
 
 $MYSQL $MYSQL_ARGS \
@@ -92,7 +92,7 @@ vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/ib_incremental_common.sh
@@ -87,12 +87,12 @@ vlog "Preparing backup"
 vlog "##############"
 vlog "# PREPARE #1 #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -94,12 +94,12 @@ EOF
 
   kill -SIGKILL $uncommitted_id
 
-  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup \
+  xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup \
        $prepare_options
-  xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+  xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
        --target-dir=$topdir/backup $prepare_options
 
-  xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+  xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
        --target-dir=$topdir/backup $prepare_options
 
   xtrabackup --prepare --export --target-dir=$topdir/backup \

--- a/storage/innobase/xtrabackup/test/inc/keyring_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/keyring_common.sh
@@ -72,7 +72,7 @@ EOF
   # wait for InnoDB to flush all dirty pages
   innodb_wait_for_flush_all
 
-  xtrabackup --backup --incremental-basedir=$topdir/backup \
+  xtrabackup --backup --backup-incremental-base=$topdir/backup \
        --target-dir=$topdir/inc1 $backup_options
 
   run_cmd $MYSQL $MYSQL_ARGS test <<EOF
@@ -89,17 +89,17 @@ EOF
 
   sleep 3
 
-  xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+  xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
        --target-dir=$topdir/inc2 $backup_options
 
   kill -SIGKILL $uncommitted_id
 
   xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup \
        $prepare_options
-  xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+  xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
        --target-dir=$topdir/backup $prepare_options
 
-  xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+  xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc2 \
        --target-dir=$topdir/backup $prepare_options
 
   xtrabackup --prepare --export --target-dir=$topdir/backup \

--- a/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
@@ -91,10 +91,10 @@ EOF
 innodb_wait_for_flush_all
 
 xtrabackup --backup --target-dir=$topdir/backup1 \
-           --incremental-basedir=$topdir/backup --transition-key=123 ${extra_args}
+           --backup-incremental-base=$topdir/backup --transition-key=123 ${extra_args}
 
 xtrabackup --backup --target-dir=$topdir/tmp \
-           --incremental-basedir=$topdir/backuplsn --transition-key=123 \
+           --backup-incremental-base=$topdir/backuplsn --transition-key=123 \
            --stream=xbstream ${extra_args} > $topdir/backup1.xbs
 
 record_db_state test
@@ -116,7 +116,7 @@ function restore_and_verify() {
         done
     fi
 
-    xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/backup1 \
+    xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/backup1 \
                --transition-key=123
 
     if [ $working_compression = "yes" ] ; then

--- a/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
+++ b/storage/innobase/xtrabackup/test/inc/page_compression_common.sh
@@ -106,7 +106,7 @@ function decompress() {
 }
 
 function restore_and_verify() {
-    xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup \
+    xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup \
                --transition-key=123
 
     if [ $working_compression = "yes" ] ; then

--- a/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
+++ b/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
@@ -14,9 +14,9 @@ $MYSQL $MYSQL_ARGS -e "INSERT INTO t VALUES (4), (5), (6)" test
 
 xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full \
 				      --incremental-dir=$topdir/inc
 
 xtrabackup --prepare --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
+++ b/storage/innobase/xtrabackup/test/suites/binlog/bug1523687.sh
@@ -12,12 +12,12 @@ xtrabackup --backup --target-dir=$topdir/full
 
 $MYSQL $MYSQL_ARGS -e "INSERT INTO t VALUES (4), (5), (6)" test
 
-xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/full --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full \
-				      --incremental-dir=$topdir/inc
+				      --prepare-incremental-from-dir=$topdir/inc
 
 xtrabackup --prepare --target-dir=$topdir/full
 

--- a/storage/innobase/xtrabackup/test/suites/check_tables/descent_nodeptr_cycle.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/descent_nodeptr_cycle.sh
@@ -30,7 +30,7 @@ SELECT n, CONCAT('p', n) FROM seq;
 EOF
 
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 PAGE_SIZE=$(get_page_size "$IBD")

--- a/storage/innobase/xtrabackup/test/suites/check_tables/father_child_mismatch.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/father_child_mismatch.sh
@@ -43,8 +43,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 # Find an actual clustered-index leaf (level-0 INDEX) page rather than assuming

--- a/storage/innobase/xtrabackup/test/suites/check_tables/incremental_future_lsn.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/incremental_future_lsn.sh
@@ -44,10 +44,10 @@ xtrabackup --backup --incremental-basedir=$topdir/full \
   --target-dir=$topdir/inc1
 
 vlog "Prepare full (apply-log-only)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
 vlog "Merge incremental + --check-tables (delta pages just written, redo applied)"
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
   --check-tables --target-dir=$topdir/full 2>&1 | tee $topdir/merge.log
 grep -q "verifying checksums of tablespace" $topdir/merge.log || \
   die "checksum pass did not run during incremental merge"

--- a/storage/innobase/xtrabackup/test/suites/check_tables/incremental_future_lsn.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/incremental_future_lsn.sh
@@ -40,14 +40,14 @@ run_cmd $MYSQL $MYSQL_ARGS test -e \
   "BEGIN; UPDATE t1 SET b = REPEAT('w', 200); ROLLBACK;"
 
 vlog "Incremental backup"
-xtrabackup --backup --incremental-basedir=$topdir/full \
+xtrabackup --backup --backup-incremental-base=$topdir/full \
   --target-dir=$topdir/inc1
 
 vlog "Prepare full (apply-log-only)"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
 vlog "Merge incremental + --check-tables (delta pages just written, redo applied)"
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
   --check-tables --target-dir=$topdir/full 2>&1 | tee $topdir/merge.log
 grep -q "verifying checksums of tablespace" $topdir/merge.log || \
   die "checksum pass did not run during incremental merge"

--- a/storage/innobase/xtrabackup/test/suites/check_tables/node_ptr_no_extend.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/node_ptr_no_extend.sh
@@ -38,7 +38,7 @@ EOF
 
 vlog "Full backup + apply-log-only prepare"
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 

--- a/storage/innobase/xtrabackup/test/suites/check_tables/page_header_heap_top_nrecs.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/page_header_heap_top_nrecs.sh
@@ -43,7 +43,7 @@ EOF
 
 vlog "Full backup + apply-log-only prepare"
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 vlog "Locate a clustered-index leaf page (level 0)"

--- a/storage/innobase/xtrabackup/test/suites/check_tables/page_type_all_levels.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/page_type_all_levels.sh
@@ -37,7 +37,7 @@ EOF
 
 vlog "Full backup + apply-log-only prepare"
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/t.ibd
 

--- a/storage/innobase/xtrabackup/test/suites/check_tables/page_type_root.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/page_type_root.sh
@@ -44,8 +44,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SZ=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/partial_page_write.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/partial_page_write.sh
@@ -47,7 +47,7 @@ SELECT n, CONCAT('p', n) FROM seq;
 EOF
 
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 PAGE_SIZE=$(get_page_size "$IBD")

--- a/storage/innobase/xtrabackup/test/suites/check_tables/record_status_invalid.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/record_status_invalid.sh
@@ -44,7 +44,7 @@ EOF
 
 vlog "Full backup + apply-log-only prepare"
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 vlog "Locate a clustered-index leaf page and its first user record"

--- a/storage/innobase/xtrabackup/test/suites/check_tables/root_fseg_page_no.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/root_fseg_page_no.sh
@@ -38,8 +38,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SZ=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/root_fseg_space.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/root_fseg_space.sh
@@ -43,8 +43,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SZ=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/root_level_corrupt.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/root_level_corrupt.sh
@@ -28,7 +28,7 @@ SELECT n, CONCAT('p', n) FROM seq;
 EOF
 
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 PAGE_SIZE=$(get_page_size "$IBD")

--- a/storage/innobase/xtrabackup/test/suites/check_tables/sdi_record_header.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/sdi_record_header.sh
@@ -62,8 +62,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SZ=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/sibling_link_cycle.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/sibling_link_cycle.sh
@@ -31,7 +31,7 @@ SELECT n, CONCAT('p', n) FROM seq;
 EOF
 
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 PAGE_SIZE=$(get_page_size "$IBD")

--- a/storage/innobase/xtrabackup/test/suites/check_tables/sibling_next_out_of_bounds.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/sibling_next_out_of_bounds.sh
@@ -39,8 +39,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SIZE=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/sibling_prev_link.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/sibling_prev_link.sh
@@ -41,8 +41,8 @@ EOF
 vlog "Full backup"
 xtrabackup --backup --target-dir=$topdir/backup
 
-vlog "Prepare with --apply-log-only (leave the backup re-preparable)"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+vlog "Prepare with --apply-redo-only (leave the backup re-preparable)"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
 IBD=$topdir/backup/test/test_users.ibd
 PAGE_SZ=16384

--- a/storage/innobase/xtrabackup/test/suites/check_tables/sibling_record_status.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/sibling_record_status.sh
@@ -36,7 +36,7 @@ SELECT n, CONCAT('p', n) FROM seq;
 EOF
 
 xtrabackup --backup --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 IBD=$topdir/backup/test/t1.ibd
 
 PAGE_SIZE=$(get_page_size "$IBD")

--- a/storage/innobase/xtrabackup/test/suites/check_tables/system_undo_checksum.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/system_undo_checksum.sh
@@ -53,7 +53,7 @@ xtrabackup --backup --target-dir=$topdir/backup
 #
 vlog "=== Control: clean system/undo checksum pass ==="
 cp -r $topdir/backup $topdir/backup_ok
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_ok
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_ok
 xtrabackup --prepare --check-tables --target-dir=$topdir/backup_ok 2>&1 \
   | tee $topdir/ok.log
 grep -q "verifying checksums of tablespace" $topdir/ok.log || \
@@ -67,7 +67,7 @@ vlog "Control passed"
 #
 vlog "=== Negative: corrupt undo tablespace ==="
 cp -r $topdir/backup $topdir/backup_undo
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_undo
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_undo
 UNDO=$(ls $topdir/backup_undo/undo_* 2>/dev/null | head -1)
 [ -n "$UNDO" ] || die "could not find an undo tablespace in the backup"
 corrupt_last_page "$UNDO"
@@ -87,7 +87,7 @@ vlog "Negative(undo) passed"
 #
 vlog "=== Negative: corrupt system tablespace (ibdata1) ==="
 cp -r $topdir/backup $topdir/backup_sys
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_sys
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_sys
 corrupt_last_page "$topdir/backup_sys/ibdata1"
 
 run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
@@ -109,7 +109,7 @@ vlog "Negative(ibdata) passed"
 #
 vlog "=== Negative: corrupt ibdata1 startup-range page (TRX_SYS, page 5) ==="
 cp -r $topdir/backup $topdir/backup_hot
-# Do NOT --apply-log-only first: we want recovery to read the corrupt page.
+# Do NOT --apply-redo-only first: we want recovery to read the corrupt page.
 mach_write_8 "$topdir/backup_hot/ibdata1" 5 200 0xDEADBEEFDEADBEEF
 run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --check-tables \
   --target-dir=$topdir/backup_hot 2>&1 | tee $topdir/hot.log

--- a/storage/innobase/xtrabackup/test/suites/check_tables/table_types_and_options.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/table_types_and_options.sh
@@ -97,7 +97,7 @@ for i in $(seq 101 200); do
 done
 
 vlog "Incremental backup 1"
-xtrabackup --backup --incremental-basedir=$topdir/full \
+xtrabackup --backup --backup-incremental-base=$topdir/full \
            --target-dir=$topdir/inc1 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup_inc1.log >&2)
@@ -126,7 +126,7 @@ for i in $(seq 201 300); do
 done
 
 vlog "Incremental backup 2"
-xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
            --target-dir=$topdir/inc2 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup_inc2.log >&2)
@@ -145,7 +145,7 @@ grep -q "All table checks passed" $topdir/prepare_full.log || \
 
 vlog "Prepare inc1 with --apply-redo-only --check-tables (should run check)"
 xtrabackup --prepare --apply-redo-only --check-tables \
-           --incremental-dir=$topdir/inc1 --target-dir=$topdir/full \
+           --prepare-incremental-from-dir=$topdir/inc1 --target-dir=$topdir/full \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2>&1 | tee $topdir/prepare_inc1.log
 grep log-applied $topdir/full/xtrabackup_checkpoints
@@ -156,7 +156,7 @@ grep -q "All table checks passed" $topdir/prepare_inc1.log || \
 
 vlog "Prepare inc2 with --check-tables (final prepare, should run check)"
 xtrabackup --prepare --check-tables \
-           --incremental-dir=$topdir/inc2 --target-dir=$topdir/full \
+           --prepare-incremental-from-dir=$topdir/inc2 --target-dir=$topdir/full \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2>&1 | tee $topdir/prepare_inc2.log
 grep full-prepared $topdir/full/xtrabackup_checkpoints

--- a/storage/innobase/xtrabackup/test/suites/check_tables/table_types_and_options.sh
+++ b/storage/innobase/xtrabackup/test/suites/check_tables/table_types_and_options.sh
@@ -133,26 +133,26 @@ xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 
 record_db_state test
 
-vlog "Prepare full with --apply-log-only --check-tables (should run check)"
-xtrabackup --prepare --apply-log-only --check-tables --target-dir=$topdir/full \
+vlog "Prepare full with --apply-redo-only --check-tables (should run check)"
+xtrabackup --prepare --apply-redo-only --check-tables --target-dir=$topdir/full \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2>&1 | tee $topdir/prepare_full.log
 grep log-applied $topdir/full/xtrabackup_checkpoints
 grep -q "Starting table checks" $topdir/prepare_full.log || \
-  die "check-tables should run during --apply-log-only prepare"
+  die "check-tables should run during --apply-redo-only prepare"
 grep -q "All table checks passed" $topdir/prepare_full.log || \
-  die "Table checks did not pass during --apply-log-only prepare"
+  die "Table checks did not pass during --apply-redo-only prepare"
 
-vlog "Prepare inc1 with --apply-log-only --check-tables (should run check)"
-xtrabackup --prepare --apply-log-only --check-tables \
+vlog "Prepare inc1 with --apply-redo-only --check-tables (should run check)"
+xtrabackup --prepare --apply-redo-only --check-tables \
            --incremental-dir=$topdir/inc1 --target-dir=$topdir/full \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2>&1 | tee $topdir/prepare_inc1.log
 grep log-applied $topdir/full/xtrabackup_checkpoints
 grep -q "Starting table checks" $topdir/prepare_inc1.log || \
-  die "check-tables should run during incremental --apply-log-only prepare"
+  die "check-tables should run during incremental --apply-redo-only prepare"
 grep -q "All table checks passed" $topdir/prepare_inc1.log || \
-  die "Table checks did not pass during incremental --apply-log-only prepare"
+  die "Table checks did not pass during incremental --apply-redo-only prepare"
 
 vlog "Prepare inc2 with --check-tables (final prepare, should run check)"
 xtrabackup --prepare --check-tables \
@@ -230,8 +230,8 @@ xtrabackup --backup --target-dir=$topdir/backup2 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup2.log >&2)
 
-vlog "Prepare with --apply-log-only first"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup2 \
+vlog "Prepare with --apply-redo-only first"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup2 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/prepare_s2_alog.log >&2)
 
@@ -270,8 +270,8 @@ xtrabackup --backup --target-dir=$topdir/backup3 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup3.log >&2)
 
-vlog "Prepare with --apply-log-only first"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup3 \
+vlog "Prepare with --apply-redo-only first"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup3 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/prepare_s3_alog.log >&2)
 
@@ -303,8 +303,8 @@ xtrabackup --backup --target-dir=$topdir/backup4 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup4.log >&2)
 
-vlog "Prepare with --apply-log-only first"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup4 \
+vlog "Prepare with --apply-redo-only first"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup4 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/prepare_s4_alog.log >&2)
 
@@ -350,8 +350,8 @@ xtrabackup --backup --target-dir=$topdir/backup5 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/backup5.log >&2)
 
-vlog "Prepare with --apply-log-only first"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup5 \
+vlog "Prepare with --apply-redo-only first"
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup5 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args} \
            2> >(tee $topdir/prepare_s5_alog.log >&2)
 

--- a/storage/innobase/xtrabackup/test/suites/compression/bug977652.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/bug977652.sh
@@ -16,4 +16,4 @@ xtrabackup --backup --compress --target-dir=$topdir/full
 
 # Test that incremental backups work without uncompressing the full one
 xtrabackup --backup --compress \
-    --incremental-basedir=$topdir/full --target-dir=$topdir/incremental
+    --backup-incremental-base=$topdir/full --target-dir=$topdir/incremental

--- a/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
@@ -17,6 +17,6 @@ xtrabackup --backup --compress --target-dir=$topdir/inc --incremental-basedir=$t
 xtrabackup --decompress --target-dir=$topdir/backup
 xtrabackup --decompress --target-dir=$topdir/inc
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup --incremental-dir=$topdir/inc
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
+++ b/storage/innobase/xtrabackup/test/suites/compression/pxb-1552.sh
@@ -12,11 +12,11 @@ xtrabackup --backup --compress --target-dir=$topdir/backup
 
 mysql -e "DELETE FROM payment LIMIT 100" sakila
 
-xtrabackup --backup --compress --target-dir=$topdir/inc --incremental-basedir=$topdir/backup
+xtrabackup --backup --compress --target-dir=$topdir/inc --backup-incremental-base=$topdir/backup
 
 xtrabackup --decompress --target-dir=$topdir/backup
 xtrabackup --decompress --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
@@ -154,7 +154,7 @@ vlog "Making incremental backup"
 inc_backup_dir=$topdir/incremental_backup
 xtrabackup --datadir=$mysql_datadir --backup \
     --target-dir=$inc_backup_dir \
-    --incremental-basedir=$full_backup_dir \
+    --backup-incremental-base=$full_backup_dir \
     $keyring_args
 
 vlog "Incremental backup created in directory $inc_backup_dir"
@@ -170,7 +170,7 @@ vlog "Making incremental backup"
 inc_backup_dir2=$topdir/incremental_backup2
 xtrabackup --datadir=$mysql_datadir --backup \
     --target-dir=$inc_backup_dir2 \
-    --incremental-basedir=$inc_backup_dir \
+    --backup-incremental-base=$inc_backup_dir \
     $keyring_args
 
 vlog "Incremental backup 2 created in directory $inc_backup_dir2"
@@ -189,14 +189,14 @@ vlog "Log applied to full backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
     --apply-redo-only \
     --target-dir=$full_backup_dir \
-    --incremental-dir=$inc_backup_dir \
+    --prepare-incremental-from-dir=$inc_backup_dir \
     --xtrabackup-plugin-dir=$plugin_dir \
     $keyring_args
 vlog "Delta applied to full backup"
 
 xtrabackup --datadir=$mysql_datadir --prepare \
     --target-dir=$full_backup_dir \
-    --incremental-dir=$inc_backup_dir2 \
+    --prepare-incremental-from-dir=$inc_backup_dir2 \
     --xtrabackup-plugin-dir=$plugin_dir \
     $keyring_args
 vlog "Delta2 applied to full backup"

--- a/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/bug1737525.sh
@@ -180,14 +180,14 @@ record_db_state test
 # Restoring backup
 vlog "Preparing backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
-    --apply-log-only \
+    --apply-redo-only \
     --target-dir=$full_backup_dir \
     --xtrabackup-plugin-dir=$plugin_dir \
     $keyring_args
 vlog "Log applied to full backup"
 
 xtrabackup --datadir=$mysql_datadir --prepare \
-    --apply-log-only \
+    --apply-redo-only \
     --target-dir=$full_backup_dir \
     --incremental-dir=$inc_backup_dir \
     --xtrabackup-plugin-dir=$plugin_dir \

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
@@ -59,14 +59,14 @@ xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
 	   $keyring_args
 
-${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
+${XB_BIN} --prepare --apply-redo-only --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_encryption_export.sh
@@ -43,7 +43,7 @@ ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 EOF
 
-xtrabackup --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --backup-incremental-base=$topdir/backup \
 	   --target-dir=$topdir/inc1 \
 	   $keyring_args
 
@@ -55,18 +55,18 @@ ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 EOF
 
-xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
 	   $keyring_args
 
 ${XB_BIN} --prepare --apply-redo-only --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+${XB_BIN} --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
@@ -41,14 +41,14 @@ job_id=$!
 sleep 2
 kill -USR1 $job_id
 wait $job_id
-xtrabackup --backup --incremental-basedir=$topdir/full \
+xtrabackup --backup --backup-incremental-base=$topdir/full \
      --target-dir=$topdir/inc1
 record_db_state test
 stop_server
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full ${prepare_options}
-xtrabackup --prepare --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --prepare-incremental-from-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
 rm -rf $mysql_datadir
 xtrabackup --copy-back --target-dir=$topdir/full
@@ -67,7 +67,7 @@ job_id=$!
 sleep 2
 xtrabackup --backup --target-dir=$topdir/full
 sleep 2
-xtrabackup --backup --incremental-basedir=$topdir/full \
+xtrabackup --backup --backup-incremental-base=$topdir/full \
      --target-dir=$topdir/inc1
 kill -USR1 $job_id
 wait $job_id
@@ -94,12 +94,12 @@ start_server
 run_insert &
 job_id=$!
 sleep 2
-xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
      --target-dir=$topdir/inc2
 sleep 2
 kill -USR1 $job_id
 wait $job_id
-xtrabackup --backup --incremental-basedir=$topdir/inc2 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc2 \
      --target-dir=$topdir/inc3
 record_db_state test
 stop_server
@@ -107,13 +107,13 @@ stop_server
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full ${prepare_options}
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --component-keyring-config=${keyring_component_cnf} --keyring-file-data=${keyring_file_component}"
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc2 \
     --target-dir=$topdir/full ${prepare_options}
-xtrabackup --prepare --incremental-dir=$topdir/inc3 \
+xtrabackup --prepare --prepare-incremental-from-dir=$topdir/inc3 \
    --target-dir=$topdir/full ${prepare_options}
 rm -rf $mysql_datadir
 xtrabackup --copy-back --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/innodb_keyring_plugin_to_component.sh
@@ -47,7 +47,7 @@ record_db_state test
 stop_server
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full ${prepare_options}
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full ${prepare_options}
 xtrabackup --prepare --incremental-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
 rm -rf $mysql_datadir
@@ -106,12 +106,12 @@ stop_server
 
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --keyring-file-data=${keyring_file_plugin}"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full ${prepare_options}
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full ${prepare_options}
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
      --target-dir=$topdir/full ${prepare_options}
 
 prepare_options="--xtrabackup-plugin-dir=${plugin_dir} --component-keyring-config=${keyring_component_cnf} --keyring-file-data=${keyring_file_component}"
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
     --target-dir=$topdir/full ${prepare_options}
 xtrabackup --prepare --incremental-dir=$topdir/inc3 \
    --target-dir=$topdir/full ${prepare_options}

--- a/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
@@ -64,14 +64,14 @@ xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
 	   --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --target-dir=$topdir/backup \
+${XB_BIN} --prepare --apply-redo-only --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 

--- a/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/keyring/reencrypt.sh
@@ -48,7 +48,7 @@ ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 EOF
 
-xtrabackup --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --backup-incremental-base=$topdir/backup \
            --target-dir=$topdir/inc1 \
            --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
@@ -60,18 +60,18 @@ ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 EOF
 
-xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
 	   --target-dir=$topdir/inc2 \
 	   --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
 ${XB_BIN} --prepare --apply-redo-only --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+${XB_BIN} --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
-${XB_BIN} --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+${XB_BIN} --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc2 \
 	  --target-dir=$topdir/backup \
 	  --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
@@ -42,7 +42,7 @@ vlog "restore"
 stop_server
 rm -r $mysql_datadir
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup --transition-key=123
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup --transition-key=123
 
 xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc --transition-key=123
 

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/encryption_after_checkpoint.sh
@@ -34,7 +34,7 @@ ALTER TABLE t3 ENCRYPTION 'N';
 EOF
 
 vlog "take incremental backup"
-xtrabackup --backup --target-dir=$topdir/inc --page-tracking --incremental-basedir=$topdir/backup --transition-key=123
+xtrabackup --backup --target-dir=$topdir/inc --page-tracking --backup-incremental-base=$topdir/backup --transition-key=123
 
 record_db_state test
 
@@ -44,7 +44,7 @@ rm -r $mysql_datadir
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup --transition-key=123
 
-xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc --transition-key=123
+xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc --transition-key=123
 
 vlog "copy back"
 xtrabackup --copy-back --target-dir=$topdir/backup --transition-key=123 \

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/validate_tracking_start_lsn.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/validate_tracking_start_lsn.sh
@@ -58,7 +58,7 @@ EOF
 
 vlog "case#2 checkpoint is stopped and still incremental should complete "
 
-xtrabackup --backup --target-dir=$topdir/inc  --incremental-basedir=$topdir/backup  --page-tracking --debug_sync="xtrabackup_after_wait_page_tracking" 2>&1 | tee $topdir/pxb_inc.log &
+xtrabackup --backup --target-dir=$topdir/inc  --backup-incremental-base=$topdir/backup  --page-tracking --debug_sync="xtrabackup_after_wait_page_tracking" 2>&1 | tee $topdir/pxb_inc.log &
 job_pid=$!
 
 pid_file=$topdir/inc/xtrabackup_debug_sync

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
@@ -81,7 +81,7 @@ vlog "Making incremental backup"
 
 # Incremental backup
 xtrabackup --datadir=$mysql_datadir --page-tracking --backup \
---target-dir=$topdir/delta --incremental-basedir=$topdir/full \
+--target-dir=$topdir/delta --backup-incremental-base=$topdir/full \
 
 vlog "Incremental backup done"
 vlog "Preparing backup"
@@ -92,7 +92,7 @@ xtrabackup --datadir=$mysql_datadir --prepare \
 vlog "Log applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --apply-redo-only --target-dir=$topdir/full \
---incremental-dir=$topdir/delta
+--prepare-incremental-from-dir=$topdir/delta
 vlog "Delta applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_enable_pagetracking.sh
@@ -88,10 +88,10 @@ vlog "Preparing backup"
 
 # Prepare backup
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full
+--apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full \
+--apply-redo-only --target-dir=$topdir/full \
 --incremental-dir=$topdir/delta
 vlog "Delta applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
@@ -79,7 +79,7 @@ vlog "Making incremental backup"
 
 # Incremental backup
 xtrabackup --datadir=$mysql_datadir --page-tracking --backup \
---target-dir=$topdir/delta --incremental-basedir=$topdir/full \
+--target-dir=$topdir/delta --backup-incremental-base=$topdir/full \
 
 vlog "Incremental backup done"
 vlog "Preparing backup"
@@ -90,7 +90,7 @@ xtrabackup --datadir=$mysql_datadir --prepare \
 vlog "Log applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --apply-redo-only --target-dir=$topdir/full \
---incremental-dir=$topdir/delta
+--prepare-incremental-from-dir=$topdir/delta
 vlog "Delta applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
 --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_incremental_disable_pagetracking.sh
@@ -86,10 +86,10 @@ vlog "Preparing backup"
 
 # Prepare backup
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full
+--apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \
---apply-log-only --target-dir=$topdir/full \
+--apply-redo-only --target-dir=$topdir/full \
 --incremental-dir=$topdir/delta
 vlog "Delta applied to backup"
 xtrabackup --datadir=$mysql_datadir --prepare \

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_pagetracking_merge_gap.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_pagetracking_merge_gap.sh
@@ -281,7 +281,7 @@ done
 vlog "restore the 50% auto incremental and verify content"
 stop_server
 rm -rf $mysql_datadir
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full_50
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_50
 xtrabackup --prepare --target-dir=$topdir/full_50 \
     --incremental-dir=$topdir/inc_50_auto
 xtrabackup --copy-back --target-dir=$topdir/full_50 --datadir=$mysql_datadir

--- a/storage/innobase/xtrabackup/test/suites/pagetracking/xb_pagetracking_merge_gap.sh
+++ b/storage/innobase/xtrabackup/test/suites/pagetracking/xb_pagetracking_merge_gap.sh
@@ -122,7 +122,7 @@ take_and_verify() {
   [ "$setting" != "auto" ] && gap_arg="--page-tracking-merge-gap=$setting"
 
   xtrabackup --backup --page-tracking $gap_arg \
-      --incremental-basedir=$topdir/full_$label --target-dir=$tgt \
+      --backup-incremental-base=$topdir/full_$label --target-dir=$tgt \
       2>&1 | tee $tgt.log
 
   local changed ranges groups batches
@@ -283,7 +283,7 @@ stop_server
 rm -rf $mysql_datadir
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_50
 xtrabackup --prepare --target-dir=$topdir/full_50 \
-    --incremental-dir=$topdir/inc_50_auto
+    --prepare-incremental-from-dir=$topdir/inc_50_auto
 xtrabackup --copy-back --target-dir=$topdir/full_50 --datadir=$mysql_datadir
 start_server
 verify_db_state test

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
@@ -55,7 +55,7 @@ function run_test() {
 
   XB_ERROR_LOG=$topdir/backup_inc.log
 	BACKUP_DIR=$topdir/backup_inc
-	xtrabackup_background --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_enc_general_tablespace --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
+	xtrabackup_background --backup --target-dir=$topdir/backup_inc --backup-incremental-base=$topdir/backup_enc_general_tablespace --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
 
 	wait_for_debug_sync_thread "before_file_copy"
 
@@ -89,7 +89,7 @@ function run_test() {
   record_db_state test
   stop_server
   xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
-  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace --incremental-dir=$topdir/backup_inc --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace --prepare-incremental-from-dir=$topdir/backup_inc --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
   rm -rf $mysql_datadir/*
   xtrabackup --copy-back --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error.sh
@@ -88,7 +88,7 @@ function run_test() {
 
   record_db_state test
   stop_server
-  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_enc_general_tablespace --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
   xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace --incremental-dir=$topdir/backup_inc --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
   rm -rf $mysql_datadir/*

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
@@ -93,7 +93,7 @@ function run_test() {
   record_db_state test
   stop_server
 
-  xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_enc_general_tablespace_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_enc_general_tablespace_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
   xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace_external --incremental-dir=$topdir/backup_inc_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
   rm -rf $mysql_datadir/*

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/encryption_general_tablespace_error_external.sh
@@ -59,7 +59,7 @@ function run_test() {
 
   XB_ERROR_LOG=$topdir/backup_inc.log
 	BACKUP_DIR=$topdir/backup_inc_external
-	xtrabackup_background --backup --target-dir=$topdir/backup_inc_external --incremental-basedir=$topdir/backup_enc_general_tablespace_external --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
+	xtrabackup_background --backup --target-dir=$topdir/backup_inc_external --backup-incremental-base=$topdir/backup_enc_general_tablespace_external --lock-ddl=REDUCED  --debug-sync-thread="before_file_copy"
 
 	wait_for_debug_sync_thread "before_file_copy"
 
@@ -94,7 +94,7 @@ function run_test() {
   stop_server
 
   xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_enc_general_tablespace_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
-  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace_external --incremental-dir=$topdir/backup_inc_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
+  xtrabackup --prepare --target-dir=$topdir/backup_enc_general_tablespace_external --prepare-incremental-from-dir=$topdir/backup_inc_external --xtrabackup-plugin-dir=${plugin_dir} ${keyring_args}
 
   rm -rf $mysql_datadir/*
   rm -rf $topdir/external/*

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
@@ -49,7 +49,7 @@ run_cmd wait $job_pid
 
 
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
 xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
 record_db_state test
 stop_server

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental.sh
@@ -19,7 +19,7 @@ xtrabackup --backup --target-dir=$topdir/backup_base --lock-ddl=REDUCED
 $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO test.original_table VALUES (2);" test
 innodb_wait_for_flush_all
 
-xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+xtrabackup --backup --target-dir=$topdir/backup_inc --backup-incremental-base=$topdir/backup_base \
   --debug-sync="xtrabackup_load_tablespaces_pause" --lock-ddl=REDUCED \
   2> >( tee $topdir/backup_with_new_table.log)&
 
@@ -50,7 +50,7 @@ run_cmd wait $job_pid
 
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
-xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+xtrabackup --prepare --target-dir=$topdir/backup_base --prepare-incremental-from-dir=$topdir/backup_inc
 record_db_state test
 stop_server
 rm -rf $mysql_datadir/*

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
@@ -34,7 +34,7 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
 xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
 
 # Ensure that t2.ibd shouldn't be present

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_delete.sh
@@ -16,7 +16,7 @@ innodb_wait_for_flush_all
 
 $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t2(a INT)" test
 
-xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+xtrabackup --backup --target-dir=$topdir/backup_inc --backup-incremental-base=$topdir/backup_base \
   --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
   2> >( tee $topdir/backup_inc.log)&
 
@@ -35,7 +35,7 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
-xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+xtrabackup --prepare --target-dir=$topdir/backup_base --prepare-incremental-from-dir=$topdir/backup_inc
 
 # Ensure that t2.ibd shouldn't be present
 FILE=$topdir/backup_base/test/t2.ibd

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
@@ -36,7 +36,7 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
 xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
 
 # Ensure two things. t1.ibd and t2.ibd shouldn't be present

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename.sh
@@ -18,7 +18,7 @@ innodb_wait_for_flush_all
 
 $MYSQL $MYSQL_ARGS -Ns -e "RENAME TABLE t1 to t2" test
 
-xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+xtrabackup --backup --target-dir=$topdir/backup_inc --backup-incremental-base=$topdir/backup_base \
   --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
   2> >( tee $topdir/backup_inc.log)&
 
@@ -37,7 +37,7 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
-xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+xtrabackup --prepare --target-dir=$topdir/backup_base --prepare-incremental-from-dir=$topdir/backup_inc
 
 # Ensure two things. t1.ibd and t2.ibd shouldn't be present
 FILE=$topdir/backup_base/test/t1.ibd

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
@@ -34,7 +34,7 @@ vlog "Resuming xtrabackup"
 kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup_base
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
 xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
 
 # Ensure two things. t1.ibd shouldn't be present

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/incremental_rename_2.sh
@@ -16,7 +16,7 @@ innodb_wait_for_flush_all
 $MYSQL $MYSQL_ARGS -Ns -e "CREATE TABLE t1(a INT);" test
 $MYSQL $MYSQL_ARGS -Ns -e "INSERT INTO t1 VALUES (1),(2),(3),(4)" test
 
-xtrabackup --backup --target-dir=$topdir/backup_inc --incremental-basedir=$topdir/backup_base \
+xtrabackup --backup --target-dir=$topdir/backup_inc --backup-incremental-base=$topdir/backup_base \
   --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
   2> >( tee $topdir/backup_inc.log)&
 
@@ -35,7 +35,7 @@ kill -SIGCONT $xb_pid
 run_cmd wait $job_pid
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup_base
-xtrabackup --prepare --target-dir=$topdir/backup_base --incremental-dir=$topdir/backup_inc
+xtrabackup --prepare --target-dir=$topdir/backup_base --prepare-incremental-from-dir=$topdir/backup_inc
 
 # Ensure two things. t1.ibd shouldn't be present
 FILE=$topdir/backup_base/test/t1.ibd

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
@@ -82,7 +82,7 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 	${full_backup_name} | \
     xbstream -xv -C $topdir/downloaded_full --parallel=4
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/downloaded_full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/downloaded_full
 
 run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
         --parallel=4 \

--- a/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
+++ b/storage/innobase/xtrabackup/test/suites/reducedlock/xbcloud.sh
@@ -49,7 +49,7 @@ vlog "take incremental backup"
 
 
 
-(xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --stream \
+(xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full --stream \
   --debug-sync="ddl_tracker_before_lock_ddl" --lock-ddl=REDUCED \
 | run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
             --parallel=4 \
@@ -91,7 +91,7 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 
 xtrabackup --prepare \
 	   --target-dir=$topdir/downloaded_full \
-	   --incremental-dir=$topdir/downloaded_inc
+	   --prepare-incremental-from-dir=$topdir/downloaded_inc
 
 stop_server
 rm -rf $MYSQLD_DATADIR/*

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/compress.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/compress.sh
@@ -28,7 +28,7 @@ FULL_PREPARE_CMD="xtrabackup
     --target-dir=$topdir/backup &&
   xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="xtrabackup

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/compress.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/compress.sh
@@ -17,7 +17,7 @@ FULL_BACKUP_CMD="xtrabackup
 INC_BACKUP_CMD="xtrabackup
     --backup
     --target-dir=$topdir/inc
-    --incremental-basedir=$topdir/backup
+    --backup-incremental-base=$topdir/backup
     --parallel=10
     --compress
     --compress-threads=10"
@@ -38,7 +38,7 @@ INC_PREPARE_CMD="xtrabackup
    xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/compress_encrypt.sh
@@ -38,7 +38,7 @@ FULL_PREPARE_CMD="xtrabackup
     --target-dir=$topdir/backup &&
   xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="xtrabackup

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/compress_encrypt.sh
@@ -22,7 +22,7 @@ FULL_BACKUP_CMD="xtrabackup
 INC_BACKUP_CMD="xtrabackup
     --backup
     --target-dir=$topdir/inc
-    --incremental-basedir=$topdir/backup
+    --backup-incremental-base=$topdir/backup
     --parallel=4
     --compress
     --compress-threads=4
@@ -50,7 +50,7 @@ INC_PREPARE_CMD="xtrabackup
   xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=4"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/cross_engine_trx.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/cross_engine_trx.sh
@@ -51,11 +51,11 @@ done | mysql test &
 # backup
 xtrabackup --parallel=4 --backup --target-dir=$topdir/backup
 xtrabackup --parallel=4 --backup --target-dir=$topdir/inc1 \
-           --incremental-basedir=$topdir/backup
+           --backup-incremental-base=$topdir/backup
 xtrabackup --parallel=4 --backup --target-dir=$topdir/inc2 \
-           --incremental-basedir=$topdir/inc1
+           --backup-incremental-base=$topdir/inc1
 xtrabackup --parallel=4 --backup --target-dir=$topdir/inc3 \
-           --incremental-basedir=$topdir/inc2
+           --backup-incremental-base=$topdir/inc2
 
 xtrabackup --parallel=4 --backup --target-dir=$topdir/backup22
 
@@ -64,11 +64,11 @@ stop_server
 # prepare
 xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
-           --incremental-dir=$topdir/inc1
+           --prepare-incremental-from-dir=$topdir/inc1
 xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
-           --incremental-dir=$topdir/inc2
+           --prepare-incremental-from-dir=$topdir/inc2
 xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
-           --incremental-dir=$topdir/inc3
+           --prepare-incremental-from-dir=$topdir/inc3
 xtrabackup --prepare --target-dir=$topdir/backup
 
 # # clenup and restore

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/cross_engine_trx.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/cross_engine_trx.sh
@@ -62,12 +62,12 @@ xtrabackup --parallel=4 --backup --target-dir=$topdir/backup22
 stop_server
 
 # prepare
-xtrabackup --parallel=4 --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --parallel=4 --prepare --apply-log-only --target-dir=$topdir/backup \
+xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup
+xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
            --incremental-dir=$topdir/inc1
-xtrabackup --parallel=4 --prepare --apply-log-only --target-dir=$topdir/backup \
+xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
            --incremental-dir=$topdir/inc2
-xtrabackup --parallel=4 --prepare --apply-log-only --target-dir=$topdir/backup \
+xtrabackup --parallel=4 --prepare --apply-redo-only --target-dir=$topdir/backup \
            --incremental-dir=$topdir/inc3
 xtrabackup --prepare --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/datadir.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/datadir.sh
@@ -37,7 +37,7 @@ if ! [ -d $topdir/inc/.rocksdb ] ; then
     die "Rocksdb haven't been backed up"
 fi
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
 
 rm -rf $mysql_datadir $rocks_datadir

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/datadir.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/datadir.sh
@@ -31,14 +31,14 @@ mysql -e "INSERT INTO t (a) VALUES (4), (5), (6)" test
 
 old_checksum=$(checksum_table_columns test t a)
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/backup
 
 if ! [ -d $topdir/inc/.rocksdb ] ; then
     die "Rocksdb haven't been backed up"
 fi
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc
 
 rm -rf $mysql_datadir $rocks_datadir
 

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
@@ -85,8 +85,8 @@ cat $sst_sizes >&2
 # Test: Prepare with --parallel=1 copies RocksDB files largest-first
 ###############################################################################
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
   --target-dir=$topdir/full --parallel=1
 
 # During incremental prepare, copy_incremental_over_full() moves RocksDB files

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/largest_first_incremental.sh
@@ -62,7 +62,7 @@ sleep 2
 # Take incremental backup
 ###############################################################################
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --parallel=1
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full --parallel=1
 
 # Show RocksDB files in incremental directory
 vlog "RocksDB files in incremental backup:"
@@ -86,7 +86,7 @@ cat $sst_sizes >&2
 ###############################################################################
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc \
   --target-dir=$topdir/full --parallel=1
 
 # During incremental prepare, copy_incremental_over_full() moves RocksDB files

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/local.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/local.sh
@@ -14,7 +14,7 @@ FULL_BACKUP_CMD="xtrabackup
 INC_BACKUP_CMD="xtrabackup
     --backup
     --target-dir=$topdir/inc
-    --incremental-basedir=$topdir/backup
+    --backup-incremental-base=$topdir/backup
     --parallel=10"
 
 FULL_PREPARE_CMD="xtrabackup
@@ -25,7 +25,7 @@ FULL_PREPARE_CMD="xtrabackup
 INC_PREPARE_CMD="xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/local.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/local.sh
@@ -19,7 +19,7 @@ INC_BACKUP_CMD="xtrabackup
 
 FULL_PREPARE_CMD="xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="xtrabackup

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/local_max_age.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/local_max_age.sh
@@ -16,7 +16,7 @@ FULL_BACKUP_CMD="xtrabackup
 INC_BACKUP_CMD="xtrabackup
     --backup
     --target-dir=$topdir/inc
-    --incremental-basedir=$topdir/backup
+    --backup-incremental-base=$topdir/backup
     --parallel=10"
 
 FULL_PREPARE_CMD="xtrabackup
@@ -27,7 +27,7 @@ FULL_PREPARE_CMD="xtrabackup
 INC_PREPARE_CMD="xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/local_max_age.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/local_max_age.sh
@@ -21,7 +21,7 @@ INC_BACKUP_CMD="xtrabackup
 
 FULL_PREPARE_CMD="xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="xtrabackup

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream.sh
@@ -14,7 +14,7 @@ FULL_BACKUP_CMD="xtrabackup
 
 INC_BACKUP_CMD="xtrabackup
     --backup
-    --incremental-basedir=$topdir/backuplsn
+    --backup-incremental-base=$topdir/backuplsn
     --parallel=10
     --stream=xbstream >$topdir/inc.xbstream"
 
@@ -30,7 +30,7 @@ INC_PREPARE_CMD="mkdir $topdir/inc &&
   xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream.sh
@@ -22,7 +22,7 @@ FULL_PREPARE_CMD="mkdir $topdir/backup &&
   xbstream -C $topdir/backup -x --parallel=10 < $topdir/backup.xbstream &&
   xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="mkdir $topdir/inc &&

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress.sh
@@ -27,7 +27,7 @@ FULL_PREPARE_CMD="mkdir $topdir/backup &&
      --parallel=10 --decompress < $topdir/backup.xbstream &&
   xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="mkdir $topdir/inc &&

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress.sh
@@ -16,7 +16,7 @@ FULL_BACKUP_CMD="xtrabackup
 
 INC_BACKUP_CMD="xtrabackup
     --backup
-    --incremental-basedir=$topdir/backuplsn
+    --backup-incremental-base=$topdir/backuplsn
     --parallel=10
     --compress
     --compress-threads=10
@@ -36,7 +36,7 @@ INC_PREPARE_CMD="mkdir $topdir/inc &&
   xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress_encrypt.sh
@@ -20,7 +20,7 @@ FULL_BACKUP_CMD="xtrabackup
 
 INC_BACKUP_CMD="xtrabackup
     --backup
-    --incremental-basedir=$topdir/backuplsn
+    --backup-incremental-base=$topdir/backuplsn
     --parallel=10
     --compress
     --compress-threads=10
@@ -42,7 +42,7 @@ INC_PREPARE_CMD="mkdir $topdir/inc &&
   xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir"

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress_encrypt.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/stream_compress_encrypt.sh
@@ -32,7 +32,7 @@ FULL_PREPARE_CMD="mkdir $topdir/backup &&
      --encrypt-key=$pass < $topdir/backup.xbstream &&
   xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="mkdir $topdir/inc &&

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/wal_dir_abs_archive.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/wal_dir_abs_archive.sh
@@ -30,7 +30,7 @@ INC_BACKUP_CMD="xtrabackup
 
 FULL_PREPARE_CMD="xtrabackup
     --prepare
-    --apply-log-only
+    --apply-redo-only
     --target-dir=$topdir/backup"
 
 INC_PREPARE_CMD="xtrabackup

--- a/storage/innobase/xtrabackup/test/suites/rocksdb/wal_dir_abs_archive.sh
+++ b/storage/innobase/xtrabackup/test/suites/rocksdb/wal_dir_abs_archive.sh
@@ -25,7 +25,7 @@ FULL_BACKUP_CMD="xtrabackup
 INC_BACKUP_CMD="xtrabackup
     --backup
     --target-dir=$topdir/inc
-    --incremental-basedir=$topdir/backup
+    --backup-incremental-base=$topdir/backup
     --parallel=10"
 
 FULL_PREPARE_CMD="xtrabackup
@@ -36,7 +36,7 @@ FULL_PREPARE_CMD="xtrabackup
 INC_PREPARE_CMD="xtrabackup
     --prepare
     --target-dir=$topdir/backup
-    --incremental-dir=$topdir/inc
+    --prepare-incremental-from-dir=$topdir/inc
     --parallel=10"
 
 CLEANUP_CMD="rm -rf $mysql_datadir ${TEST_VAR_ROOT}/rocks"

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
@@ -40,14 +40,14 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 	${full_backup_name} | \
     xbstream -xv -C $topdir/downloaded_full --parallel=4
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/downloaded_full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/downloaded_full
 
 run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
         --parallel=4 \
         ${inc_backup_name} | \
     xbstream -xv -C $topdir/downloaded_inc
 
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare --apply-redo-only \
 	   --target-dir=$topdir/downloaded_full \
 	   --incremental-dir=$topdir/downloaded_inc
 

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/basic_operations.sh
@@ -23,7 +23,7 @@ xtrabackup --backup --stream=xbstream --extra-lsndir=$full_backup_dir \
 
 vlog "take incremental backup"
 
-xtrabackup --backup --incremental-basedir=$full_backup_dir \
+xtrabackup --backup --backup-incremental-base=$full_backup_dir \
 	   --stream=xbstream --target-dir=inc_backup_dir \
 	   --parallel=4 | \
     run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf put \
@@ -49,7 +49,7 @@ run_cmd xbcloud --defaults-file=$topdir/xbcloud.cnf get \
 
 xtrabackup --prepare --apply-redo-only \
 	   --target-dir=$topdir/downloaded_full \
-	   --incremental-dir=$topdir/downloaded_inc
+	   --prepare-incremental-from-dir=$topdir/downloaded_inc
 
 xtrabackup --prepare --target-dir=$topdir/downloaded_full
 

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
@@ -21,10 +21,10 @@ wait ${insert_pid}
 run_insert &
 insert_pid=$!
 vlog "Test 1 - Taking inc1 backup"
-take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${full_backup_dir} --extra-lsndir=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc_backup_name}"
+take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --backup-incremental-base=${full_backup_dir} --extra-lsndir=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc_backup_name}"
 wait ${insert_pid}
 vlog "Test 1 - Taking inc2 backup"
-take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc2_backup_name}"
+take_backup_fifo_xbcloud ${topdir}/stream "--parallel=4 --fifo-streams=3 --backup-incremental-base=${inc_backup_dir}" "--parallel=10 --fifo-streams=3 ${inc2_backup_name}"
 record_db_state test
 
 vlog "download & prepare"
@@ -36,9 +36,9 @@ stop_server
 vlog "Test 1 - Preparing full backup"
 xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full
 vlog "Test 1 - Preparing inc1 backup"
-xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --prepare-incremental-from-dir=${topdir}/inc1
 vlog "Test 1 - Preparing inc2 backup"
-xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
+xtrabackup --prepare --target-dir=${topdir}/full --prepare-incremental-from-dir=${topdir}/inc2
 rm -rf ${mysql_datadir}
 vlog "Test 1 - Running copy-back"
 xtrabackup --copy-back --target-dir=${topdir}/full

--- a/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
+++ b/storage/innobase/xtrabackup/test/suites/xbcloud/fifo.sh
@@ -34,9 +34,9 @@ download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc_bac
 download_fifo_xbcloud ${topdir}/stream "--parallel=10 --fifo-streams=3 ${inc2_backup_name}" "-x -C ${topdir}/inc2 --fifo-streams=3"
 stop_server
 vlog "Test 1 - Preparing full backup"
-xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full
 vlog "Test 1 - Preparing inc1 backup"
-xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
 vlog "Test 1 - Preparing inc2 backup"
 xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
 rm -rf ${mysql_datadir}

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -112,7 +112,7 @@ compare_files $topdir/backup $mysql_datadir
 mysql -e "CREATE TABLE t3 (a INT) ENGINE=MyISAM" test
 mysql -e "CREATE TABLE t4 (a INT) ENGINE=InnoDB" test
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full
 xtrabackup --prepare --target-dir=$topdir/full --apply-redo-only
-xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/full --prepare-incremental-from-dir=$topdir/inc
 compare_files_inc $topdir/full $mysql_datadir

--- a/storage/innobase/xtrabackup/test/t/all_files.sh
+++ b/storage/innobase/xtrabackup/test/t/all_files.sh
@@ -113,6 +113,6 @@ mysql -e "CREATE TABLE t3 (a INT) ENGINE=MyISAM" test
 mysql -e "CREATE TABLE t4 (a INT) ENGINE=InnoDB" test
 
 xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
-xtrabackup --prepare --target-dir=$topdir/full --apply-log-only
+xtrabackup --prepare --target-dir=$topdir/full --apply-redo-only
 xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
 compare_files_inc $topdir/full $mysql_datadir

--- a/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
+++ b/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
@@ -30,7 +30,7 @@ vlog "### case #2 check redo log is disabled before incremental backup ###"
 run_cmd xtrabackup --backup --target-dir=$topdir/full
 mysql -e "alter instance disable innodb redo_log"
 run_cmd_expect_failure xtrabackup --backup --target-dir=$topdir/inc \
-	--incremental-basedir=$topdir/full 2>&1 \
+	--backup-incremental-base=$topdir/full 2>&1 \
 	| tee $topdir/inc.log
 grep "Redo logging is disabled, cannot take consistent backup" $topdir/inc.log || die "missing error message"
 rm -r $topdir/full
@@ -65,7 +65,7 @@ mysql -e "alter instance enable innodb redo_log"
 vlog "### case #4 check redo log is disabled during incremental backup ###"
 run_cmd xtrabackup --backup --target-dir=$topdir/full
 run_cmd_expect_failure xtrabackup --backup --lock-ddl=OFF --target-dir=$topdir/inc \
-	--incremental-basedir=$topdir/full \
+	--backup-incremental-base=$topdir/full \
 	--debug-sync="data_copy_thread_func" 2>&1 \
 	| tee $topdir/inc.log &
 job_pid=$!
@@ -111,12 +111,12 @@ xtrabackup --backup --target-dir=$topdir/full
 mysql -e "alter instance disable innodb redo_log"
 load_sakila
 mysql -e "alter instance enable innodb redo_log"
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full
 record_db_state sakila
 stop_server
 rm -r $mysql_datadir
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
-xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/full --prepare-incremental-from-dir=$topdir/inc
 xtrabackup --copy-back --target-dir=$topdir/full
 start_server
 verify_db_state sakila

--- a/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
+++ b/storage/innobase/xtrabackup/test/t/alter_instance_redo.sh
@@ -115,7 +115,7 @@ xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
 record_db_state sakila
 stop_server
 rm -r $mysql_datadir
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
 xtrabackup --copy-back --target-dir=$topdir/full
 start_server

--- a/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
+++ b/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
@@ -1,0 +1,65 @@
+#
+# PXB-3758: --apply-redo-only replaces the confusingly named --apply-log-only.
+#
+# Both spellings drive the same knob, so this test pins down all three cases:
+# the new name works (and stops at redo, so an incremental still applies on
+# top), the old name still works but warns, and passing both is rejected.
+#
+
+start_server
+
+mysql -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+mysql -e "INSERT INTO t1 (a) VALUES (1), (2), (3)" test
+
+xtrabackup --backup --target-dir=$topdir/full
+
+mysql -e "INSERT INTO t1 (a) VALUES (10), (20), (30)" test
+
+xtrabackup --backup --incremental-basedir=$topdir/full \
+	   --target-dir=$topdir/inc
+
+record_db_state test
+
+# --apply-redo-only is the recommended spelling: it must not nag the operator.
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
+
+if grep -q "apply-log-only is deprecated" $OUTFILE ; then
+	die "--apply-redo-only must not emit the --apply-log-only deprecation warning"
+fi
+
+# It has to leave the backup at "redo applied, undo skipped" - that is the
+# whole point of the option, and what makes the incremental below apply.
+grep -q "backup_type = log-applied" $topdir/full/xtrabackup_checkpoints \
+	|| die "--apply-redo-only did not stop after redo apply"
+
+# The old spelling keeps working, on the same backup, and warns once.
+xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+	   --target-dir=$topdir/full
+
+grep -q "apply-log-only is deprecated and will be removed in a future release" \
+	$OUTFILE || die "--apply-log-only did not emit a deprecation warning"
+
+xtrabackup --prepare --target-dir=$topdir/full
+
+# Both spellings at once is operator confusion, never intent.
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-redo-only \
+		       --apply-log-only --target-dir=$topdir/full
+
+grep -q "are the same option; pass only one" $OUTFILE \
+	|| die "passing both spellings was not rejected with the expected error"
+
+# Order must not matter, and neither should an explicit value.
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-log-only \
+		       --apply-redo-only --target-dir=$topdir/full
+
+# The chain prepared through both spellings restores to the recorded state.
+stop_server
+rm -rf $mysql_datadir/*
+
+xtrabackup --copy-back --target-dir=$topdir/full
+
+start_server
+
+verify_db_state test
+
+rm -rf $topdir/full $topdir/inc

--- a/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
+++ b/storage/innobase/xtrabackup/test/t/apply_redo_only_alias.sh
@@ -15,7 +15,7 @@ xtrabackup --backup --target-dir=$topdir/full
 
 mysql -e "INSERT INTO t1 (a) VALUES (10), (20), (30)" test
 
-xtrabackup --backup --incremental-basedir=$topdir/full \
+xtrabackup --backup --backup-incremental-base=$topdir/full \
 	   --target-dir=$topdir/inc
 
 record_db_state test
@@ -33,7 +33,7 @@ grep -q "backup_type = log-applied" $topdir/full/xtrabackup_checkpoints \
 	|| die "--apply-redo-only did not stop after redo apply"
 
 # The old spelling keeps working, on the same backup, and warns once.
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-log-only --prepare-incremental-from-dir=$topdir/inc \
 	   --target-dir=$topdir/full
 
 grep -q "apply-log-only is deprecated and will be removed in a future release" \

--- a/storage/innobase/xtrabackup/test/t/backup_locks.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_locks.sh
@@ -32,7 +32,7 @@ Com_flush	3
 EOF
 
 xtrabackup --backup \
-           --incremental-basedir=$topdir/full_backup \
+           --backup-incremental-base=$topdir/full_backup \
            --target-dir=$topdir/inc_backup
 
 $MYSQL $MYSQL_ARGS -Ns -e \

--- a/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
@@ -174,10 +174,10 @@ assert_target_strict "$topdir/backup6inc2" "$bs6inc2" "scen6 (inc2)"
 
 # Restore the chain end-to-end.
 record_db_state test
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup6full
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup6inc1 \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup6full
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup6inc1 \
     --target-dir=$topdir/backup6full
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup6inc2 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup6inc2 \
     --target-dir=$topdir/backup6full
 xtrabackup --prepare --target-dir=$topdir/backup6full
 stop_server

--- a/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_size_basic.sh
@@ -151,7 +151,7 @@ for i in $(seq 1 100) ; do
 done | mysql test
 
 mkdir -p $topdir/lsn6inc1
-xtrabackup --backup --incremental-basedir=$topdir/backup6full \
+xtrabackup --backup --backup-incremental-base=$topdir/backup6full \
     --target-dir=$topdir/backup6inc1 --extra-lsndir=$topdir/lsn6inc1
 
 bs6inc1=$(get_field "$topdir/lsn6inc1/xtrabackup_info" backup_size)
@@ -166,7 +166,7 @@ for i in $(seq 1 50) ; do
 done | mysql test
 
 mkdir -p $topdir/lsn6inc2
-xtrabackup --backup --incremental-basedir=$topdir/backup6inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/backup6inc1 \
     --target-dir=$topdir/backup6inc2 --extra-lsndir=$topdir/lsn6inc2
 
 bs6inc2=$(get_field "$topdir/lsn6inc2/xtrabackup_info" backup_size)
@@ -175,9 +175,9 @@ assert_target_strict "$topdir/backup6inc2" "$bs6inc2" "scen6 (inc2)"
 # Restore the chain end-to-end.
 record_db_state test
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup6full
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup6inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/backup6inc1 \
     --target-dir=$topdir/backup6full
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup6inc2 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/backup6inc2 \
     --target-dir=$topdir/backup6full
 xtrabackup --prepare --target-dir=$topdir/backup6full
 stop_server

--- a/storage/innobase/xtrabackup/test/t/backup_size_compress.sh
+++ b/storage/innobase/xtrabackup/test/t/backup_size_compress.sh
@@ -144,7 +144,7 @@ done | mysql test
 
 mkdir -p $topdir/lsn4inc1
 xtrabackup --backup --compress=lz4 \
-    --incremental-basedir=$topdir/lsn4full \
+    --backup-incremental-base=$topdir/lsn4full \
     --target-dir=$topdir/backup4inc1 --extra-lsndir=$topdir/lsn4inc1
 
 bs4inc1=$(get_field "$topdir/lsn4inc1/xtrabackup_info" backup_size)

--- a/storage/innobase/xtrabackup/test/t/bug1002688.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1002688.sh
@@ -28,14 +28,14 @@ vlog "Making incremental backup"
 # Incremental backup
 inc_backup_dir=$topdir/incremental_backup
 xtrabackup --backup \
-    --incremental-basedir=$full_backup_dir --target-dir=$inc_backup_dir
+    --backup-incremental-base=$full_backup_dir --target-dir=$inc_backup_dir
 vlog "Incremental backup created in directory $inc_backup_dir"
 
 vlog "Preparing backup"
 xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir/ \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$inc_backup_dir/ \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1002688.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1002688.sh
@@ -32,10 +32,10 @@ xtrabackup --backup \
 vlog "Incremental backup created in directory $inc_backup_dir"
 
 vlog "Preparing backup"
-xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir/ \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir/ \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1022562.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1022562.sh
@@ -44,7 +44,7 @@ vlog "Making incremental backup"
 
 # Incremental backup
 xtrabackup --datadir=$mysql_datadir --backup \
-    --target-dir=$DELTA_DIR --incremental-basedir=$FULL_DIR \
+    --target-dir=$DELTA_DIR --backup-incremental-base=$FULL_DIR \
     $mysqld_additional_args
 
 vlog "Incremental backup done"
@@ -56,7 +56,7 @@ xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
 vlog "Log applied to backup"
 
 xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
-    --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR \
+    --target-dir=$FULL_DIR --prepare-incremental-from-dir=$DELTA_DIR \
     $mysqld_additional_args
 vlog "Delta applied to backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1022562.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1022562.sh
@@ -51,11 +51,11 @@ vlog "Incremental backup done"
 vlog "Preparing backup"
 
 # Prepare backup
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$FULL_DIR $mysqld_additional_args
 vlog "Log applied to backup"
 
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR \
     $mysqld_additional_args
 vlog "Delta applied to backup"

--- a/storage/innobase/xtrabackup/test/t/bug1028949.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1028949.sh
@@ -54,7 +54,7 @@ function test_bug_1028949()
 
   # Incremental backup
   xtrabackup --datadir=$mysql_datadir --backup \
-      --target-dir=$DELTA_DIR --incremental-basedir=$FULL_DIR
+      --target-dir=$DELTA_DIR --backup-incremental-base=$FULL_DIR
 
   vlog "Incremental backup done"
   vlog "Preparing backup"
@@ -65,7 +65,7 @@ function test_bug_1028949()
   vlog "Log applied to backup"
 
   xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
-      --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR
+      --target-dir=$FULL_DIR --prepare-incremental-from-dir=$DELTA_DIR
   vlog "Delta applied to backup"
 
   xtrabackup --datadir=$mysql_datadir --prepare --target-dir=$FULL_DIR

--- a/storage/innobase/xtrabackup/test/t/bug1028949.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1028949.sh
@@ -60,11 +60,11 @@ function test_bug_1028949()
   vlog "Preparing backup"
 
   # Prepare backup
-  xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+  xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
       --target-dir=$FULL_DIR
   vlog "Log applied to backup"
 
-  xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+  xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
       --target-dir=$FULL_DIR --incremental-dir=$DELTA_DIR
   vlog "Delta applied to backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1038127.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1038127.sh
@@ -27,10 +27,10 @@ sed -ie '/space_id/ d' $topdir/inc/test/t1.ibd.meta
 
 vlog "Preparing backup"
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
     --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1038127.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1038127.sh
@@ -20,7 +20,7 @@ xtrabackup --backup --target-dir=$topdir/full
 
 vlog "Creating incremental backup"
 
-xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/full --target-dir=$topdir/inc
 
 # remove space_id = something line from .meta file
 sed -ie '/space_id/ d' $topdir/inc/test/t1.ibd.meta
@@ -30,7 +30,7 @@ vlog "Preparing backup"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc \
     --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug1062684.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1062684.sh
@@ -57,12 +57,12 @@ vlog "Preparing backup"
 vlog "##############"
 vlog "# PREPARE #1 #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/t/bug1062684.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1062684.sh
@@ -48,7 +48,7 @@ vlog "###############"
 
 # Incremental backup
 inc_backup_dir=$topdir/backup/inc
-xtrabackup --backup --incremental-basedir=$full_backup_dir \
+xtrabackup --backup --backup-incremental-base=$full_backup_dir \
     --target-dir=$inc_backup_dir
 vlog "Incremental backup done to directory $inc_backup_dir"
 
@@ -62,7 +62,7 @@ vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/t/bug1112224.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1112224.sh
@@ -30,11 +30,11 @@ xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
 sed -ie '/space_id/ d' $topdir/inc/test/t12.ibd.meta
 vlog "Preparing backup"
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
 # Command should fail and print error message
-run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-log-only \
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-redo-only \
     --incremental-dir=$topdir/inc --target-dir=$topdir/full
 if ! grep -q "Cannot handle DDL operation" $OUTFILE
 then

--- a/storage/innobase/xtrabackup/test/t/bug1112224.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1112224.sh
@@ -24,7 +24,7 @@ EOF
 
 vlog "Creating incremental backup"
 
-xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/full --target-dir=$topdir/inc
 
 # remove space_id = something line from .meta file
 sed -ie '/space_id/ d' $topdir/inc/test/t12.ibd.meta
@@ -35,7 +35,7 @@ vlog "Log applied to full backup"
 
 # Command should fail and print error message
 run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare --apply-redo-only \
-    --incremental-dir=$topdir/inc --target-dir=$topdir/full
+    --prepare-incremental-from-dir=$topdir/inc --target-dir=$topdir/full
 if ! grep -q "Cannot handle DDL operation" $OUTFILE
 then
 	die "Error message not found!"

--- a/storage/innobase/xtrabackup/test/t/bug1363234.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1363234.sh
@@ -18,13 +18,13 @@ load_sakila
 # backup
 xtrabackup --backup --target-dir=$topdir/backup
 xtrabackup --backup \
-    --incremental-basedir=$topdir/backup --target-dir=$topdir/inc1
+    --backup-incremental-base=$topdir/backup --target-dir=$topdir/inc1
 xtrabackup --backup \
-    --incremental-basedir=$topdir/inc1 --target-dir=$topdir/inc2
+    --backup-incremental-base=$topdir/inc1 --target-dir=$topdir/inc2
 
 # prepare (last one would fail)
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
     --target-dir=$topdir/backup
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc2 \
     --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/bug1363234.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1363234.sh
@@ -23,8 +23,8 @@ xtrabackup --backup \
     --incremental-basedir=$topdir/inc1 --target-dir=$topdir/inc2
 
 # prepare (last one would fail)
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
     --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc2 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
     --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/bug1532101.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1532101.sh
@@ -33,4 +33,4 @@ xtrabackup --backup --target-dir=$topdir/backup
 kill -SIGKILL $job_master
 stop_server
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/bug1535312.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1535312.sh
@@ -33,13 +33,13 @@ INSERT INTO p VALUES (10), (20), (30);
 
 EOF
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full
 
 record_db_state test
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
-xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/full --prepare-incremental-from-dir=$topdir/inc
 
 stop_server
 

--- a/storage/innobase/xtrabackup/test/t/bug1535312.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1535312.sh
@@ -37,7 +37,7 @@ xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full
 
 record_db_state test
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
 xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
 

--- a/storage/innobase/xtrabackup/test/t/bug1642826.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1642826.sh
@@ -10,7 +10,7 @@ mkdir backup
 
 xtrabackup --backup --target-dir=backup/full --extra-lsndir=backup/lsn
 xtrabackup --backup --incremental-basedir=backup/full --target-dir=backup/inc_1
-xtrabackup --prepare --apply-log-only --target-dir=backup/full
+xtrabackup --prepare --apply-redo-only --target-dir=backup/full
 xtrabackup --prepare --target-dir=backup/full --incremental-dir=backup/inc_1
 
 rm -rf backup/*
@@ -21,6 +21,6 @@ export HOME=$topdir
 
 run_cmd $XB_BIN $XB_ARGS --backup --target-dir=~/backup/full --extra-lsndir=~/backup/lsn
 run_cmd $XB_BIN $XB_ARGS --backup --incremental-basedir=~/backup/full --target-dir=~/backup/inc_1
-xtrabackup --prepare --apply-log-only --target-dir=~/backup/full
+xtrabackup --prepare --apply-redo-only --target-dir=~/backup/full
 xtrabackup --prepare --target-dir=~/backup/full --incremental-dir=~/backup/inc_1
 

--- a/storage/innobase/xtrabackup/test/t/bug1642826.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1642826.sh
@@ -9,9 +9,9 @@ cd $topdir
 mkdir backup
 
 xtrabackup --backup --target-dir=backup/full --extra-lsndir=backup/lsn
-xtrabackup --backup --incremental-basedir=backup/full --target-dir=backup/inc_1
+xtrabackup --backup --backup-incremental-base=backup/full --target-dir=backup/inc_1
 xtrabackup --prepare --apply-redo-only --target-dir=backup/full
-xtrabackup --prepare --target-dir=backup/full --incremental-dir=backup/inc_1
+xtrabackup --prepare --target-dir=backup/full --prepare-incremental-from-dir=backup/inc_1
 
 rm -rf backup/*
 
@@ -20,7 +20,7 @@ cd -
 export HOME=$topdir
 
 run_cmd $XB_BIN $XB_ARGS --backup --target-dir=~/backup/full --extra-lsndir=~/backup/lsn
-run_cmd $XB_BIN $XB_ARGS --backup --incremental-basedir=~/backup/full --target-dir=~/backup/inc_1
+run_cmd $XB_BIN $XB_ARGS --backup --backup-incremental-base=~/backup/full --target-dir=~/backup/inc_1
 xtrabackup --prepare --apply-redo-only --target-dir=~/backup/full
-xtrabackup --prepare --target-dir=~/backup/full --incremental-dir=~/backup/inc_1
+xtrabackup --prepare --target-dir=~/backup/full --prepare-incremental-from-dir=~/backup/inc_1
 

--- a/storage/innobase/xtrabackup/test/t/bug1669592.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1669592.sh
@@ -18,7 +18,7 @@ ${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (2)" test
 
 xtrabackup --backup --target-dir=$topdir/backup-inc --incremental-basedir=$topdir/backup
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --prepare --incremental-dir=$topdir/backup-inc --target-dir=$topdir/backup
 
 test -d $topdir/backup/#innodb_redo || die "redo directory are not found in full backup directory"

--- a/storage/innobase/xtrabackup/test/t/bug1669592.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1669592.sh
@@ -1,5 +1,5 @@
 #
-# Bug 1669592: xtrabackup --prepare --incremental-dir=... --target-dir=...
+# Bug 1669592: xtrabackup --prepare --prepare-incremental-from-dir=... --target-dir=...
 #              creates redo logs in wrong directory
 #
 
@@ -16,10 +16,10 @@ xtrabackup --backup --target-dir=$topdir/backup
 
 ${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t1 VALUES (2)" test
 
-xtrabackup --backup --target-dir=$topdir/backup-inc --incremental-basedir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/backup-inc --backup-incremental-base=$topdir/backup
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --incremental-dir=$topdir/backup-inc --target-dir=$topdir/backup
+xtrabackup --prepare --prepare-incremental-from-dir=$topdir/backup-inc --target-dir=$topdir/backup
 
 test -d $topdir/backup/#innodb_redo || die "redo directory are not found in full backup directory"
 

--- a/storage/innobase/xtrabackup/test/t/bug1691093.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1691093.sh
@@ -15,12 +15,12 @@ xtrabackup --backup \
 
 vlog "Prepare full"
 
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare --apply-redo-only \
     --throttle=40 \
     --target-dir=$topdir/backup/full
 
 vlog "Prepare incremental"
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare --apply-redo-only \
     --throttle=40 \
     --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta \
     2>&1 | tee $topdir/pxb.log

--- a/storage/innobase/xtrabackup/test/t/bug1691093.sh
+++ b/storage/innobase/xtrabackup/test/t/bug1691093.sh
@@ -11,7 +11,7 @@ vlog "Incremental backup"
 
 xtrabackup --backup \
     --target-dir=$topdir/backup/delta \
-    --incremental-basedir=$topdir/backup/full
+    --backup-incremental-base=$topdir/backup/full
 
 vlog "Prepare full"
 
@@ -22,7 +22,7 @@ xtrabackup --prepare --apply-redo-only \
 vlog "Prepare incremental"
 xtrabackup --prepare --apply-redo-only \
     --throttle=40 \
-    --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta \
+    --target-dir=$topdir/backup/full --prepare-incremental-from-dir=$topdir/backup/delta \
     2>&1 | tee $topdir/pxb.log
 
 run_cmd grep '.*--throttle' $topdir/pxb.log

--- a/storage/innobase/xtrabackup/test/t/bug759701.sh
+++ b/storage/innobase/xtrabackup/test/t/bug759701.sh
@@ -29,14 +29,14 @@ vlog "Making incremental backup"
 # Incremental backup
 inc_backup_dir=$topdir/incremental_backup
 xtrabackup --backup \
-    --incremental-basedir=$full_backup_dir --target-dir=$inc_backup_dir
+    --backup-incremental-base=$full_backup_dir --target-dir=$inc_backup_dir
 vlog "Incremental backup created in directory $inc_backup_dir"
 
 vlog "Preparing backup"
 xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug759701.sh
+++ b/storage/innobase/xtrabackup/test/t/bug759701.sh
@@ -33,10 +33,10 @@ xtrabackup --backup \
 vlog "Incremental backup created in directory $inc_backup_dir"
 
 vlog "Preparing backup"
-xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug766607.sh
+++ b/storage/innobase/xtrabackup/test/t/bug766607.sh
@@ -20,14 +20,14 @@ EOF
 force_checkpoint
 
 vlog "Making incremental backup"
-xtrabackup --backup --incremental-basedir=$topdir/backup/full --target-dir=$topdir/backup/delta
+xtrabackup --backup --backup-incremental-base=$topdir/backup/full --target-dir=$topdir/backup/delta
 
 vlog "Preparing full backup"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup/full
 
 # The following would fail before the bugfix
 vlog "Applying incremental delta"
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
 
 vlog "Preparing full backup"
 xtrabackup --prepare --target-dir=$topdir/backup/full

--- a/storage/innobase/xtrabackup/test/t/bug766607.sh
+++ b/storage/innobase/xtrabackup/test/t/bug766607.sh
@@ -23,11 +23,11 @@ vlog "Making incremental backup"
 xtrabackup --backup --incremental-basedir=$topdir/backup/full --target-dir=$topdir/backup/delta
 
 vlog "Preparing full backup"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup/full
 
 # The following would fail before the bugfix
 vlog "Applying incremental delta"
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/backup/delta --target-dir=$topdir/backup/full
 
 vlog "Preparing full backup"
 xtrabackup --prepare --target-dir=$topdir/backup/full

--- a/storage/innobase/xtrabackup/test/t/bug856400.sh
+++ b/storage/innobase/xtrabackup/test/t/bug856400.sh
@@ -58,10 +58,10 @@ xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
 
 vlog "Preparing backup"
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
     --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug856400.sh
+++ b/storage/innobase/xtrabackup/test/t/bug856400.sh
@@ -54,14 +54,14 @@ EOF
 
 vlog "Creating incremental backup"
 
-xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/full --target-dir=$topdir/inc
 
 vlog "Preparing backup"
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc \
     --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug932623.sh
+++ b/storage/innobase/xtrabackup/test/t/bug932623.sh
@@ -42,10 +42,10 @@ xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
 
 vlog "Preparing backup"
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
-xtrabackup --prepare --apply-log-only \
+xtrabackup --prepare --apply-redo-only \
     --incremental-dir=$topdir/inc --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 

--- a/storage/innobase/xtrabackup/test/t/bug932623.sh
+++ b/storage/innobase/xtrabackup/test/t/bug932623.sh
@@ -38,7 +38,7 @@ EOF
 
 vlog "Creating incremental backup"
 
-xtrabackup --backup --incremental-basedir=$topdir/full --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/full --target-dir=$topdir/inc
 
 vlog "Preparing backup"
 
@@ -46,7 +46,7 @@ xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 vlog "Log applied to full backup"
 
 xtrabackup --prepare --apply-redo-only \
-    --incremental-dir=$topdir/inc --target-dir=$topdir/full
+    --prepare-incremental-from-dir=$topdir/inc --target-dir=$topdir/full
 vlog "Delta applied to full backup"
 
 xtrabackup --prepare --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/t/bug976945.sh
+++ b/storage/innobase/xtrabackup/test/t/bug976945.sh
@@ -19,7 +19,7 @@ full_backup_dir=${MYSQLD_VARDIR}/full_backup
 xtrabackup --backup --target-dir=$full_backup_dir
 
 vlog "Preparing backup"
-xtrabackup --prepare --apply-log-only --target-dir=$full_backup_dir
+xtrabackup --prepare --apply-redo-only --target-dir=$full_backup_dir
 vlog "Log applied to full backup"
 
 # Destroying mysql data

--- a/storage/innobase/xtrabackup/test/t/create_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/t/create_tablespace.sh
@@ -46,7 +46,7 @@ INSERT INTO test.t2_3 VALUES (1100), (1200), (1300);
 EOF
 
 xtrabackup --backup --target-dir=$topdir/inc \
-	   --incremental-basedir=$topdir/full --lock-ddl=OFF \
+	   --backup-incremental-base=$topdir/full --lock-ddl=OFF \
 	   --debug-sync="data_copy_thread_func" &
 
 job_pid=$!
@@ -97,7 +97,7 @@ run_cmd wait $job_pid
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
-xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/full --prepare-incremental-from-dir=$topdir/inc
 
 record_db_state test
 

--- a/storage/innobase/xtrabackup/test/t/create_tablespace.sh
+++ b/storage/innobase/xtrabackup/test/t/create_tablespace.sh
@@ -95,7 +95,7 @@ kill -SIGCONT $xb_pid
 
 run_cmd wait $job_pid
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
 
 xtrabackup --prepare --target-dir=$topdir/full --incremental-dir=$topdir/inc
 

--- a/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
@@ -25,7 +25,7 @@ xtrabackup --backup --target-dir=$topdir/backup
 ${MYSQL} ${MYSQL_ARGS} -e "SET GLOBAL innodb_buffer_pool_dump_now=ON;"
 
 # incremental backup
-xtrabackup --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --backup-incremental-base=$topdir/backup \
     --target-dir=$topdir/incremental
 
 if [ -f $topdir/incremental/pool/dump ] ; then
@@ -38,7 +38,7 @@ fi
 # prepare
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/incremental \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/incremental \
     --target-dir=$topdir/backup
 
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_buffer_pool_dump_incremental.sh
@@ -36,9 +36,9 @@ else
 fi
 
 # prepare
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/incremental \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/incremental \
     --target-dir=$topdir/backup
 
 xtrabackup --prepare --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
@@ -75,12 +75,12 @@ vlog "Preparing backup"
 vlog "##############"
 vlog "# PREPARE #1 #"
 vlog "##############"
-xtrabackup_no_defaults_file --prepare --apply-log-only --target-dir$full_backup_dir
+xtrabackup_no_defaults_file --prepare --apply-redo-only --target-dir$full_backup_dir
 vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup_no_defaults_file --prepare --apply-log-only --incremental-dir=$inc_backup_dir \
+xtrabackup_no_defaults_file --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
+++ b/storage/innobase/xtrabackup/test/t/ib_doublewrite.sh
@@ -66,7 +66,7 @@ vlog "###############"
 
 # Incremental backup
 inc_backup_dir=$topdir/backup/inc
-xtrabackup --backup --incremental --incremental-basedir=$full_backup_dir \
+xtrabackup --backup --incremental --backup-incremental-base=$full_backup_dir \
     --target=dir=$inc_backup_dir
 vlog "Incremental backup done to directory $inc_backup_dir"
 
@@ -80,7 +80,7 @@ vlog "Log applied to full backup"
 vlog "##############"
 vlog "# PREPARE #2 #"
 vlog "##############"
-xtrabackup_no_defaults_file --prepare --apply-redo-only --incremental-dir=$inc_backup_dir \
+xtrabackup_no_defaults_file --prepare --apply-redo-only --prepare-incremental-from-dir=$inc_backup_dir \
     --target-dir=$full_backup_dir
 vlog "Delta applied to full backup"
 vlog "##############"

--- a/storage/innobase/xtrabackup/test/t/incremental_option_aliases.sh
+++ b/storage/innobase/xtrabackup/test/t/incremental_option_aliases.sh
@@ -1,0 +1,87 @@
+#
+# PXB-3840: the incremental options were renamed so the name says which
+# phase they belong to.
+#
+#   --incremental-basedir -> --backup-incremental-base   (--backup)
+#   --incremental-dir     -> --prepare-incremental-from-dir  (--prepare)
+#
+# Both spellings drive the same variable, so this pins down all three
+# cases: the new names work, the old names still work but warn, and
+# passing an old name together with its new one is rejected.
+#
+
+start_server
+
+mysql -e "CREATE TABLE t1 (a INT) ENGINE=InnoDB" test
+mysql -e "INSERT INTO t1 (a) VALUES (1), (2), (3)" test
+
+xtrabackup --backup --target-dir=$topdir/full
+
+mysql -e "INSERT INTO t1 (a) VALUES (10), (20), (30)" test
+
+# The new names are the recommended spelling, so they must not nag.
+xtrabackup --backup --backup-incremental-base=$topdir/full \
+	   --target-dir=$topdir/inc
+
+record_db_state test
+
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only \
+	   --prepare-incremental-from-dir=$topdir/inc --target-dir=$topdir/full
+xtrabackup --prepare --target-dir=$topdir/full
+
+for opt in incremental-basedir incremental-dir ; do
+	if grep -q -- "--$opt is deprecated" $OUTFILE ; then
+		die "--$opt warning emitted when only the new names were used"
+	fi
+done
+
+# The chain built and prepared through the new names has to restore.
+stop_server
+rm -rf $mysql_datadir/*
+
+xtrabackup --copy-back --target-dir=$topdir/full
+
+start_server
+
+verify_db_state test
+
+# The old names keep working, and each warns once.
+mysql -e "INSERT INTO t1 (a) VALUES (100), (200)" test
+
+xtrabackup --backup --target-dir=$topdir/full2
+xtrabackup --backup --incremental-basedir=$topdir/full2 \
+	   --target-dir=$topdir/inc2
+
+grep -q -- "--incremental-basedir is deprecated and will be removed in a future release" \
+	$OUTFILE || die "--incremental-basedir did not emit a deprecation warning"
+grep -q -- "Please use --backup-incremental-base instead" $OUTFILE \
+	|| die "--incremental-basedir warning does not name the new option"
+
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full2
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc2 \
+	   --target-dir=$topdir/full2
+
+grep -q -- "--incremental-dir is deprecated and will be removed in a future release" \
+	$OUTFILE || die "--incremental-dir did not emit a deprecation warning"
+grep -q -- "Please use --prepare-incremental-from-dir instead" $OUTFILE \
+	|| die "--incremental-dir warning does not name the new option"
+
+# An old name together with its new one is operator confusion, never intent.
+run_cmd_expect_failure $XB_BIN $XB_ARGS --backup \
+		       --incremental-basedir=$topdir/full2 \
+		       --backup-incremental-base=$topdir/full2 \
+		       --target-dir=$topdir/inc3
+
+grep -q -- "--incremental-basedir and --backup-incremental-base are the same option; pass only one" \
+	$OUTFILE || die "passing both backup spellings was not rejected"
+
+run_cmd_expect_failure $XB_BIN $XB_ARGS --prepare \
+		       --incremental-dir=$topdir/inc2 \
+		       --prepare-incremental-from-dir=$topdir/inc2 \
+		       --target-dir=$topdir/full2
+
+grep -q -- "--incremental-dir and --prepare-incremental-from-dir are the same option; pass only one" \
+	$OUTFILE || die "passing both prepare spellings was not rejected"
+
+rm -rf $topdir/full $topdir/inc $topdir/full2 $topdir/inc2

--- a/storage/innobase/xtrabackup/test/t/pxb-1784.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1784.sh
@@ -24,7 +24,7 @@ done &
 
 xtrabackup --backup --incremental-basedir=$topdir/backup --target-dir=$topdir/inc
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
 
 stop_server

--- a/storage/innobase/xtrabackup/test/t/pxb-1784.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1784.sh
@@ -22,10 +22,10 @@ while true ; do
     mysql -e "ALTER UNDO TABLESPACE undo2 SET ACTIVE"
 done &
 
-xtrabackup --backup --incremental-basedir=$topdir/backup --target-dir=$topdir/inc
+xtrabackup --backup --backup-incremental-base=$topdir/backup --target-dir=$topdir/inc
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc
 
 stop_server
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1824.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1824.sh
@@ -59,10 +59,10 @@ stop_server
 
 # apply log shoulnd't fail
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
 	   --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
 	   --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1824.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1824.sh
@@ -46,9 +46,9 @@ while true ; do
 done >/dev/null 2>/dev/null &
 
 xtrabackup --backup --target-dir=$topdir/backup --parallel=8
-xtrabackup --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --backup-incremental-base=$topdir/backup \
 	   --target-dir=$topdir/inc --parallel=8
-xtrabackup --backup --incremental-basedir=$topdir/inc \
+xtrabackup --backup --backup-incremental-base=$topdir/inc \
 	   --target-dir=$topdir/inc1 --parallel=8
 
 if ! grep -q flushed_lsn $topdir/backup/xtrabackup_checkpoints ; then
@@ -60,9 +60,9 @@ stop_server
 # apply log shoulnd't fail
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc \
 	   --target-dir=$topdir/backup
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
 	   --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/pxb-1862.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1862.sh
@@ -11,16 +11,16 @@ xtrabackup --backup --target-dir=$topdir/backup
 
 mysql -e "INSERT INTO t1 (a) VALUES (10), (20), (30)" test
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/backup
 
 cp -a $topdir/backup $topdir/backup1
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup1
 
-xtrabackup --prepare --incremental-dir=$topdir/inc --target-dir=$topdir/backup
+xtrabackup --prepare --prepare-incremental-from-dir=$topdir/inc --target-dir=$topdir/backup
 
-run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --prepare --incremental-dir=$topdir/inc \
+run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --prepare --prepare-incremental-from-dir=$topdir/inc \
 		       --target-dir=$topdir/backup1
 
 grep -q "xtrabackup_logfile was already used to '--prepare'" $OUTFILE || die "error message not found!"

--- a/storage/innobase/xtrabackup/test/t/pxb-1862.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb-1862.sh
@@ -15,8 +15,8 @@ xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/backu
 
 cp -a $topdir/backup $topdir/backup1
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup1
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup1
 
 xtrabackup --prepare --incremental-dir=$topdir/inc --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/pxb170.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb170.sh
@@ -1,6 +1,6 @@
 ############################################################################
 # PXB-170: xtrabackup should not allow to apply incremental backup on
-#          top of the backup prepared without --apply-log-only
+#          top of the backup prepared without --apply-redo-only
 ############################################################################
 
 . inc/common.sh
@@ -23,10 +23,10 @@ xtrabackup --backup --incremental-basedir=$topdir/inc1 \
 		--target-dir=$topdir/inc2
 
 # prepare
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 grep log-applied $topdir/backup/xtrabackup_checkpoints
 
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
 		--target-dir=$topdir/backup
 grep log-applied $topdir/backup/xtrabackup_checkpoints
 

--- a/storage/innobase/xtrabackup/test/t/pxb170.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb170.sh
@@ -14,24 +14,24 @@ xtrabackup --backup --target-dir=$topdir/backup
 
 # incremental backup
 run_cmd ${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t values (11), (12), (13)" test
-xtrabackup --backup --incremental-basedir=$topdir/backup \
+xtrabackup --backup --backup-incremental-base=$topdir/backup \
 		--target-dir=$topdir/inc1
 
 # incremental backup
 run_cmd ${MYSQL} ${MYSQL_ARGS} -e "INSERT INTO t values (21), (22), (23)" test
-xtrabackup --backup --incremental-basedir=$topdir/inc1 \
+xtrabackup --backup --backup-incremental-base=$topdir/inc1 \
 		--target-dir=$topdir/inc2
 
 # prepare
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 grep log-applied $topdir/backup/xtrabackup_checkpoints
 
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc1 \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc1 \
 		--target-dir=$topdir/backup
 grep log-applied $topdir/backup/xtrabackup_checkpoints
 
-xtrabackup --prepare --incremental-dir=$topdir/inc2 --target-dir=$topdir/backup
+xtrabackup --prepare --prepare-incremental-from-dir=$topdir/inc2 --target-dir=$topdir/backup
 grep full-prepared $topdir/backup/xtrabackup_checkpoints
 
 run_cmd_expect_failure ${XB_BIN} ${XB_ARGS} --prepare \
-		--incremental-dir=$topdir/inc2 --target-dir=$topdir/backup
+		--prepare-incremental-from-dir=$topdir/inc2 --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
@@ -49,7 +49,7 @@ mysql -e "FLUSH TABLES" test
 # Take incremental backup
 ###############################################################################
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/full --parallel=1
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/full --parallel=1
 
 # Show .delta file sizes for debugging
 vlog "Delta file sizes in incremental backup:"
@@ -72,7 +72,7 @@ cat $delta_sizes >&2
 ###############################################################################
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc \
   --target-dir=$topdir/full --parallel=1
 
 # Extract the "Applying" lines from the log (only those referencing test/ deltas)

--- a/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
+++ b/storage/innobase/xtrabackup/test/t/pxb_largest_first_delta.sh
@@ -71,8 +71,8 @@ cat $delta_sizes >&2
 # Test: Prepare with --parallel=1 applies largest .delta first
 ###############################################################################
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc \
   --target-dir=$topdir/full --parallel=1
 
 # Extract the "Applying" lines from the log (only those referencing test/ deltas)

--- a/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
+++ b/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
@@ -38,7 +38,7 @@ function restore_from()
         fi
         vlog "Preparing $incremental_dir as incremental"
         run_cmd xtrabackup --prepare $extra\
-           --target-dir=$backup_path --incremental-dir=$incremental_dir
+           --target-dir=$backup_path --prepare-incremental-from-dir=$incremental_dir
     done
 
     run_cmd xtrabackup --copy-back --target-dir=$backup_path
@@ -72,7 +72,7 @@ function test_backup_with_custom_read_buffer()
 
     vlog "Incremental backup  : $buffer_size buffer size"
     xtrabackup --backup \
-        --incremental-basedir=$backup_dest_base \
+        --backup-incremental-base=$backup_dest_base \
         --target-dir=$backup_dest_inc
 
     vlog "Restoring incremental : $buffer_size buffer size"

--- a/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
+++ b/storage/innobase/xtrabackup/test/t/read_buffer_size.sh
@@ -18,7 +18,7 @@ function restore_from()
     if [ "$#" -ne 0 ]
     then
         vlog "Preparing $backup_path as base of incremental backup"
-        extra="--apply-log-only "
+        extra="--apply-redo-only "
     else
         vlog "Preparing $backup_path"
     fi
@@ -34,7 +34,7 @@ function restore_from()
             vlog "Last incremental $incremental_dir"
             extra=
         else
-            extra='--apply-log-only'
+            extra='--apply-redo-only'
         fi
         vlog "Preparing $incremental_dir as incremental"
         run_cmd xtrabackup --prepare $extra\

--- a/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
@@ -61,7 +61,7 @@ xtrabackup --backup --target-dir=$topdir/backup
 mysql -e "CREATE UNDO TABLESPACE undo3 ADD DATAFILE '$undo_directory_ext/undo3.ibu'"
 mysql -e "CREATE UNDO TABLESPACE undo4 ADD DATAFILE 'undo4.ibu'"
 
-xtrabackup --backup --target-dir=$topdir/inc --incremental-basedir=$topdir/backup
+xtrabackup --backup --target-dir=$topdir/inc --backup-incremental-base=$topdir/backup
 
 kill -SIGKILL $job_master
 stop_server
@@ -71,7 +71,7 @@ rm -rf $undo_directory/*
 rm -rf $undo_directory_ext/*
 
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
+xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc
 
 xtrabackup --copy-back --target-dir=$topdir/backup
 

--- a/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
+++ b/storage/innobase/xtrabackup/test/t/undo_tablespaces.sh
@@ -70,7 +70,7 @@ rm -rf $MYSQLD_DATADIR/*
 rm -rf $undo_directory/*
 rm -rf $undo_directory_ext/*
 
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc
 
 xtrabackup --copy-back --target-dir=$topdir/backup

--- a/storage/innobase/xtrabackup/test/t/xb_apply_archived_logs.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_apply_archived_logs.sh
@@ -263,7 +263,7 @@ function test_archived_logs
 	#########################################
 	# Apply logs only to the remembered lsn #
 	#########################################
-	# --apply-log-only is set implicitly because unfinished transactions
+	# --apply-redo-only is set implicitly because unfinished transactions
 	# can be finished on further logs applying but using this option with
 	# --innodb-log-arch-dir is tested here to prove this bug
 	# https://bugs.launchpad.net/percona-xtrabackup/+bug/1199555 is not
@@ -273,7 +273,7 @@ function test_archived_logs
 		   --target-dir=$BACKUP_DIR \
 		   --innodb-log-arch-dir=$ARCHIVED_LOGS_DIR \
 		   --to-archived-lsn=$LSN \
-		   --apply-log-only \
+		   --apply-redo-only \
 		   $XTRABACKUP_OPTIONS
 	#Copy prepared data to server data dir
 	cp -R $BACKUP_DIR/* $mysql_datadir
@@ -296,7 +296,7 @@ function test_archived_logs
 	xtrabackup --prepare \
 		   --target-dir=$BACKUP_DIR \
 		   --innodb-log-arch-dir=$ARCHIVED_LOGS_DIR \
-		   --apply-log-only \
+		   --apply-redo-only \
 		   $XTRABACKUP_OPTIONS
 	#Copy prepared data to server data dir
 	rm -rf $mysql_datadir

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validations.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validations.sh
@@ -59,7 +59,7 @@ run_cmd xtrabackup --backup --target-dir=$topdir/inc1 --incremental-basedir=$top
 
 run_cmd xtrabackup --target-dir=$topdir/backup --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress --parallel=4
 run_cmd xtrabackup --target-dir=$topdir/inc1 --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress --parallel=4
-run_cmd xtrabackup --prepare --apply-log-only --target-dir=$topdir/backup
+run_cmd xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
 run_cmd xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc1
 
 # Restore

--- a/storage/innobase/xtrabackup/test/t/xb_decompress_file_validations.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_decompress_file_validations.sh
@@ -55,12 +55,12 @@ vlog "case#3 backup with compress&encryption and without modified file name"
 wait $insert_pid
 record_db_state test
 
-run_cmd xtrabackup --backup --target-dir=$topdir/inc1 --incremental-basedir=$topdir/backup --compress=zstd --encrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___
+run_cmd xtrabackup --backup --target-dir=$topdir/inc1 --backup-incremental-base=$topdir/backup --compress=zstd --encrypt=AES256 --encrypt-key=percona_xtrabackup_is_awesome___
 
 run_cmd xtrabackup --target-dir=$topdir/backup --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress --parallel=4
 run_cmd xtrabackup --target-dir=$topdir/inc1 --encrypt-key=percona_xtrabackup_is_awesome___ --decrypt=AES256 --decompress --parallel=4
 run_cmd xtrabackup --prepare --apply-redo-only --target-dir=$topdir/backup
-run_cmd xtrabackup --prepare --target-dir=$topdir/backup --incremental-dir=$topdir/inc1
+run_cmd xtrabackup --prepare --target-dir=$topdir/backup --prepare-incremental-from-dir=$topdir/inc1
 
 # Restore
 stop_server

--- a/storage/innobase/xtrabackup/test/t/xb_export.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_export.sh
@@ -264,7 +264,7 @@ mkdir -p $topdir/backup/full
 
 xtrabackup --datadir=$mysql_datadir --backup --target-dir=$topdir/backup/full
 
-xtrabackup --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$topdir/backup/full
 
 xtrabackup --datadir=$mysql_datadir --prepare \

--- a/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
@@ -30,7 +30,7 @@ vlog "Backup created in directory $backup_dir"
 if has_backup_locks
 then
     vlog "Preparing the backup to create xtrabackup_galera_info"
-    xtrabackup --prepare --apply-log-only --target-dir=$backup_dir
+    xtrabackup --prepare --apply-redo-only --target-dir=$backup_dir
 
     # bug 1643803: incremental backups do not include xtrabackup_binlog_info and xtrabackup_galera_info
     test -f $backup_dir/xtrabackup_galera_info ||

--- a/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_galera_info.sh
@@ -21,7 +21,7 @@ backup_dir1=$topdir/backup1
 
 xtrabackup --backup --galera-info --target-dir=$backup_dir
 
-xtrabackup --backup --galera-info --target-dir=$backup_dir1  --incremental-basedir=$backup_dir
+xtrabackup --backup --galera-info --target-dir=$backup_dir1  --backup-incremental-base=$backup_dir
 
 vlog "Backup created in directory $backup_dir"
 
@@ -36,7 +36,7 @@ then
     test -f $backup_dir/xtrabackup_galera_info ||
       die "xtrabackup_galera_info was not created"
 
-    xtrabackup --prepare --target-dir=$backup_dir --incremental-dir=$backup_dir1
+    xtrabackup --prepare --target-dir=$backup_dir --prepare-incremental-from-dir=$backup_dir1
 fi
 
 test -f $backup_dir/xtrabackup_galera_info ||

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
@@ -120,7 +120,7 @@ incremental_sample`
  
   # Incremental backup
   xtrabackup --datadir=$mysql_datadir --backup $ib_inc_extra_args  \
-      --target-dir=$topdir/delta --incremental-basedir=$topdir/full \
+      --target-dir=$topdir/delta --backup-incremental-base=$topdir/full \
       $suspend_arg &
 
   xb_pid=$!
@@ -144,7 +144,7 @@ incremental_sample`
   vlog "Log applied to backup"
   xtrabackup --datadir=$mysql_datadir --prepare \
       --apply-redo-only --target-dir=$topdir/full \
-      --incremental-dir=$topdir/delta
+      --prepare-incremental-from-dir=$topdir/delta
   vlog "Delta applied to backup"
   xtrabackup --datadir=$mysql_datadir --prepare \
       --target-dir=$topdir/full

--- a/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
+++ b/storage/innobase/xtrabackup/test/t/xb_incremental_compressed.inc
@@ -140,10 +140,10 @@ incremental_sample`
 
   # Prepare backup
   xtrabackup --datadir=$mysql_datadir --prepare \
-      --apply-log-only --target-dir=$topdir/full
+      --apply-redo-only --target-dir=$topdir/full
   vlog "Log applied to backup"
   xtrabackup --datadir=$mysql_datadir --prepare \
-      --apply-log-only --target-dir=$topdir/full \
+      --apply-redo-only --target-dir=$topdir/full \
       --incremental-dir=$topdir/delta
   vlog "Delta applied to backup"
   xtrabackup --datadir=$mysql_datadir --prepare \

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
@@ -42,7 +42,7 @@ load_dbase_data sakila
 
 # Do an incremental parallel backup
 xtrabackup --backup --parallel=8 \
-    --incremental-basedir=$topdir/full_backup --target-dir=$topdir/inc_backup
+    --backup-incremental-base=$topdir/full_backup --target-dir=$topdir/inc_backup
 
 stop_server
 # Remove datadir
@@ -50,7 +50,7 @@ rm -r $mysql_datadir
 
 vlog "Applying log"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_backup
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc_backup \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc_backup \
     --target-dir=$topdir/full_backup
 xtrabackup --prepare --target-dir=$topdir/full_backup
 

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental.sh
@@ -49,8 +49,8 @@ stop_server
 rm -r $mysql_datadir
 
 vlog "Applying log"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full_backup
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc_backup \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_backup
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc_backup \
     --target-dir=$topdir/full_backup
 xtrabackup --prepare --target-dir=$topdir/full_backup
 

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
@@ -122,7 +122,7 @@ start_server --innodb_buffer_pool-size=1G --innodb_redo_log_capacity=2G
 
 # Do an incremental parallel backup
 xtrabackup --backup --parallel=$num_threads \
-    --incremental-basedir=$topdir/full_backup --target-dir=$topdir/inc_backup
+    --backup-incremental-base=$topdir/full_backup --target-dir=$topdir/inc_backup
 
 stop_server
 # Remove datadir
@@ -130,7 +130,7 @@ rm -r $mysql_datadir
 
 vlog "Applying log"
 xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_backup --parallel=$num_threads
-xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc_backup --parallel=$num_threads \
+xtrabackup --prepare --apply-redo-only --prepare-incremental-from-dir=$topdir/inc_backup --parallel=$num_threads \
     --target-dir=$topdir/full_backup 2> $topdir/inc.log
 
 check_pattern_numbers() {

--- a/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_parallel_incremental_prepare.sh
@@ -129,8 +129,8 @@ stop_server
 rm -r $mysql_datadir
 
 vlog "Applying log"
-xtrabackup --prepare --apply-log-only --target-dir=$topdir/full_backup --parallel=$num_threads
-xtrabackup --prepare --apply-log-only --incremental-dir=$topdir/inc_backup --parallel=$num_threads \
+xtrabackup --prepare --apply-redo-only --target-dir=$topdir/full_backup --parallel=$num_threads
+xtrabackup --prepare --apply-redo-only --incremental-dir=$topdir/inc_backup --parallel=$num_threads \
     --target-dir=$topdir/full_backup 2> $topdir/inc.log
 
 check_pattern_numbers() {

--- a/storage/innobase/xtrabackup/test/t/xb_part_range.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_part_range.sh
@@ -69,7 +69,7 @@ vlog "Making incremental backup"
 
 # Incremental backup
 xtrabackup --no-defaults --datadir=$mysql_datadir --backup \
-    --target-dir=$topdir/backup/delta --incremental-basedir=$topdir/backup/full
+    --target-dir=$topdir/backup/delta --backup-incremental-base=$topdir/backup/full
 
 vlog "Incremental backup done"
 vlog "Preparing backup"
@@ -79,7 +79,7 @@ xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$topdir/backup/full
 vlog "Log applied to backup"
 xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-redo-only \
-    --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta
+    --target-dir=$topdir/backup/full --prepare-incremental-from-dir=$topdir/backup/delta
 vlog "Delta applied to backup"
 xtrabackup --no-defaults --datadir=$mysql_datadir --prepare \
     --target-dir=$topdir/backup/full

--- a/storage/innobase/xtrabackup/test/t/xb_part_range.sh
+++ b/storage/innobase/xtrabackup/test/t/xb_part_range.sh
@@ -75,10 +75,10 @@ vlog "Incremental backup done"
 vlog "Preparing backup"
 
 # Prepare backup
-xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$topdir/backup/full
 vlog "Log applied to backup"
-xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-log-only \
+xtrabackup --no-defaults --datadir=$mysql_datadir --prepare --apply-redo-only \
     --target-dir=$topdir/backup/full --incremental-dir=$topdir/backup/delta
 vlog "Delta applied to backup"
 xtrabackup --no-defaults --datadir=$mysql_datadir --prepare \

--- a/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
+++ b/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
@@ -38,9 +38,9 @@ record_db_state test
 
 stop_server
 vlog "Test 2 - Preparing full backup"
-xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full
 vlog "Test 2 - Preparing inc1 backup"
-xtrabackup --prepare --apply-log-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
 vlog "Test 2 - Preparing inc2 backup"
 xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
 rm -rf ${mysql_datadir}

--- a/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
+++ b/storage/innobase/xtrabackup/test/t/xbstream_fifo.sh
@@ -30,19 +30,19 @@ wait ${insert_pid}
 run_insert &
 insert_pid=$!
 vlog "Test 2 - Taking inc1 backup"
-take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --incremental-basedir=${topdir}/full" "-x -C ${topdir}/inc1 --fifo-streams=3"
+take_backup_fifo_xbstream ${topdir}/stream "--parallel=4 --fifo-streams=3 --backup-incremental-base=${topdir}/full" "-x -C ${topdir}/inc1 --fifo-streams=3"
 wait ${insert_pid}
 vlog "Test 2 - Taking inc2 backup"
-take_backup_fifo_xbstream ${topdir}/stream "--parallel=2 --fifo-streams=3 --incremental-basedir=${topdir}/inc1" "-x -C ${topdir}/inc2 --fifo-streams=3 --parallel=6"
+take_backup_fifo_xbstream ${topdir}/stream "--parallel=2 --fifo-streams=3 --backup-incremental-base=${topdir}/inc1" "-x -C ${topdir}/inc2 --fifo-streams=3 --parallel=6"
 record_db_state test
 
 stop_server
 vlog "Test 2 - Preparing full backup"
 xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full
 vlog "Test 2 - Preparing inc1 backup"
-xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --incremental-dir=${topdir}/inc1
+xtrabackup --prepare --apply-redo-only --target-dir=${topdir}/full --prepare-incremental-from-dir=${topdir}/inc1
 vlog "Test 2 - Preparing inc2 backup"
-xtrabackup --prepare --target-dir=${topdir}/full --incremental-dir=${topdir}/inc2
+xtrabackup --prepare --target-dir=${topdir}/full --prepare-incremental-from-dir=${topdir}/inc2
 rm -rf ${mysql_datadir}
 vlog "Test 2 - Runninc copy-back"
 xtrabackup --copy-back --target-dir=${topdir}/full


### PR DESCRIPTION
Both alias renames in one PR, because they want the same mechanism. Three commits, each of which builds on its own:

| commit | what |
|---|---|
| `b014a3a0618` | **base**: table driven check for renamed options, no aliases yet |
| `9de4def0fe1` | **PXB-3758**: `--apply-log-only` → `--apply-redo-only` |
| `e8a242c3ab9` | **PXB-3840**: the two incremental options |

## Commit 1: the mechanism

Every rename wants the same two behaviours: warn once when the old name is used, and refuse a command line that passes the old name together with the new one. Both names drive the same variable, so passing both is a mistake rather than intent, and silently picking one would hide it.

```c
struct renamed_option {
  std::string_view old_name;
  std::string_view new_name;
};

static const std::array<renamed_option, 0> renamed_options = {};

static bool check_renamed_options();   // called from xb_init()
```

The table starts empty; the next two commits add their rows. A future rename is one row.

## Commit 2: PXB-3758

`--apply-log-only` does not apply anything called a "log only" — it applies the redo log and skips undo, which is what the new name says.

| command line | behaviour |
|---|---|
| `--apply-redo-only` | works, quiet |
| `--apply-log-only` | works, one startup warning |
| both | rejected, exit 1, either order |

## Commit 3: PXB-3840

The old names differ only by the word "base", and the parser takes either one in either phase. A mix-up is not reported: it surfaces later as a wrong `from_lsn` or a wrong delta target.

| old | new | phase |
|---|---|---|
| `--incremental-basedir` | `--backup-incremental-base` | `--backup` |
| `--incremental-dir` | `--prepare-incremental-from-dir` | `--prepare` |

Cloud aware values for `--backup-incremental-base` are left to PXB-3821; this is the rename only.

No specific removal version is named anywhere, since the next LTS is not decided.

## Tests

Each alias commit moves **every** test onto its new names, so the only place an old name survives is that commit's own deprecation test:

- commit 2 converts 92 test files and adds `t/apply_redo_only_alias.sh`
- commit 3 converts 76 test files and adds `t/incremental_option_aliases.sh`

Commit 2's new test itself used `--incremental-dir`, so commit 3 converts that line too — which is why it touches 76 files and not 75.

Both new tests check the same shape: the new names do the real work end to end (build a full plus incremental chain, restore it, compare against the recorded state), the new names stay quiet, each old name warns exactly once and names its replacement, and old plus new together is rejected.

## Testing

Full framework run on a 128 core host, every suite, with S3/MinIO, Vault and KMIP configured, in **both** build types. A Debug build matters here: the release run skips every `require_debug_pxb_version` test, which includes the whole `reducedlock` suite, and `reducedlock/incremental*.sh` are among the files these commits rewrite.

Results to follow in a comment; the runs are in progress against these exact commits.

Every commit was checked with clang-format 11 (what CI installs) and 15 (what `.clang-format` on this branch asks for). Note that the mismatch between those two is itself a bug, fixed separately in PXB-3883.

https://perconadev.atlassian.net/browse/PXB-3758
https://perconadev.atlassian.net/browse/PXB-3840