### PR TITLE
PXB-3882 : [8.4] Fix the Debug build with gcc 15

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -43,7 +43,7 @@ extern ds_ctxt_t *ds_redo;
 constexpr size_t HEADER_BLOCK_SIZE = 4096;
 static bool archive_first_block_zero = false;
 std::atomic<bool> Redo_Log_Reader::m_error;
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
 
 Redo_Log_Reader::Redo_Log_Reader() {
   log_hdr_buf.alloc_withkey(UT_NEW_THIS_FILE_PSI_KEY,


### PR DESCRIPTION
## What

The Debug build does not compile:

```
storage/innobase/xtrabackup/src/redo_log.cc:46:37: error: extra ';' outside of a function [-Werror=extra-semi]
   46 | IF_DEBUG(bool force_reopen = false;);
```

`IF_DEBUG(x)` expands to `x` in a Debug build, so the line ends up with two semicolons and gcc rejects the redundant one. A release build expands `IF_DEBUG` away, which is why this has never shown up in CI or in any release build.

One character:

```diff
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
```

## Why it matters

A Debug build is the only way to run the `require_debug_pxb_version` tests, and that is the entire `reducedlock` suite plus the `*_debug` check_tables and keyring tests. On a release build those all skip. So without this, roughly 40 tests cannot be run at all on this branch — I found it while trying to run them.

The same line is present unchanged in 8.0, 9.7 and trunk. 9.7 and trunk are handled by the follow-up PRs in this set; 8.0 is not covered here.

## Testing

`percona/8.4` does not build with gcc 15.2 for reasons unrelated to this change: the release link fails with `undefined reference to crc32` out of the bundled zlib, and the Debug build hits three `-Werror=class-memaccess` errors in `lock0lock.cc`. Those are pre-existing and predate this commit.

So this was built and tested with **gcc 13.3 (Ubuntu 24.04 container)**, where both configurations build cleanly:

```text
RelWithDebInfo   BUILD OK (0 errors, 4 keyring components)
Debug            BUILD OK (0 errors, 4 keyring components)
```

Framework run against that container build, Percona Server 8.4.10-10:

```text
Debug            432 run, 339 successful, 87 skipped, 6 failed
RelWithDebInfo   432 run, 300 successful, 128 skipped, 4 failed
```

The failures are environmental, not from this commit, and the release run demonstrates it: **this change cannot affect a release binary at all**, since `IF_DEBUG` expands to nothing there, yet the release run still shows 4 of the same failures. They are `gr.slave_info` and `gr.gr_basic` (group replication), `main.bug1623210`, `main.xb_decompress_file_validations`, plus `main.estimate_memory` and `reducedlock.basic_operation` in Debug. The container has no external services wired up, which also accounts for the higher skip count.

The point this PR needs to make is the first two lines: with the fix, a Debug build exists and the suite runs on it. Before it, there was no Debug build to run.

https://perconadev.atlassian.net/browse/PXB-3882