### PR TITLE
PXB-3882 : [9.7] Fix the Debug build with gcc 15

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -43,7 +43,7 @@ extern ds_ctxt_t *ds_redo;
 constexpr size_t HEADER_BLOCK_SIZE = 4096;
 static bool archive_first_block_zero = false;
 std::atomic<bool> Redo_Log_Reader::m_error;
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
 
 Redo_Log_Reader::Redo_Log_Reader() {
   log_hdr_buf.alloc_withkey(UT_NEW_THIS_FILE_PSI_KEY,


### PR DESCRIPTION
Merged forward from the 8.4 branch (#1811).

## What

The Debug build does not compile:

```
storage/innobase/xtrabackup/src/redo_log.cc:46:37: error: extra ';' outside of a function [-Werror=extra-semi]
   46 | IF_DEBUG(bool force_reopen = false;);
```

`IF_DEBUG(x)` expands to `x` in a Debug build, so the line ends up with two semicolons. Release expands `IF_DEBUG` away, which is why CI and every release build have stayed green.

```diff
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
```

## Why it matters

A Debug build is the only way to run the `require_debug_pxb_version` tests: the whole `reducedlock` suite plus the `*_debug` check_tables and keyring tests. They all skip on a release build, so about 40 tests could not be run on this branch at all.

## Testing

Built and ran the full framework on a 128 core host, both configurations, all suites, with S3/MinIO, Vault and KMIP configured:

```text
RelWithDebInfo  -j128   431 run, 321 successful, 110 skipped, 0 failed
Debug           -j64    431 run, 362 successful, 68 skipped, 1 failed
```

Zero `io_setup` noise in both. The Debug run executes 36 `reducedlock` tests that the release run skips, which is exactly what this fix unlocks.

The single Debug failure, `main.estimate_memory`, is unrelated and pre-existing. It is untouched by this commit, only runs in a Debug build, and fails at `xtrabackup --prepare --use-free-memory-pct=99`, which sizes the buffer pool to about 2^64 bytes (`total size = 17179869183.875000G`) and then cannot allocate it. It reproduces on an idle host with 489G available, so it is not contention from the parallel run. Worth its own ticket.

https://perconadev.atlassian.net/browse/PXB-3882