### PR TITLE
PXB-3882 : [trunk] Fix the Debug build with gcc 15

### DIFF
--- a/storage/innobase/xtrabackup/src/redo_log.cc
+++ b/storage/innobase/xtrabackup/src/redo_log.cc
@@ -43,7 +43,7 @@ extern ds_ctxt_t *ds_redo;
 constexpr size_t HEADER_BLOCK_SIZE = 4096;
 static bool archive_first_block_zero = false;
 std::atomic<bool> Redo_Log_Reader::m_error;
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
 
 Redo_Log_Reader::Redo_Log_Reader() {
   log_hdr_buf.alloc_withkey(UT_NEW_THIS_FILE_PSI_KEY,


### PR DESCRIPTION
Merged forward from 9.7 (#1812), which came from 8.4 (#1811).

## What

The Debug build does not compile:

```
storage/innobase/xtrabackup/src/redo_log.cc:46:37: error: extra ';' outside of a function [-Werror=extra-semi]
   46 | IF_DEBUG(bool force_reopen = false;);
```

`IF_DEBUG(x)` expands to `x` in a Debug build, so the line ends up with two semicolons. Release expands it away, which is why this has stayed green everywhere.

```diff
-IF_DEBUG(bool force_reopen = false;);
+IF_DEBUG(bool force_reopen = false;)
```

## Why it matters

A Debug build is the only way to run the `require_debug_pxb_version` tests, which is the whole `reducedlock` suite plus the `*_debug` check_tables and keyring tests. Around 40 tests could not be run on this branch at all.

## Testing

Full framework run on a 128 core host, both configurations, all suites, with S3/MinIO, Vault and KMIP configured:

```text
RelWithDebInfo  -j128   431 run, 321 successful, 110 skipped, 0 failed
Debug           -j64    431 run, 361 successful, 68 skipped, 2 failed
```

Zero `io_setup` noise in both. The Debug run executes 36 `reducedlock` tests the release run skips.

Both Debug failures are unrelated and pre-existing, and neither test is touched by this commit:

- `main.estimate_memory` fails at `xtrabackup --prepare --use-free-memory-pct=99`, sizing the buffer pool to about 2^64 bytes and failing to allocate it. Debug only, and it reproduces on an idle host with 489G available.
- `xb_parallel_incremental_prepare` is resource pressure at `-j64` under Debug, dying on `Difficult to find free blocks in the buffer pool (167472 search iterations)`. It passes when rerun with low parallelism.

https://perconadev.atlassian.net/browse/PXB-3882